### PR TITLE
feat: add manual update action

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,25 @@ docker compose up -d
 
 > 或重跑一次一键脚本（选 `Upgrade` 模式），等价。
 
+Telegram「⚙ 系统设置 → 🆕 版本更新」发现新版本后，也会显示「⬆️ 立即更新」按钮。点击后会先展示确认页，确认后在后台执行升级命令并通过 Telegram 推送执行状态。默认命令等价于：
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+如需自定义部署目录或命令，可在 `data/config.json` 中设置：
+
+```json
+{
+  "updateChecker": {
+    "updateCommand": "docker compose pull && docker compose up -d",
+    "workingDirectory": "/opt/parrot"
+  }
+}
+```
+
+`workingDirectory` 留空时使用 Parrot 进程当前工作目录。请确保该目录包含正确的 `docker-compose.yml`，且运行 Parrot 的用户具备 Docker 权限。
+
 ### 日志
 
 ```bash

--- a/config.example.json
+++ b/config.example.json
@@ -134,6 +134,15 @@
       "network_monitor": true
     }
   },
+  "updateChecker": {
+    "enabled": true,
+    "intervalSeconds": 3600,
+    "includePrerelease": true,
+    "repo": "danger-dream/Parrot",
+    "ignoredVersions": [],
+    "updateCommand": "docker compose pull && docker compose up -d",
+    "workingDirectory": ""
+  },
   "cchMode": "disabled",
   "cchStaticValue": "00000",
   "oauthDefaultModels": [

--- a/src/config.py
+++ b/src/config.py
@@ -176,6 +176,11 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "includePrerelease": True,
         "repo": "danger-dream/Parrot",
         "ignoredVersions": [],
+        # Telegram「立即更新」确认后执行的部署命令。默认适配 README 的
+        # Docker Compose 升级流程；源码/自定义部署可改成自己的脚本。
+        "updateCommand": "docker compose pull && docker compose up -d",
+        # 命令执行目录；留空时使用当前进程工作目录。
+        "workingDirectory": "",
     },
     "cchMode": "disabled",
     "cchStaticValue": "00000",

--- a/src/telegram/menus/update_menu.py
+++ b/src/telegram/menus/update_menu.py
@@ -4,6 +4,7 @@
 功能：
 - 显示当前版本 / 最新版本 / 发布时间 / changelog 摘要
 - 立即检查（同步阻塞拉一次）
+- 发现新版本时确认后一键执行部署升级命令
 - 忽略此版本（加入 ignoredVersions）/ 清空忽略列表
 - 设置：总开关 / 间隔 / 是否含 prerelease
 """
@@ -24,6 +25,16 @@ def _update_cfg(patch: dict) -> None:
     def _mut(c):
         c.setdefault("updateChecker", {}).update(patch)
     config.update(_mut)
+
+
+def _available_update_version() -> Optional[str]:
+    cfg = _cfg()
+    ignored = set(cfg.get("ignoredVersions") or [])
+    st = update_checker.get_cached() or {}
+    latest = st.get("latest_version")
+    if latest and update_checker._has_newer(latest) and latest not in ignored:
+        return latest
+    return None
 
 
 def _format_main_text() -> str:
@@ -100,6 +111,7 @@ def _format_kb() -> dict:
         if latest in ignored:
             rows.append([ui.btn(f"✅ 取消忽略 {latest}", f"upd:unignore:{latest}")])
         else:
+            rows.append([ui.btn(f"⬆️ 立即更新到 {latest}", "upd:update_confirm")])
             rows.append([ui.btn(f"🔕 忽略 {latest}", f"upd:ignore:{latest}")])
     if ignored:
         rows.append([ui.btn(f"🧹 清空忽略列表（{len(ignored)}）", "upd:clear_ignored")])
@@ -115,6 +127,38 @@ def show(chat_id: int, message_id: int, cb_id: Optional[str] = None) -> None:
 
 def send_new(chat_id: int) -> None:
     ui.send(chat_id, ui.truncate(_format_main_text()), reply_markup=_format_kb())
+
+
+def _format_update_confirm_text(version: str) -> str:
+    cmd_cfg = update_checker.get_update_command_config()
+    command = cmd_cfg["command"]
+    cwd = cmd_cfg["workingDirectory"]
+    return "\n".join([
+        "⬆️ <b>确认立即更新 Parrot？</b>",
+        "",
+        f"目标版本: <code>{ui.escape_html(version)}</code>",
+        f"工作目录: <code>{ui.escape_html(cwd)}</code>",
+        f"将执行命令: <code>{ui.escape_html(command or '未配置')}</code>",
+        "",
+        "风险提示:",
+        "• 会拉取新 Docker 镜像并重建服务；Telegram Bot 可能短暂离线。",
+        "• 请确认工作目录包含正确的 docker-compose.yml，且当前运行环境有 Docker 权限。",
+        "• 命令输出只会截断显示，完整日志请到服务器查看。",
+    ])
+
+
+def _show_update_confirm(chat_id: int, message_id: int, cb_id: str) -> None:
+    version = _available_update_version()
+    if not version:
+        ui.answer_cb(cb_id, "当前没有可更新版本")
+        show(chat_id, message_id)
+        return
+    ui.answer_cb(cb_id)
+    rows = [
+        [ui.btn("✅ 确认执行更新", "upd:update_run")],
+        [ui.btn("❌ 取消", "menu:update")],
+    ]
+    ui.edit(chat_id, message_id, _format_update_confirm_text(version), reply_markup=ui.inline_kb(rows))
 
 
 # ─── 操作 ────────────────────────────────────────────────────────
@@ -168,6 +212,30 @@ def _refresh(chat_id: int, message_id: int, cb_id: str) -> None:
     show(chat_id, message_id)
 
 
+def _run_update(chat_id: int, message_id: int, cb_id: str) -> None:
+    version = _available_update_version()
+    if not version:
+        ui.answer_cb(cb_id, "当前没有可更新版本")
+        show(chat_id, message_id)
+        return
+
+    def _notify(text: str) -> None:
+        ui.send(chat_id, ui.truncate(text))
+
+    started, msg = update_checker.start_manual_update(_notify)
+    if not started:
+        ui.answer_cb(cb_id, msg, show_alert=True)
+        show(chat_id, message_id)
+        return
+    ui.answer_cb(cb_id, msg)
+    ui.edit(
+        chat_id, message_id,
+        "⬆️ <b>更新任务已在后台启动</b>\n\n"
+        "执行中会继续通过 Telegram 发送状态。服务重建期间 Bot 可能短暂离线。",
+        reply_markup=ui.inline_kb([[ui.btn("◀ 返回版本更新", "menu:update")]]),
+    )
+
+
 def _ignore_version(chat_id: int, message_id: int, cb_id: str, version: str) -> None:
     if not version:
         ui.answer_cb(cb_id, "版本号为空")
@@ -206,6 +274,10 @@ def handle_callback(chat_id: int, message_id: int, cb_id: str, data: str) -> boo
         _edit_interval(chat_id, message_id, cb_id); return True
     if data == "upd:refresh":
         _refresh(chat_id, message_id, cb_id); return True
+    if data == "upd:update_confirm":
+        _show_update_confirm(chat_id, message_id, cb_id); return True
+    if data == "upd:update_run":
+        _run_update(chat_id, message_id, cb_id); return True
     if data.startswith("upd:ignore:"):
         _ignore_version(chat_id, message_id, cb_id, data.split(":", 2)[2]); return True
     if data.startswith("upd:unignore:"):

--- a/src/tests/test_update_menu_manual_update.py
+++ b/src/tests/test_update_menu_manual_update.py
@@ -1,0 +1,124 @@
+"""Telegram update menu manual update smoke tests."""
+
+from __future__ import annotations
+
+import os as _ap_os, sys as _ap_sys
+_ap_sys.path.insert(0, _ap_os.path.dirname(_ap_os.path.dirname(_ap_os.path.dirname(_ap_os.path.abspath(__file__)))))
+from src.tests import _isolation
+_isolation.isolate()
+
+import os
+import sys
+import time
+
+
+def _import_modules():
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    if root not in sys.path:
+        sys.path.insert(0, root)
+    from src import config, update_checker
+    from src.telegram import ui
+    from src.telegram.menus import update_menu
+    return {
+        "config": config,
+        "update_checker": update_checker,
+        "ui": ui,
+        "update_menu": update_menu,
+    }
+
+
+class ApiRecorder:
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+
+    def __call__(self, method, data=None):
+        self.calls.append((method, dict(data) if data else {}))
+        return {"ok": True, "result": {}}
+
+    def by(self, method):
+        return [d for m, d in self.calls if m == method]
+
+    def last(self, method):
+        calls = self.by(method)
+        return calls[-1] if calls else None
+
+
+def _install(m):
+    rec = ApiRecorder()
+    m["ui"].api = rec
+    return rec
+
+
+def _set_latest(m, version="v9.9.9"):
+    m["update_checker"]._set_cache({
+        "repo": "danger-dream/Parrot",
+        "latest_version": version,
+        "latest_name": "Test release",
+        "latest_url": "https://example.test/release",
+        "latest_body": "Changes",
+        "latest_published_at": "2026-05-18T00:00:00Z",
+        "latest_prerelease": False,
+        "notified_for": None,
+        "checked_at": 1,
+    })
+
+
+def test_manual_update_button_and_confirm_route(m):
+    rec = _install(m)
+    _set_latest(m)
+    m["config"].update(lambda c: c.setdefault("updateChecker", {}).update({"ignoredVersions": []}))
+
+    m["update_menu"].show(42, 100, "cb")
+    edit = rec.last("editMessageText")
+    buttons = [
+        b["callback_data"]
+        for row in edit["reply_markup"]["inline_keyboard"]
+        for b in row
+        if "callback_data" in b
+    ]
+    assert "upd:update_confirm" in buttons
+
+    assert m["update_menu"].handle_callback(42, 100, "cb2", "upd:update_confirm") is True
+    confirm = rec.last("editMessageText")
+    assert "确认立即更新" in confirm["text"]
+    assert "docker compose pull" in confirm["text"]
+    confirm_buttons = [
+        b["callback_data"]
+        for row in confirm["reply_markup"]["inline_keyboard"]
+        for b in row
+        if "callback_data" in b
+    ]
+    assert "upd:update_run" in confirm_buttons
+
+    m["config"].update(lambda c: c.setdefault("updateChecker", {}).update({"ignoredVersions": ["v9.9.9"]}))
+    m["update_menu"].show(42, 100, "cb3")
+    ignored_edit = rec.last("editMessageText")
+    ignored_buttons = [
+        b["callback_data"]
+        for row in ignored_edit["reply_markup"]["inline_keyboard"]
+        for b in row
+        if "callback_data" in b
+    ]
+    assert "upd:update_confirm" not in ignored_buttons
+
+
+def test_manual_update_concurrency_guard(m):
+    uc = m["update_checker"]
+    uc._set_manual_update_running(False)
+    m["config"].update(lambda c: c.setdefault("updateChecker", {}).update({
+        "updateCommand": "sleep 0.2",
+        "workingDirectory": os.getcwd(),
+    }))
+
+    messages: list[str] = []
+    started, msg = uc.start_manual_update(messages.append)
+    assert started is True, msg
+    started2, msg2 = uc.start_manual_update(messages.append)
+    assert started2 is False
+    assert "正在执行" in msg2
+
+    deadline = time.time() + 2
+    while uc.is_manual_update_running() and time.time() < deadline:
+        time.sleep(0.02)
+    assert uc.is_manual_update_running() is False
+    assert any("执行完成" in s for s in messages)

--- a/src/update_checker.py
+++ b/src/update_checker.py
@@ -15,9 +15,11 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import subprocess
 import threading
 import time
-from typing import Optional
+from typing import Callable, Optional
 
 from packaging.version import InvalidVersion, Version
 
@@ -35,6 +37,18 @@ def _cfg() -> dict:
         "includePrerelease": bool(uc.get("includePrerelease", True)),
         "repo": str(uc.get("repo") or "danger-dream/Parrot").strip(),
         "ignoredVersions": list(uc.get("ignoredVersions") or []),
+        "updateCommand": str(uc.get("updateCommand") or "docker compose pull && docker compose up -d").strip(),
+        "workingDirectory": str(uc.get("workingDirectory") or "").strip(),
+    }
+
+
+def get_update_command_config() -> dict:
+    """Return the command/cwd used by the Telegram manual update action."""
+    cfg = _cfg()
+    cwd = cfg["workingDirectory"] or os.getcwd()
+    return {
+        "command": cfg["updateCommand"],
+        "workingDirectory": cwd,
     }
 
 
@@ -186,6 +200,104 @@ def get_update_banner() -> Optional[str]:
         f"<code>{notifier.escape_html(latest)}</code> — "
         "进入「⚙ 系统设置 → 🆕 版本更新」查看详情"
     )
+
+
+# ─── 手动升级执行器 ───────────────────────────────────────────────
+
+_manual_update_lock = threading.Lock()
+_manual_update_running = False
+
+
+def is_manual_update_running() -> bool:
+    with _manual_update_lock:
+        return _manual_update_running
+
+
+def _set_manual_update_running(value: bool) -> None:
+    global _manual_update_running
+    with _manual_update_lock:
+        _manual_update_running = value
+
+
+def _clip_output(text: str, limit: int = 2600) -> str:
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[-limit:].lstrip() + "\n…（仅显示最后部分日志）"
+
+
+def _format_manual_update_result(returncode: int, output: str) -> str:
+    clipped = _clip_output(output)
+    if returncode == 0:
+        head = "✅ <b>Parrot 更新命令执行完成</b>"
+    else:
+        head = f"❌ <b>Parrot 更新命令失败</b>（退出码 <code>{returncode}</code>）"
+    if not clipped:
+        return head
+    return f"{head}\n\n<pre>{notifier.escape_html(clipped)}</pre>"
+
+
+def _run_manual_update(command: str, cwd: str, notify: Callable[[str], None]) -> None:
+    try:
+        notify(
+            "⬆️ <b>开始执行 Parrot 更新命令</b>\n\n"
+            f"目录: <code>{notifier.escape_html(cwd)}</code>\n"
+            f"命令: <code>{notifier.escape_html(command)}</code>"
+        )
+        proc = subprocess.run(
+            command,
+            shell=True,
+            cwd=cwd,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=900,
+        )
+        notify(_format_manual_update_result(proc.returncode, proc.stdout or ""))
+    except subprocess.TimeoutExpired as exc:
+        output = exc.stdout or ""
+        if isinstance(output, bytes):
+            output = output.decode(errors="replace")
+        notify(
+            "❌ <b>Parrot 更新命令超时</b>（900s）\n\n"
+            f"<pre>{notifier.escape_html(_clip_output(output))}</pre>"
+        )
+    except Exception as exc:
+        notify(f"❌ <b>Parrot 更新命令启动失败</b>: <code>{notifier.escape_html(str(exc))}</code>")
+    finally:
+        _set_manual_update_running(False)
+
+
+def start_manual_update(notify: Callable[[str], None]) -> tuple[bool, str]:
+    """Start the configured update command in a background thread.
+
+    Returns (started, message). The caller is responsible for checking that a
+    non-ignored newer release exists before invoking this function.
+    """
+    with _manual_update_lock:
+        global _manual_update_running
+        if _manual_update_running:
+            return False, "已有更新任务正在执行"
+        _manual_update_running = True
+
+    cmd_cfg = get_update_command_config()
+    command = cmd_cfg["command"]
+    cwd = cmd_cfg["workingDirectory"]
+    if not command:
+        _set_manual_update_running(False)
+        return False, "未配置 updateChecker.updateCommand"
+    if not os.path.isdir(cwd):
+        _set_manual_update_running(False)
+        return False, f"工作目录不存在: {cwd}"
+
+    t = threading.Thread(
+        target=_run_manual_update,
+        args=(command, cwd, notify),
+        name="parrot-manual-update",
+        daemon=True,
+    )
+    t.start()
+    return True, "更新任务已在后台启动"
 
 
 # ─── HTTP 抓取 ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add a guarded Telegram "立即更新" flow when a newer non-ignored release is available
- show a confirmation page before running the configured deployment command
- run the update command in a background thread with concurrency protection and truncated Telegram status output
- document `updateChecker.updateCommand` and `updateChecker.workingDirectory`

## Default behavior
The default command follows the README Docker Compose upgrade flow:

```bash
docker compose pull && docker compose up -d
```

`workingDirectory` defaults to the Parrot process current working directory when unset.

## Tests
- `python3 -m venv /root/projects/parrot-inspect/venv && /root/projects/parrot-inspect/venv/bin/pip install -r requirements.txt pytest pytest-asyncio`
- `/root/projects/parrot-inspect/venv/bin/python -m pytest src/tests/test_update_menu_manual_update.py -q` ✅ 2 passed
- `/root/projects/parrot-inspect/venv/bin/python -m pytest src/tests/test_update_menu_manual_update.py src/tests/test_tg_safe_send.py src/tests/test_m10_system_menu.py -q` ✅ 19 passed
- `/root/projects/parrot-inspect/venv/bin/python -m pytest src/tests -q` ⚠️ 460 passed, 4 errors; all errors are pre-existing fixture issues in `src/tests/test_saturated_only.py` (`_import_modules` / `m_oa` fixture missing), unrelated to this change.
