### PR TITLE
fix: prevent duplicate OpenAI quota recovery notices

### DIFF
--- a/src/failover.py
+++ b/src/failover.py
@@ -334,13 +334,12 @@ def _maybe_auto_disable_by_codex_snapshot(account_key: str, email: str,
     try:
         ek = notifier.escape_html
         _acc = oauth_manager.get_account(account_key)
-        _plan = (_acc.get("plan_type") or "") if _acc else ""
-        _plan_tag = f" · {ek(_plan)}" if _plan else ""
+        _label = oauth_manager.openai_plan_workspace_label(_acc) if _acc else "OpenAI"
         notifier.notify_event(
             "quota_disabled",
             "⚠ <b>OAuth 配额已用尽（响应头实时触发）</b>\n"
             f"账号: <code>{ek(email)}</code>\n"
-            f"🅾️ OpenAI{_plan_tag}\n"
+            f"🅾️ {ek(_label)}\n"
             f"超限窗口: <code>{' / '.join(over_windows)}</code> "
             f"(阈值 {threshold:.0f}%)\n"
             f"恢复时间: <code>{latest_iso or 'unknown'}</code>"

--- a/src/oauth_manager.py
+++ b/src/oauth_manager.py
@@ -1165,6 +1165,129 @@ def _usage_has_any_quota_signal(usage: dict) -> bool:
     return any(u is not None for u in extract_utils_percent(usage))
 
 
+def openai_plan_workspace_label(acc: dict | None) -> str:
+    """Human label for OpenAI OAuth accounts.
+
+    The same email can appear in multiple ChatGPT workspaces. Keep the label
+    readable for notifications: plan plus workspace name, without leaking a raw
+    workspace/account UUID suffix.
+    """
+    if not acc:
+        return "OpenAI"
+    plan_raw = str(acc.get("plan_type") or "").strip()
+    workspace = str(acc.get("workspace_name") or "").strip()
+    plan_map = {
+        "team": "Team",
+        "plus": "Plus",
+        "pro": "Pro",
+        "free": "Free",
+        "enterprise": "Enterprise",
+    }
+    plan = plan_map.get(plan_raw.lower(), plan_raw[:1].upper() + plan_raw[1:] if plan_raw else "")
+    if plan and workspace and workspace.lower() != "personal":
+        return f"OpenAI · {plan}（{workspace}）"
+    if plan:
+        return f"OpenAI · {plan}"
+    if workspace and workspace.lower() != "personal":
+        return f"OpenAI · {workspace}"
+    return "OpenAI"
+
+
+def _ms_timestamp(value) -> int | None:
+    try:
+        if value is None:
+            return None
+        v = float(value)
+    except (TypeError, ValueError):
+        return None
+    # state_db historically stores quota timestamps in milliseconds, while a few
+    # call sites/comments still talk in seconds. Accept both for safety.
+    if v > 10_000_000_000:
+        return int(v)
+    if v > 1_000_000_000:
+        return int(v * 1000)
+    return None
+
+
+def _iso_from_ms(ms: int | None) -> str | None:
+    if ms is None:
+        return None
+    try:
+        return _format_utc(datetime.fromtimestamp(ms / 1000, tz=timezone.utc))
+    except Exception:
+        return None
+
+
+def _latest_iso(*values: str | None) -> str | None:
+    latest = None
+    for value in values:
+        dt = _parse_iso(value)
+        if dt is not None and (latest is None or dt > latest):
+            latest = dt
+    return _format_utc(latest.astimezone(timezone.utc)) if latest else None
+
+
+def _cached_openai_codex_quota_hit(account_key: str, threshold: float) -> dict:
+    """Return active Codex response-header quota hits cached for an OpenAI account.
+
+    WHAM /usage and Codex response headers can disagree near reset boundaries.
+    If a quota-disabled account has a still-active Codex header snapshot over the
+    threshold, quota_monitor must not immediately resume it just because WHAM is
+    below threshold. Use last_passive_update_at + reset_after_seconds so expired
+    header snapshots don't keep accounts disabled forever.
+    """
+    row = state_db.quota_load(account_key)
+    if not row:
+        return {"any_over": False, "hit_windows": [], "latest_reset": None}
+
+    base_ms = _ms_timestamp(row.get("last_passive_update_at")) or _ms_timestamp(row.get("fetched_at"))
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    hits: list[str] = []
+    resets: list[str | None] = []
+
+    for label, pct_key, reset_key in (
+        ("codex primary", "codex_primary_used_pct", "codex_primary_reset_sec"),
+        ("codex secondary", "codex_secondary_used_pct", "codex_secondary_reset_sec"),
+    ):
+        try:
+            pct = float(row.get(pct_key)) if row.get(pct_key) is not None else None
+        except (TypeError, ValueError):
+            pct = None
+        if pct is None or pct < threshold:
+            continue
+
+        reset_iso = None
+        reset_ms = None
+        try:
+            reset_sec = row.get(reset_key)
+            if reset_sec is not None:
+                reset_sec = int(reset_sec)
+                # Most rows store reset-after-seconds relative to the passive
+                # snapshot. Be tolerant of future absolute epoch seconds too.
+                if reset_sec > 1_000_000_000:
+                    reset_ms = reset_sec * 1000
+                elif base_ms is not None:
+                    reset_ms = base_ms + max(0, reset_sec) * 1000
+                reset_iso = _iso_from_ms(reset_ms)
+        except Exception:
+            reset_ms = None
+            reset_iso = None
+
+        # The cached header said "over threshold", but its reset time has passed;
+        # ignore it and let fresh WHAM usage decide recovery.
+        if reset_ms is not None and reset_ms <= now_ms:
+            continue
+
+        hits.append(f"{label} {pct:.0f}%")
+        resets.append(reset_iso)
+
+    return {
+        "any_over": bool(hits),
+        "hit_windows": hits,
+        "latest_reset": _latest_iso(*resets),
+    }
+
+
 def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
                                  *, threshold: float | None = None,
                                  fresh: bool = True) -> dict:
@@ -1218,12 +1341,24 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
                 "hit_windows": hit_windows,
                 "disabled_until": acc.get("disabled_until")}
 
+    cached_codex_hit = None
+    if provider_of(account_key) == "openai":
+        cached_codex_hit = _cached_openai_codex_quota_hit(account_key, threshold)
+        if cached_codex_hit.get("any_over"):
+            any_over = True
+            for _hit in cached_codex_hit.get("hit_windows") or []:
+                if _hit not in hit_windows:
+                    hit_windows.append(_hit)
+
     if any_over:
         if reason == "quota":
             return {"action": "still_over_quota", "utils": utils,
                     "any_over": True, "hit_windows": hit_windows,
-                    "disabled_until": acc.get("disabled_until")}
-        latest_reset = reset_iso_for_hit_windows(usage, threshold)
+                    "disabled_until": acc.get("disabled_until") or (cached_codex_hit or {}).get("latest_reset")}
+        latest_reset = _latest_iso(
+            reset_iso_for_hit_windows(usage, threshold),
+            (cached_codex_hit or {}).get("latest_reset"),
+        )
         try:
             set_disabled_by_quota(account_key, latest_reset)
         except Exception as exc:
@@ -1236,8 +1371,9 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
 
     # 全部窗口都可用。OpenAI 的 usage 来自响应头/最小 probe 的缓存合成，
     # 空缓存或被节流跳过的旧缓存不能证明额度恢复；尤其 quota 禁用账号不能
-    # 因 [None, None, None, None] 被误恢复。若拿到新鲜有效 usage，则真实
-    # 低用量优先于旧 disabled_until，避免 30d 已重置仍卡在 quota 禁用。
+    # 因 [None, None, None, None] 被误恢复。若 disabled_until 仍在未来，也不
+    # 提前恢复：OpenAI WHAM 与 Codex 响应头在边界附近会不同步，提前恢复会
+    # 造成“恢复通知 → 下一次请求马上响应头禁用”的假恢复。
     if reason == "quota":
         if provider_of(account_key) == "openai":
             if not _usage_has_any_quota_signal(usage):
@@ -1246,6 +1382,10 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
                         "disabled_until": acc.get("disabled_until")}
             if not fresh:
                 return {"action": "quota_stale_keep_disabled", "utils": utils,
+                        "any_over": False, "hit_windows": [],
+                        "disabled_until": acc.get("disabled_until")}
+            if _quota_disabled_until_still_future(acc):
+                return {"action": "quota_cooldown_keep_disabled", "utils": utils,
                         "any_over": False, "hit_windows": [],
                         "disabled_until": acc.get("disabled_until")}
         try:
@@ -2275,8 +2415,8 @@ async def quota_monitor_once() -> dict:
             _pl = claude_plan_label(acc)
             _plan_tag = f"\n🅰 Claude · {notifier.escape_html(_pl)}" if _pl else ""
         elif provider_of(ak) == "openai":
-            _pl = acc.get("plan_type") or ""
-            _plan_tag = f"\n🅾 OpenAI · {notifier.escape_html(_pl)}" if _pl else ""
+            _label = openai_plan_workspace_label(acc)
+            _plan_tag = f"\n🅾 {notifier.escape_html(_label)}" if _label else ""
 
         if action == "disabled":
             latest_reset = result["disabled_until"]
@@ -2294,10 +2434,12 @@ async def quota_monitor_once() -> dict:
             out[email] = "still_over_quota"
         elif action == "resumed":
             out[email] = "resumed"
-            notifier.notify_event(
+            notifier.throttled_notify_event_sync(
                 "quota_resumed",
+                f"quota_resumed:{ak}",
                 "✅ <b>OAuth 配额已恢复，账号重新启用</b>\n"
                 f"账号: <code>{notifier.escape_html(email)}</code>{_plan_tag}",
+                cooldown_seconds=300,
             )
         elif action == "kept_enabled":
             parts = [f"{u:.0f}%" if u is not None else "-" for u in utils]

--- a/src/tests/test_openai_oauth_quota.py
+++ b/src/tests/test_openai_oauth_quota.py
@@ -64,9 +64,17 @@ def _setup(m):
     m["config"].update(_reset)
     for row in m["state_db"].quota_load_all():
         m["state_db"].quota_delete(row.get("account_key") or row["email"])
-    # 清 failover 的节流桶（test 之间不共享节流状态）
+    # 清 failover / UI 的跨 test 状态。
     m["failover"]._codex_snapshot_last.clear()
     m["states"].clear_all()
+    # UI list/detail helpers schedule daemon background refreshes in production. In
+    # this standalone integration test they race with the next case's isolated
+    # config/state, so no-op the schedulers and clear in-flight buckets.
+    if "oauth_menu" in m:
+        m["oauth_menu"]._schedule_oauth_cache_refresh_for_ui = lambda *a, **kw: None
+        m["oauth_menu"]._schedule_openai_metadata_for_ui = lambda *a, **kw: None
+        m["oauth_menu"]._BACKGROUND_REFRESH_INFLIGHT.clear()
+        m["oauth_menu"]._METADATA_REFRESH_INFLIGHT.clear()
 
 
 def _add_openai(m, email="q@openai.test"):
@@ -405,6 +413,139 @@ def test_oauth_menu_refresh_usage_openai_auto_disables_over_quota(m):
     print("  [PASS] oauth_menu refresh_usage(openai): wham over-quota auto disables")
 
 
+def test_openai_quota_resume_respects_active_codex_snapshot(m):
+    """WHAM 低于阈值时，仍要尊重未过期的 Codex 响应头超限快照。"""
+    _setup(m)
+    email = "edge@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    m["oauth_manager"].set_disabled_by_quota(key, "2099-01-01T00:00:00Z")
+
+    snap = m["openai_provider"].parse_rate_limit_headers({
+        "x-codex-primary-used-percent": "96",
+        "x-codex-primary-reset-after-seconds": "3600",
+        "x-codex-primary-window-minutes": "300",
+        "x-codex-secondary-used-percent": "10",
+        "x-codex-secondary-window-minutes": "10080",
+    })
+    assert snap is not None
+    m["state_db"].quota_save_openai_snapshot(
+        key, snap, m["openai_provider"].normalize_codex_snapshot(snap), email=email,
+    )
+
+    wham_below_threshold = {
+        "five_hour": {"utilization": 1.0, "resets_at": "2099-01-01T00:01:00Z"},
+        "seven_day": {"utilization": 1.0, "resets_at": "2099-01-01T01:00:00Z"},
+        "seven_day_sonnet": {},
+        "seven_day_opus": {},
+        "extra_usage": {"is_enabled": False},
+        "openai": {"source": "wham_usage"},
+    }
+    result = m["oauth_manager"].evaluate_and_toggle_by_usage(
+        key, wham_below_threshold, threshold=95, fresh=True,
+    )
+    acc = m["oauth_manager"].get_account(key)
+    assert result["action"] == "still_over_quota", result
+    assert result["any_over"] is True, result
+    assert "codex primary 96%" in result["hit_windows"], result
+    assert acc.get("disabled_reason") == "quota", acc
+    assert acc.get("enabled") is False, acc
+    print("  [PASS] OpenAI quota resume respects active Codex over-threshold snapshot")
+
+
+def test_openai_quota_resume_waits_for_future_disabled_until(m):
+    """OpenAI quota-disabled accounts must not resume before disabled_until expires."""
+    _setup(m)
+    email = "cooldown@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    m["oauth_manager"].set_disabled_by_quota(key, "2099-01-01T00:00:00Z")
+
+    wham_below_threshold = {
+        "five_hour": {"utilization": 1.0, "resets_at": "2099-01-01T00:01:00Z"},
+        "seven_day": {"utilization": 1.0, "resets_at": "2099-01-01T01:00:00Z"},
+        "seven_day_sonnet": {},
+        "seven_day_opus": {},
+        "extra_usage": {"is_enabled": False},
+        "openai": {"source": "wham_usage"},
+    }
+    result = m["oauth_manager"].evaluate_and_toggle_by_usage(
+        key, wham_below_threshold, threshold=95, fresh=True,
+    )
+    acc = m["oauth_manager"].get_account(key)
+    assert result["action"] == "quota_cooldown_keep_disabled", result
+    assert acc.get("disabled_reason") == "quota", acc
+    assert acc.get("enabled") is False, acc
+    assert acc.get("disabled_until") == "2099-01-01T00:00:00Z", acc
+    print("  [PASS] OpenAI quota resume waits for future disabled_until")
+
+
+def test_quota_monitor_notifies_when_openai_quota_really_resumes(m):
+    """Once disabled_until has expired and fresh WHAM usage is low, resume and notify."""
+    _setup(m)
+    email = "notify-resume@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    m["oauth_manager"].set_disabled_by_quota(key, "2000-01-01T00:00:00Z")
+
+    wham_below_threshold = {
+        "five_hour": {"utilization": 1.0, "resets_at": "2000-01-01T00:01:00Z"},
+        "seven_day": {"utilization": 1.0, "resets_at": "2000-01-01T01:00:00Z"},
+        "seven_day_sonnet": {},
+        "seven_day_opus": {},
+        "extra_usage": {"is_enabled": False},
+        "openai": {"source": "wham_usage"},
+    }
+
+    calls = []
+    orig_fetch = m["oauth_manager"].fetch_usage
+    orig_notify = m["oauth_manager"].notifier.throttled_notify_event_sync
+
+    async def _fake_fetch_usage(account_key):
+        assert account_key == key
+        return wham_below_threshold
+
+    def _fake_notify(event, throttle_key, message, **kwargs):
+        calls.append((event, throttle_key, message, kwargs))
+
+    import asyncio
+    try:
+        m["oauth_manager"].fetch_usage = _fake_fetch_usage
+        m["oauth_manager"].notifier.throttled_notify_event_sync = _fake_notify
+        out = asyncio.run(m["oauth_manager"].quota_monitor_once())
+    finally:
+        m["oauth_manager"].fetch_usage = orig_fetch
+        m["oauth_manager"].notifier.throttled_notify_event_sync = orig_notify
+
+    acc = m["oauth_manager"].get_account(key)
+    assert out[email] == "resumed", out
+    assert acc.get("enabled") is True, acc
+    assert acc.get("disabled_reason") is None, acc
+    assert len(calls) == 1, calls
+    assert calls[0][0] == "quota_resumed", calls
+    assert calls[0][1] == f"quota_resumed:{key}", calls
+    assert "OAuth 配额已恢复" in calls[0][2]
+    assert "OpenAI · Plus" in calls[0][2]
+    print("  [PASS] quota_monitor resumes and sends notification after cooldown expires")
+
+
+def test_openai_plan_workspace_label_disambiguates_same_email(m):
+    _setup(m)
+    label = m["oauth_manager"].openai_plan_workspace_label({
+        "plan_type": "team",
+        "workspace_name": "us",
+        "workspace_id": "d5611c34-1909-44f5-ac0a-9ef630e41c85",
+    })
+    assert label == "OpenAI · Team（us）"
+    assert "d5611c34" not in label
+    plus_label = m["oauth_manager"].openai_plan_workspace_label({
+        "plan_type": "plus",
+        "workspace_name": "Personal",
+    })
+    assert plus_label == "OpenAI · Plus"
+    print("  [PASS] OpenAI notification label shows readable plan/workspace without raw id")
+
+
 def test_oauth_menu_refresh_all_uses_wham_for_openai(m):
     """refresh_all 对 openai：有效 access_token 直接 wham/usage，不发 probe/强刷 token。"""
     _setup(m)
@@ -572,6 +713,10 @@ def main():
         test_oauth_menu_list_cached_openai_below_dynamic_threshold_kept_enabled,
         test_oauth_menu_refresh_usage_openai_wham,
         test_oauth_menu_refresh_usage_openai_auto_disables_over_quota,
+        test_openai_quota_resume_respects_active_codex_snapshot,
+        test_openai_quota_resume_waits_for_future_disabled_until,
+        test_quota_monitor_notifies_when_openai_quota_really_resumes,
+        test_openai_plan_workspace_label_disambiguates_same_email,
         test_oauth_menu_refresh_all_uses_wham_for_openai,
         test_probe_usage_writes_snapshot_in_mock_mode,
         test_delete_account_clears_codex_snapshot_throttle,


### PR DESCRIPTION
## Summary
- Prevent quota-disabled OpenAI accounts from being resumed before their current `disabled_until` cooldown expires, even when WHAM briefly reports usage below threshold.
- Still resume and send the `quota_resumed` notification once `disabled_until` has expired and a fresh WHAM usage sample is below threshold.
- Keep active over-threshold Codex response-header snapshots authoritative so WHAM/Codex disagreement cannot trigger a false recovery.
- Format OpenAI notification labels as readable plan/workspace labels such as `OpenAI · Team（us）` and `OpenAI · Plus`, without leaking raw workspace/account ID suffixes.
- Add regression coverage for false recovery suppression, real recovery notifications, Codex snapshot disagreement, label formatting, and test isolation from UI background refresh threads.

## Test Plan
- `/tmp/parrot-pr-venv/bin/python -m py_compile src/oauth_manager.py src/failover.py src/tests/test_openai_oauth_quota.py`
- `/tmp/parrot-pr-venv/bin/python src/tests/test_openai_oauth_quota.py` → `RESULT: 20 / 20 passed`
- Repeated `src/tests/test_openai_oauth_quota.py` 3 times after stabilizing UI background-refresh isolation → all 3 runs `RESULT: 20 / 20 passed`
