### PR TITLE
Add legacy images generation routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ bak/
 .idea/
 .vscode/
 *.swp
+
+.venv/

--- a/server.py
+++ b/server.py
@@ -417,6 +417,24 @@ async def proxy_images_edit(request: Request):
     return await handle_edit(request)
 
 
+@app.post("/v1/images/generations")
+async def proxy_images_generations_legacy(request: Request):
+    """OpenAI legacy Images API compatibility endpoint.
+
+    Accepts the classic /v1/images/generations payload (prompt/model/n/size/response_format)
+    and internally uses Parrot's local image generation flow.
+    """
+    from src.openai.images_simple import handle_generate
+    return await handle_generate(request)
+
+
+@app.post("/images/generations")
+async def proxy_images_generations_legacy_no_v1(request: Request):
+    """OpenAI legacy Images API compatibility endpoint without /v1 prefix."""
+    from src.openai.images_simple import handle_generate
+    return await handle_generate(request)
+
+
 @app.post("/v1/messages")
 async def proxy_messages(request: Request):
     start_time = time.time()

--- a/src/tests/test_images_legacy_routes.py
+++ b/src/tests/test_images_legacy_routes.py
@@ -1,0 +1,46 @@
+"""Regression tests for OpenAI legacy Images API compatibility routes."""
+
+from __future__ import annotations
+
+import asyncio
+import os as _ap_os
+import sys as _ap_sys
+from types import SimpleNamespace
+
+# Keep imports isolated from any production config/state files.
+_ap_sys.path.insert(0, _ap_os.path.dirname(_ap_os.path.dirname(_ap_os.path.dirname(_ap_os.path.abspath(__file__)))))
+from src.tests import _isolation
+_isolation.isolate()
+
+
+def test_legacy_image_generation_routes_are_registered():
+    import server
+
+    routes = {
+        route.path: route
+        for route in server.app.routes
+        if getattr(route, "path", None) in {"/v1/images/generations", "/images/generations"}
+    }
+
+    assert set(routes) == {"/v1/images/generations", "/images/generations"}
+    for route in routes.values():
+        assert "POST" in route.methods
+
+
+def test_legacy_image_generation_routes_delegate_to_local_generate_handler(monkeypatch):
+    import server
+    from src.openai import images_simple
+
+    seen = []
+    sentinel = {"ok": True}
+
+    async def fake_handle_generate(request):
+        seen.append(request)
+        return sentinel
+
+    monkeypatch.setattr(images_simple, "handle_generate", fake_handle_generate)
+    fake_request = SimpleNamespace(headers={}, json=lambda: {})
+
+    assert asyncio.run(server.proxy_images_generations_legacy(fake_request)) is sentinel
+    assert asyncio.run(server.proxy_images_generations_legacy_no_v1(fake_request)) is sentinel
+    assert seen == [fake_request, fake_request]


### PR DESCRIPTION
Adds OpenAI legacy image generation compatibility routes for `/v1/images/generations` and `/images/generations`. Both routes delegate to the local Parrot image generation handler, with regression tests.

Validation performed:
- `python -m pytest -q src/tests/test_images_legacy_routes.py` → 2 passed
- `python -m pytest -q src/tests/test_images_legacy_routes.py src/tests/test_openai_m2.py src/tests/test_openai_m3.py` → 23 passed
- `python -m src.tests.test_saturated_only` → 4/4 passed
- `python -m pytest -q --ignore=src/tests/test_saturated_only.py` → 460 passed

Note: full pytest collection currently reports existing fixture errors in `src/tests/test_saturated_only.py`; that file passes via its documented script entry point.