### PR TITLE
fix: resume OpenAI quota accounts with fresh low usage

### DIFF
--- a/src/oauth_manager.py
+++ b/src/oauth_manager.py
@@ -1050,6 +1050,9 @@ def usage_from_quota_row(row: dict) -> dict:
     return {
         "five_hour": _block(row.get("five_hour_util"), row.get("five_hour_reset")),
         "seven_day": _block(row.get("seven_day_util"), row.get("seven_day_reset")),
+        "openai": {
+            "thirty_day": _block(row.get("thirty_day_util"), row.get("thirty_day_reset")),
+        },
         "seven_day_sonnet": _block(row.get("sonnet_util"), row.get("sonnet_reset")),
         "seven_day_opus": _block(row.get("opus_util"), row.get("opus_reset")),
         "extra_usage": {
@@ -1114,8 +1117,8 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
       • 所有窗口 util < threshold → 可用
           - OpenAI 账号若 usage 没有任何窗口指标，或这份 usage 不是本轮新鲜探测，
             不能作为恢复依据；保持原 quota 禁用状态，避免“未知=恢复”误判。
-          - OpenAI 账号若 disabled_until 仍在未来，也保持禁用，等窗口到期后再用
-            新鲜响应头/probe 数据恢复。
+          - OpenAI 账号若拿到新鲜有效 usage 且所有窗口均低于阈值，即使旧的
+            disabled_until 仍在未来，也恢复；真实用量优先于旧锁定时间。
           - 其他账号是 quota 禁用：set_enabled(True) 自动恢复。
           - 账号未禁用：无事发生
 
@@ -1172,13 +1175,10 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
 
     # 全部窗口都可用。OpenAI 的 usage 来自响应头/最小 probe 的缓存合成，
     # 空缓存或被节流跳过的旧缓存不能证明额度恢复；尤其 quota 禁用账号不能
-    # 因 [None, None, None, None] 被误恢复。
+    # 因 [None, None, None, None] 被误恢复。若拿到新鲜有效 usage，则真实
+    # 低用量优先于旧 disabled_until，避免 30d 已重置仍卡在 quota 禁用。
     if reason == "quota":
         if provider_of(account_key) == "openai":
-            if _quota_disabled_until_still_future(acc):
-                return {"action": "quota_waiting_reset", "utils": utils,
-                        "any_over": False, "hit_windows": [],
-                        "disabled_until": acc.get("disabled_until")}
             if not _usage_has_any_quota_signal(usage):
                 return {"action": "quota_unknown_keep_disabled", "utils": utils,
                         "any_over": False, "hit_windows": [],

--- a/src/tests/test_composite_key_migration.py
+++ b/src/tests/test_composite_key_migration.py
@@ -697,6 +697,29 @@ def test_flatten_usage_preserves_openai_thirty_day(m):
     print("  [PASS] flatten_usage: preserves OpenAI 30d quota")
 
 
+
+def test_usage_from_quota_row_preserves_openai_thirty_day(m):
+    row = {
+        "five_hour_util": None,
+        "five_hour_reset": None,
+        "seven_day_util": None,
+        "seven_day_reset": None,
+        "thirty_day_util": 1.0,
+        "thirty_day_reset": "2026-07-19T21:23:07Z",
+        "sonnet_util": None,
+        "sonnet_reset": None,
+        "opus_util": None,
+        "opus_reset": None,
+        "extra_used": 0,
+        "extra_limit": 0,
+        "extra_util": 0,
+    }
+    usage = m["oauth_manager"].usage_from_quota_row(row)
+    assert usage["openai"]["thirty_day"]["utilization"] == 1.0
+    assert usage["openai"]["thirty_day"]["resets_at"] == "2026-07-19T21:23:07Z"
+    assert m["oauth_manager"].extract_utils_percent(usage)[:3] == [None, None, 1.0]
+    print("  [PASS] usage_from_quota_row: preserves OpenAI 30d quota")
+
 # ==============================================================
 # main
 # ==============================================================
@@ -743,6 +766,7 @@ def main():
         test_flatten_usage_missing_utilization,
         test_flatten_usage_preserves_resets_and_extra,
         test_flatten_usage_preserves_openai_thirty_day,
+        test_usage_from_quota_row_preserves_openai_thirty_day,
     ]
     passed = 0
     failed = 0

--- a/src/tests/test_unified_usage_and_auto_disable.py
+++ b/src/tests/test_unified_usage_and_auto_disable.py
@@ -382,7 +382,7 @@ def test_openai_quota_disabled_not_resumed_from_unknown_usage(m):
     print("  [PASS] openai: quota-disabled account is not resumed from unknown usage")
 
 
-def test_openai_quota_disabled_waits_until_disabled_until_before_resume(m):
+def test_openai_quota_disabled_resumes_with_fresh_low_usage_before_disabled_until(m):
     _setup(m)
     _add_openai(m, "future@o.io")
     ak = "openai:future@o.io:acct-123"
@@ -392,16 +392,40 @@ def test_openai_quota_disabled_waits_until_disabled_until_before_resume(m):
     result = m["oauth_manager"].evaluate_and_toggle_by_usage(ak, {
         "five_hour": {"utilization": 10, "resets_at": None},
         "seven_day": {"utilization": 20, "resets_at": None},
+        "openai": {"thirty_day": {"utilization": 1, "resets_at": "2026-07-19T21:23:07Z"}},
         "seven_day_sonnet": {},
         "seven_day_opus": {},
         "extra_usage": {"is_enabled": False},
-    })
+    }, fresh=True)
 
     acc_after = m["oauth_manager"].get_account(ak)
-    assert result["action"] == "quota_waiting_reset", result
+    assert result["action"] == "resumed", result
+    assert acc_after.get("disabled_reason") is None
+    assert acc_after["enabled"] is True
+    print("  [PASS] openai: fresh low usage resumes before old disabled_until")
+
+
+def test_openai_quota_disabled_keeps_waiting_on_stale_low_usage(m):
+    _setup(m)
+    _add_openai(m, "stale@o.io")
+    ak = "openai:stale@o.io:acct-123"
+    future = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() + 600))
+    m["oauth_manager"].set_disabled_by_quota(ak, future)
+
+    result = m["oauth_manager"].evaluate_and_toggle_by_usage(ak, {
+        "five_hour": {"utilization": 10, "resets_at": None},
+        "seven_day": {"utilization": 20, "resets_at": None},
+        "openai": {"thirty_day": {"utilization": 1, "resets_at": "2026-07-19T21:23:07Z"}},
+        "seven_day_sonnet": {},
+        "seven_day_opus": {},
+        "extra_usage": {"is_enabled": False},
+    }, fresh=False)
+
+    acc_after = m["oauth_manager"].get_account(ak)
+    assert result["action"] == "quota_stale_keep_disabled", result
     assert acc_after["disabled_reason"] == "quota"
     assert acc_after["enabled"] is False
-    print("  [PASS] openai: quota-disabled account waits for disabled_until before resume")
+    print("  [PASS] openai: stale low usage does not resume quota-disabled account")
 
 
 def test_openai_quota_disabled_resumes_after_reset_with_fresh_low_usage(m):
@@ -452,7 +476,8 @@ def main():
         test_openai_auto_disable_respects_custom_threshold,
         test_openai_user_disabled_not_touched,
         test_openai_quota_disabled_not_resumed_from_unknown_usage,
-        test_openai_quota_disabled_waits_until_disabled_until_before_resume,
+        test_openai_quota_disabled_resumes_with_fresh_low_usage_before_disabled_until,
+        test_openai_quota_disabled_keeps_waiting_on_stale_low_usage,
         test_openai_quota_disabled_resumes_after_reset_with_fresh_low_usage,
     ]
     passed = 0


### PR DESCRIPTION
## Summary

- Allow OpenAI quota-disabled accounts to resume when a fresh usage refresh shows all known quota windows are below the configured threshold, even if the old `disabled_until` is still in the future.
- Keep the previous safety behavior for unknown or stale OpenAI usage so quota-disabled accounts are not resumed from empty/cache-only signals.
- Include cached OpenAI 30d quota fields in `usage_from_quota_row()` so cached quota evaluation stays consistent with live usage evaluation.

## Why

OpenAI WHAM 30d quotas can refresh before the previously stored `disabled_until` time. In that case Parrot could keep an account disabled with `quota_waiting_reset` even after a fresh quota refresh reports low 30d usage, requiring manual re-enable.

## Tests

- `python3 -m py_compile src/oauth_manager.py src/tests/test_unified_usage_and_auto_disable.py src/tests/test_composite_key_migration.py`
- `/tmp/parrot-pr-venv/bin/python -m src.tests.test_unified_usage_and_auto_disable` — 19/19 passed
- `/tmp/parrot-pr-venv/bin/python -m src.tests.test_composite_key_migration` — 33/33 passed
