### PR TITLE
feat(openai): show Codex reset credit expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,11 @@ JSON 请求体：
 返回当前所有启用渠道聚合的可用模型（按 API Key 白名单过滤），Anthropic 标准格式。
 **配置了模型映射的别名也会在这里一同列出**（条件：别名所在入口的家族对该 Key 放行，且别名指向的真实模型本身对该 Key 可见），这样下游客户端直接拉列表就能看到最新别名。
 
+### `GET /v1/codex/rate-limit-reset-credits`
+用 Parrot API Key 鉴权后，读取运行 Parrot 机器上的 `~/.codex/auth.json`（可用 `PARROT_CODEX_AUTH_PATH` 或 `CODEX_AUTH_PATH` 覆盖），取 `tokens.access_token` 请求 ChatGPT WHAM：`https://chatgpt.com/backend-api/wham/rate-limit-reset-credits`。
+
+返回内容只保留安全字段：可用次数、累计发放次数，以及每张重置卡的 `status` / `granted_at` / `expires_at`；不会返回 `access_token`、`refresh_token`、cookie、完整唯一 ID 或上游原始 payload。若上游返回 401，表示本机 Codex 凭证失效，或 Authorization header 没被正确携带/接受。
+
 ### `GET /health`
 运维健康检查（无鉴权）：
 ```json
@@ -359,6 +364,7 @@ JSON 请求体：
 - 每条账户显示：状态图标 / 过期时间 / 5h 7d 用量 / 月度统计 / 冷却中的模型
 - 详情页：两家族统一布局（提供者 / 计划 / 过期 / 上次刷新 / 使用量 / 月度）
 - 操作：刷新 Token / 刷新用量 / 清模型错误 / 清亲和绑定 / 启停 / 删除
+- OpenAI 详情页支持官方 Codex banked reset credit 消耗确认；账户设置页支持查看「本机 Codex 重置卡」的发放时间和过期时间（北京时间）
 - 底部批量：🔄 刷新全部用量 / 🧹 清除所有账户错误（有冷却才显示）
 - 图片生成入口：OAuth 列表底部提供「🖼 图片生成」，用于配置图片模型、缓存、图片专用账号禁用列表和最近图片日志。
 
@@ -483,7 +489,7 @@ JSON 请求体：
 }
 ```
 
-> `quotaMonitor.enabled` **默认关闭** —— 启用后每 N 秒拉一次每个 OAuth 账号的 usage（Claude 走 `/api/oauth/usage`，OpenAI 走 Codex 探测头），频繁请求可能被风控盯上。
+> `quotaMonitor.enabled` **默认关闭** —— 启用后每 N 秒拉一次每个 OAuth 账号的 usage（Claude 走 `/api/oauth/usage`，OpenAI 走 ChatGPT `wham/usage`），频繁请求可能被风控盯上。
 
 > `apiKeys.*.allowImages` **默认关闭** —— 新建或历史 API Key 不会自动获得图片生成 / 编辑能力，必须在 TG「🔑 管理 API Key」里显式开启。
 

--- a/server.py
+++ b/server.py
@@ -450,6 +450,39 @@ async def health():
     }
 
 
+@app.get("/v1/codex/rate-limit-reset-credits")
+async def codex_rate_limit_reset_credits(request: Request):
+    """Return local Codex reset-credit grant/expiry times.
+
+    Reads ~/.codex/auth.json (or PARROT_CODEX_AUTH_PATH / CODEX_AUTH_PATH), uses
+    tokens.access_token as Bearer auth for ChatGPT WHAM, and returns only safe
+    card fields: status, granted_at, expires_at. No access/refresh token, cookie
+    or full upstream ID is ever returned.
+    """
+    _key_name, _allowed_models, err = auth.validate(request.headers)
+    if err:
+        return errors.json_error_response(401, errors.ErrType.AUTH, err)
+    try:
+        return await asyncio.to_thread(
+            oauth_manager.openai_provider.fetch_local_codex_rate_limit_reset_credits_sync,
+        )
+    except FileNotFoundError:
+        return errors.json_error_response(
+            404, errors.ErrType.API,
+            "Codex auth.json not found at ~/.codex/auth.json",
+        )
+    except ValueError as exc:
+        return errors.json_error_response(400, errors.ErrType.API, str(exc))
+    except Exception as exc:
+        import httpx as _httpx
+        if isinstance(exc, _httpx.HTTPStatusError) and exc.response.status_code == 401:
+            return errors.json_error_response(
+                401, errors.ErrType.AUTH,
+                "Codex credentials are invalid or Authorization header was not accepted by ChatGPT.",
+            )
+        raise
+
+
 @app.get("/v1/models")
 async def list_models(request: Request):
     """Anthropic 标准 /v1/models：返回当前代理可见的模型清单。

--- a/src/oauth/openai.py
+++ b/src/oauth/openai.py
@@ -27,6 +27,7 @@ import os
 import secrets
 import time
 from typing import Any
+from pathlib import Path
 from urllib.parse import urlencode
 
 from .. import network
@@ -60,8 +61,10 @@ _ACCOUNTS_CHECK_TIMEOUT = 15.0
 # ChatGPT/Codex 私有用量端点。它不是 OpenAI public API；只用于主动 quota
 # 刷新/后台 monitor。业务请求返回的 x-codex-* 响应头仍由 failover 实时采样。
 WHAM_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
+WHAM_RESET_CREDITS_URL = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits"
 WHAM_RESET_CREDIT_CONSUME_URL = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume"
 _WHAM_USAGE_TIMEOUT = 30.0
+_WHAM_RESET_CREDITS_TIMEOUT = 10.0
 _WHAM_RESET_CREDIT_TIMEOUT = 10.0
 
 
@@ -611,6 +614,92 @@ def _wham_window_looks_monthly(win: dict) -> bool:
     return False
 
 
+def _coerce_str(v: Any) -> str | None:
+    if v is None:
+        return None
+    s = str(v).strip()
+    return s or None
+
+
+def _extract_reset_credit_list(payload: Any) -> list[dict]:
+    """Best-effort extraction for the dedicated WHAM reset-credit list.
+
+    The observed endpoint returns a top-level ``credits`` list plus counters. Keep
+    the parser tolerant so small upstream shape changes do not break the UI.
+    """
+    if isinstance(payload, list):
+        return [c for c in payload if isinstance(c, dict)]
+    if not isinstance(payload, dict):
+        return []
+
+    for key in ("credits", "rate_limit_reset_credits", "items", "data", "results"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            return [c for c in value if isinstance(c, dict)]
+        if isinstance(value, dict):
+            nested = value.get("credits") or value.get("items") or value.get("data")
+            if isinstance(nested, list):
+                return [c for c in nested if isinstance(c, dict)]
+    return []
+
+
+def _normalize_reset_credit_entry(raw: dict, index: int) -> dict:
+    status = _coerce_str(raw.get("status")) or "unknown"
+    granted_at = (
+        _coerce_str(raw.get("granted_at"))
+        or _coerce_str(raw.get("created_at"))
+        or _coerce_str(raw.get("issued_at"))
+        or _coerce_str(raw.get("grant_time"))
+        or _coerce_str(raw.get("createdAt"))
+        or _coerce_str(raw.get("grantedAt"))
+        or _coerce_str(raw.get("issuedAt"))
+    )
+    expires_at = (
+        _coerce_str(raw.get("expires_at"))
+        or _coerce_str(raw.get("expiration_time"))
+        or _coerce_str(raw.get("expiresAt"))
+        or _coerce_str(raw.get("expires"))
+    )
+    return {
+        "index": index,
+        "status": status,
+        "granted_at": granted_at,
+        "expires_at": expires_at,
+    }
+
+
+def normalize_rate_limit_reset_credits(payload: dict | list) -> dict:
+    """Normalize ``/wham/rate-limit-reset-credits`` without exposing IDs.
+
+    Only count fields and per-card grant/expiry/status are retained. Token-like
+    values, cookies, raw IDs and full upstream payloads are intentionally not
+    returned to keep UI/logs safe.
+    """
+    credits = [
+        _normalize_reset_credit_entry(raw, i)
+        for i, raw in enumerate(_extract_reset_credit_list(payload), start=1)
+    ]
+    available = None
+    total_earned = None
+    if isinstance(payload, dict):
+        available = _coerce_int(payload.get("available_count"))
+        total_earned = _coerce_int(payload.get("total_earned_count"))
+        if available is None:
+            summary = payload.get("rate_limit_reset_credits")
+            if isinstance(summary, dict):
+                available = _coerce_int(summary.get("available_count"))
+                total_earned = total_earned if total_earned is not None else _coerce_int(summary.get("total_earned_count"))
+    if available is None:
+        available = sum(1 for c in credits if c.get("status") == "available")
+    if total_earned is None:
+        total_earned = len(credits)
+    return {
+        "available_count": available,
+        "total_earned_count": total_earned,
+        "credits": credits,
+    }
+
+
 def normalize_wham_usage(payload: dict) -> dict:
     """把 ChatGPT `backend-api/wham/usage` 响应规范成通用 usage 结构。
 
@@ -742,6 +831,22 @@ def _mock_wham_payload() -> dict:
     }
 
 
+def _auth_headers(access_token: str, *, account_id: str | None = None,
+                  referer: str = "https://chatgpt.com/codex/settings/usage") -> dict:
+    headers = {
+        "authorization": f"Bearer {access_token}",
+        "accept": "application/json",
+        "user-agent": USER_AGENT,
+        "originator": CODEX_ORIGINATOR,
+        "openai-beta": "codex-1",
+        "origin": "https://chatgpt.com",
+        "referer": referer,
+    }
+    if account_id:
+        headers["ChatGPT-Account-ID"] = account_id
+    return headers
+
+
 def fetch_wham_usage_sync(access_token: str, *, account_id: str | None = None) -> dict:
     """主动拉 ChatGPT/Codex quota。
 
@@ -751,18 +856,10 @@ def fetch_wham_usage_sync(access_token: str, *, account_id: str | None = None) -
     if _mock_mode_enabled():
         return normalize_wham_usage(_mock_wham_payload())
 
-    headers = {
-        "authorization": f"Bearer {access_token}",
-        "accept": "application/json",
-        "user-agent": USER_AGENT,
-        "origin": "https://chatgpt.com",
-        "referer": "https://chatgpt.com/codex/settings/usage",
-    }
     # Codex 官方 BackendClient 会把 ChatGPT account/workspace id 一并带到
     # usage 请求里。单工作区账号通常只靠 Bearer 也能成功，但多工作区账号
     # 最好显式路由到当前账户，避免刷新到错误 workspace 或被上游收紧鉴权。
-    if account_id:
-        headers["ChatGPT-Account-ID"] = account_id
+    headers = _auth_headers(access_token, account_id=account_id)
 
     resp = network.get_sync(
         WHAM_USAGE_URL,
@@ -777,6 +874,111 @@ def fetch_wham_usage_sync(access_token: str, *, account_id: str | None = None) -
 async def fetch_wham_usage(access_token: str, *, account_id: str | None = None) -> dict:
     return await asyncio.to_thread(
         fetch_wham_usage_sync, access_token, account_id=account_id,
+    )
+
+
+def _mock_reset_credits_payload() -> dict:
+    now = int(time.time())
+    return {
+        "available_count": 2,
+        "total_earned_count": 2,
+        "credits": [
+            {
+                "id": "RateLimitResetCredit_mock1",
+                "status": "available",
+                "granted_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now - 3600)),
+                "expires_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now + 29 * 86400)),
+            },
+            {
+                "id": "RateLimitResetCredit_mock2",
+                "status": "available",
+                "granted_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now - 7200)),
+                "expires_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now + 30 * 86400)),
+            },
+        ],
+    }
+
+
+def fetch_rate_limit_reset_credits_sync(access_token: str, *,
+                                        account_id: str | None = None) -> dict:
+    """Fetch the dedicated Codex reset-credit cards list from ChatGPT WHAM.
+
+    This endpoint includes per-credit grant/expiry timestamps; wham/usage only
+    includes the available count. The returned structure is normalized and
+    deliberately excludes upstream IDs or raw payloads.
+    """
+    if not access_token:
+        raise ValueError("Codex access_token missing from tokens.access_token")
+    if _mock_mode_enabled():
+        return normalize_rate_limit_reset_credits(_mock_reset_credits_payload())
+
+    resp = network.get_sync(
+        WHAM_RESET_CREDITS_URL,
+        headers=_auth_headers(access_token, account_id=account_id),
+        timeout=_WHAM_RESET_CREDITS_TIMEOUT,
+        proxy_purpose="oauth_openai",
+    )
+    resp.raise_for_status()
+    return normalize_rate_limit_reset_credits(resp.json())
+
+
+async def fetch_rate_limit_reset_credits(access_token: str, *,
+                                         account_id: str | None = None) -> dict:
+    return await asyncio.to_thread(
+        fetch_rate_limit_reset_credits_sync, access_token, account_id=account_id,
+    )
+
+
+def codex_auth_path(path: str | os.PathLike | None = None) -> Path:
+    """Return the local Codex CLI auth path.
+
+    ``~/.codex/auth.json`` is the default. Operators may override it with
+    PARROT_CODEX_AUTH_PATH (or CODEX_AUTH_PATH for CLI compatibility).
+    """
+    if path:
+        return Path(path).expanduser()
+    env_path = os.environ.get("PARROT_CODEX_AUTH_PATH") or os.environ.get("CODEX_AUTH_PATH")
+    if env_path:
+        return Path(env_path).expanduser()
+    return Path.home() / ".codex" / "auth.json"
+
+
+def load_codex_auth(path: str | os.PathLike | None = None) -> dict:
+    """Load local Codex CLI auth JSON without logging or returning secrets."""
+    auth_file = codex_auth_path(path)
+    if not auth_file.exists():
+        raise FileNotFoundError(f"Codex auth.json not found: {auth_file}")
+    with auth_file.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError("Codex auth.json must contain a JSON object")
+    return data
+
+
+def _codex_auth_access_parts(auth: dict) -> tuple[str, str | None]:
+    tokens = auth.get("tokens") if isinstance(auth, dict) else None
+    if not isinstance(tokens, dict):
+        raise ValueError("Codex auth.json missing tokens object")
+    access_token = tokens.get("access_token")
+    if not isinstance(access_token, str) or not access_token.strip():
+        raise ValueError("Codex auth.json missing tokens.access_token")
+    account_id = tokens.get("account_id") or auth.get("account_id") or auth.get("chatgpt_account_id")
+    return access_token.strip(), str(account_id).strip() if account_id else None
+
+
+def fetch_local_codex_rate_limit_reset_credits_sync(
+    *, auth_path: str | os.PathLike | None = None,
+) -> dict:
+    """Read local Codex CLI credentials and fetch reset-credit grant/expiry data."""
+    access_token, account_id = _codex_auth_access_parts(load_codex_auth(auth_path))
+    return fetch_rate_limit_reset_credits_sync(access_token, account_id=account_id)
+
+
+async def fetch_local_codex_rate_limit_reset_credits(
+    *, auth_path: str | os.PathLike | None = None,
+) -> dict:
+    return await asyncio.to_thread(
+        fetch_local_codex_rate_limit_reset_credits_sync, auth_path=auth_path,
     )
 
 
@@ -808,16 +1010,8 @@ def consume_rate_limit_reset_credit_sync(access_token: str, *,
             "idempotency_key": idempotency_key,
         }
 
-    headers = {
-        "authorization": f"Bearer {access_token}",
-        "accept": "application/json",
-        "content-type": "application/json",
-        "user-agent": USER_AGENT,
-        "origin": "https://chatgpt.com",
-        "referer": "https://chatgpt.com/codex/settings/usage",
-    }
-    if account_id:
-        headers["ChatGPT-Account-ID"] = account_id
+    headers = _auth_headers(access_token, account_id=account_id)
+    headers["content-type"] = "application/json"
 
     resp = network.post_sync(
         WHAM_RESET_CREDIT_CONSUME_URL,

--- a/src/oauth_errors.py
+++ b/src/oauth_errors.py
@@ -187,6 +187,18 @@ def describe_oauth_error(
                 operation=op,
                 technical=technical,
             )
+        if op == "rate_limit_reset_credits" and status == 401:
+            return OAuthDisplayError(
+                code="openai_codex_reset_credits_401",
+                title="Codex 凭证无效或未带 Authorization",
+                reason="本机 Codex 凭证里的 tokens.access_token 可能已失效，或请求没有正确携带 Authorization header。",
+                action="在本机重新执行 Codex 登录后重试，并确认 ~/.codex/auth.json 存在 tokens.access_token。",
+                auth_error=True,
+                status=status,
+                provider=prov,
+                operation=op,
+                technical=technical,
+            )
         if status == 403:
             return OAuthDisplayError(
                 code="openai_permission_403",

--- a/src/telegram/menus/oauth_menu.py
+++ b/src/telegram/menus/oauth_menu.py
@@ -585,6 +585,112 @@ def _usage_toggle_target_label() -> str:
     return _usage_display_label(target)
 
 
+def _reset_credit_dt(iso_str: str | None) -> datetime | None:
+    if not iso_str:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(iso_str).replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except Exception:
+        return None
+
+
+def _reset_credit_time_bjt(iso_str: str | None) -> str:
+    dt = _reset_credit_dt(iso_str)
+    if dt is None:
+        return "?"
+    return dt.astimezone(_BJT).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _reset_credit_status_order(card: dict) -> tuple[int, float, int]:
+    status = str(card.get("status") or "").lower()
+    status_rank = 0 if status == "available" else 1
+    expires = _reset_credit_dt(card.get("expires_at"))
+    ts = expires.timestamp() if expires else float("inf")
+    try:
+        index = int(card.get("index") or 0)
+    except (TypeError, ValueError):
+        index = 0
+    return status_rank, ts, index
+
+
+def _codex_reset_credits_text_and_kb(result: dict) -> tuple[str, dict]:
+    cards = result.get("credits") if isinstance(result, dict) else []
+    if not isinstance(cards, list):
+        cards = []
+    cards = [c for c in cards if isinstance(c, dict)]
+    cards.sort(key=_reset_credit_status_order)
+
+    try:
+        available = int(result.get("available_count"))
+    except (TypeError, ValueError, AttributeError):
+        available = sum(1 for c in cards if str(c.get("status") or "").lower() == "available")
+    try:
+        total_earned = int(result.get("total_earned_count"))
+    except (TypeError, ValueError, AttributeError):
+        total_earned = len(cards)
+
+    lines = [
+        "♻️ <b>本机 Codex 免费重置卡</b>",
+        "",
+        f"可用次数: <code>{available}</code> · 已发放: <code>{total_earned}</code>",
+        "时间已从 UTC 转为北京时间（UTC+8）。",
+    ]
+    if not cards:
+        lines += ["", "暂无重置卡。"]
+    else:
+        lines += ["", "<b>重置卡明细</b>"]
+        for idx, card in enumerate(cards, start=1):
+            lines.append(f"{idx}. 发放时间: <code>{_reset_credit_time_bjt(card.get('granted_at'))}</code>")
+            lines.append(f"   过期时间: <code>{_reset_credit_time_bjt(card.get('expires_at'))}</code>")
+
+    rows = [
+        [ui.btn("🔄 刷新", "oa:codex_reset_credits")],
+        [ui.btn("◀ 返回账户设置", "oa:settings"), ui.btn("◀ 返回OAuth账户", "menu:oauth")],
+    ]
+    return ui.truncate("\n".join(lines)), ui.inline_kb(rows)
+
+
+def _local_codex_reset_credit_error_html(exc) -> str:
+    if isinstance(exc, FileNotFoundError):
+        return (
+            "❌ <b>未找到本机 Codex 凭证</b>\n"
+            "• 路径：<code>~/.codex/auth.json</code>\n"
+            "• 处理：先在运行 Parrot 的这台机器完成 Codex 登录，再回来刷新。"
+        )
+    if isinstance(exc, ValueError) and "tokens.access_token" in str(exc):
+        return (
+            "❌ <b>Codex 凭证格式不完整</b>\n"
+            "• 原因：<code>~/.codex/auth.json</code> 缺少 <code>tokens.access_token</code>。\n"
+            "• 处理：重新登录 Codex 后重试。"
+        )
+    return _oauth_error_html(exc, provider="openai", operation="rate_limit_reset_credits")
+
+
+def on_local_codex_reset_credits(chat_id: int, message_id: int, cb_id: str | None = None) -> None:
+    if cb_id is not None:
+        ui.answer_cb(cb_id, "查询本机 Codex 重置卡...")
+    try:
+        result = openai_provider.fetch_local_codex_rate_limit_reset_credits_sync()
+    except Exception as exc:
+        text = _local_codex_reset_credit_error_html(exc)
+        if message_id:
+            ui.edit(
+                chat_id, message_id, text,
+                reply_markup=ui.inline_kb([[ui.btn("◀ 返回账户设置", "oa:settings")]]),
+            )
+        else:
+            ui.send(chat_id, text)
+        return
+    text, kb = _codex_reset_credits_text_and_kb(result)
+    if message_id:
+        ui.edit(chat_id, message_id, text, reply_markup=kb)
+    else:
+        ui.send(chat_id, text, reply_markup=kb)
+
+
 def _settings_text_and_kb() -> tuple[str, dict]:
     anthropic_models = _default_models_for_settings("anthropic")
     openai_models = _default_models_for_settings("openai")
@@ -624,6 +730,7 @@ def _settings_text_and_kb() -> tuple[str, dict]:
          ui.btn("✏ 修改OpenAI模型", "odm:edit:openai")],
         [ui.btn("🖼 图片生成设置", "img:show"),
          ui.btn("📈 配额监控", "oa:quota")],
+        [ui.btn("♻️ 本机Codex重置卡", "oa:codex_reset_credits")],
         [ui.btn(f"🎭 CCH模式：{cch_action}", "oa:cch_toggle"),
          ui.btn(f"📊 显示: {_usage_toggle_target_label()}", "oa:usage_mode:toggle")],
         [ui.btn("🏠 返回主菜单", "menu:main"),
@@ -3083,6 +3190,9 @@ def handle_callback(chat_id: int, message_id: int, cb_id: str, data: str) -> boo
         return True
     if data == "oa:quota":
         on_quota_menu(chat_id, message_id, cb_id)
+        return True
+    if data == "oa:codex_reset_credits":
+        on_local_codex_reset_credits(chat_id, message_id, cb_id)
         return True
     if data == "oa:quota_toggle":
         on_quota_toggle(chat_id, message_id, cb_id)

--- a/src/tests/test_m7_oauth_menu.py
+++ b/src/tests/test_m7_oauth_menu.py
@@ -433,6 +433,46 @@ def test_settings_cch_and_quota_monitor_controls(m):
     print("  [PASS] OAuth settings CCH toggle + quota monitor submenu")
 
 
+def test_settings_codex_reset_credits_button_and_render(m):
+    _setup(m)
+    rec = _install_recorder(m)
+    om = m["oauth_menu"]
+
+    om.on_settings(42, 100, "cb")
+    settings = rec.last("editMessageText")
+    assert settings and "本机Codex重置卡" in repr(settings["reply_markup"])
+    flat = [
+        b["callback_data"]
+        for row in settings["reply_markup"]["inline_keyboard"]
+        for b in row if "callback_data" in b
+    ]
+    assert "oa:codex_reset_credits" in flat
+
+    orig_fetch = om.openai_provider.fetch_local_codex_rate_limit_reset_credits_sync
+    try:
+        om.openai_provider.fetch_local_codex_rate_limit_reset_credits_sync = lambda: {
+            "available_count": 1,
+            "total_earned_count": 1,
+            "credits": [{
+                "status": "available",
+                "granted_at": "2026-06-12T01:33:14Z",
+                "expires_at": "2026-07-12T01:33:14Z",
+            }],
+        }
+        rec.clear()
+        assert om.handle_callback(42, 100, "cb", "oa:codex_reset_credits") is True
+    finally:
+        om.openai_provider.fetch_local_codex_rate_limit_reset_credits_sync = orig_fetch
+
+    rendered = rec.last("editMessageText")
+    assert rendered and "本机 Codex 免费重置卡" in rendered["text"]
+    assert "可用次数: <code>1</code>" in rendered["text"]
+    assert "发放时间: <code>2026-06-12 09:33:14</code>" in rendered["text"]
+    assert "过期时间: <code>2026-07-12 09:33:14</code>" in rendered["text"]
+    assert "RateLimitResetCredit" not in rendered["text"]
+    print("  [PASS] settings exposes local Codex reset credits and renders BJT times without IDs")
+
+
 def test_refresh_token_updates_access_and_usage(m):
     _setup(m)
     _add_fake_account(m, "bob@x.com")
@@ -1025,6 +1065,7 @@ def main():
         test_view_detail_with_quota_cache,
         test_settings_usage_display_mode_toggle,
         test_settings_cch_and_quota_monitor_controls,
+        test_settings_codex_reset_credits_button_and_render,
         test_refresh_token_updates_access_and_usage,
         test_refresh_usage_only,
         test_toggle_disable_then_enable,

--- a/src/tests/test_openai_oauth.py
+++ b/src/tests/test_openai_oauth.py
@@ -474,6 +474,41 @@ def test_fetch_usage_openai_goes_through_wham(m):
     print("  [PASS] fetch_usage openai: unified path (wham/usage + account id)")
 
 
+def test_normalize_rate_limit_reset_credits_sanitizes_payload(m):
+    p = m["openai_provider"]
+    payload = {
+        "available_count": 1,
+        "total_earned_count": 2,
+        "credits": [
+            {
+                "id": "RateLimitResetCredit_secret-full-id",
+                "status": "available",
+                "granted_at": "2026-06-12T01:33:14Z",
+                "expires_at": "2026-07-12T01:33:14Z",
+                "cookie": "do-not-leak",
+            },
+            {
+                "id": "RateLimitResetCredit_redeemed-id",
+                "status": "redeemed",
+                "issued_at": "2026-06-10T00:00:00Z",
+                "expiration_time": "2026-07-10T00:00:00Z",
+            },
+        ],
+    }
+    norm = p.normalize_rate_limit_reset_credits(payload)
+    assert norm["available_count"] == 1
+    assert norm["total_earned_count"] == 2
+    assert norm["credits"][0] == {
+        "index": 1,
+        "status": "available",
+        "granted_at": "2026-06-12T01:33:14Z",
+        "expires_at": "2026-07-12T01:33:14Z",
+    }
+    assert "RateLimitResetCredit_secret" not in repr(norm)
+    assert "cookie" not in repr(norm)
+    print("  [PASS] normalize_rate_limit_reset_credits: keeps times/counts, drops IDs/secrets")
+
+
 def test_fetch_wham_usage_sends_account_id_header(m):
     """wham/usage 请求显式带 ChatGPT-Account-ID，与 Codex BackendClient 对齐。"""
     _setup(m)
@@ -519,6 +554,59 @@ def test_fetch_wham_usage_sends_account_id_header(m):
     assert usage["five_hour"]["utilization"] == 1.0
     assert usage["seven_day"]["utilization"] == 3.0
     print("  [PASS] fetch_wham_usage_sync: sends ChatGPT-Account-ID header")
+
+
+def test_fetch_rate_limit_reset_credits_sends_auth_and_account_header(m):
+    """Dedicated reset-credit endpoint uses Codex Bearer auth and redacts raw IDs."""
+    _setup(m)
+    p = m["openai_provider"]
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+        headers = {"content-type": "application/json"}
+        text = "{}"
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "available_count": 1,
+                "total_earned_count": 1,
+                "credits": [{
+                    "id": "RateLimitResetCredit_sensitive-id",
+                    "status": "available",
+                    "granted_at": "2026-06-12T01:33:14Z",
+                    "expires_at": "2026-07-12T01:33:14Z",
+                }],
+            }
+
+    orig_get = p.network.get_sync
+    try:
+        m["config"].update(lambda c: c.setdefault("oauth", {}).__setitem__("mockMode", False))
+
+        def _fake_get(url, *, headers=None, **kwargs):
+            captured["url"] = url
+            captured["headers"] = dict(headers or {})
+            captured["timeout"] = kwargs.get("timeout")
+            captured["proxy_purpose"] = kwargs.get("proxy_purpose")
+            return _Resp()
+
+        p.network.get_sync = _fake_get
+        credits = p.fetch_rate_limit_reset_credits_sync("at-token", account_id="acct-x")
+    finally:
+        p.network.get_sync = orig_get
+        m["config"].update(lambda c: c.setdefault("oauth", {}).__setitem__("mockMode", True))
+
+    assert captured["url"] == p.WHAM_RESET_CREDITS_URL
+    assert captured["headers"].get("authorization") == "Bearer at-token"
+    assert captured["headers"].get("ChatGPT-Account-ID") == "acct-x"
+    assert captured["headers"].get("openai-beta") == "codex-1"
+    assert captured["proxy_purpose"] == "oauth_openai"
+    assert credits["credits"][0]["granted_at"] == "2026-06-12T01:33:14Z"
+    assert "sensitive-id" not in repr(credits)
+    print("  [PASS] fetch_rate_limit_reset_credits_sync: auth/account headers + sanitized output")
 
 
 # ─── TG bot: OpenAI add via PKCE ─────────────────────────────────
@@ -640,7 +728,9 @@ def main():
         test_refresh_notice_openai_wording,
         test_openai_refresh_updates_id_token_metadata,
         test_fetch_usage_openai_goes_through_wham,
+        test_normalize_rate_limit_reset_credits_sanitizes_payload,
         test_fetch_wham_usage_sends_account_id_header,
+        test_fetch_rate_limit_reset_credits_sends_auth_and_account_header,
         test_tg_openai_add_via_pkce,
         test_tg_openai_add_state_mismatch,
         test_tg_openai_add_via_rt,


### PR DESCRIPTION
## Summary
- add a safe Parrot endpoint to read local Codex CLI credentials from `~/.codex/auth.json` (or `PARROT_CODEX_AUTH_PATH` / `CODEX_AUTH_PATH`) and fetch ChatGPT WHAM `rate-limit-reset-credits`
- normalize reset-credit cards to available/earned counts plus per-card `granted_at` / `expires_at` / `status`, without returning `access_token`, `refresh_token`, cookie, raw payloads, or full upstream IDs
- expose a Telegram settings button that renders each reset card's grant and expiry time in Beijing time with Chinese copy, and return a specific 401 explanation for expired credentials or missing/invalid Authorization

## Tests
- `python3 -m py_compile server.py src/oauth/openai.py src/oauth_errors.py src/telegram/menus/oauth_menu.py src/tests/test_openai_oauth.py src/tests/test_m7_oauth_menu.py`
- `.venv/bin/python -m pytest src/tests/test_openai_oauth.py src/tests/test_m7_oauth_menu.py -q`
