### PR TITLE
fix: 修复 OpenAI 配额恢复与 API Key 排队请求体回放

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,11 @@ API Key 还支持启用/停用与单 Key 请求限流：全局默认在「⚙ �
     "defaultMaxRequestBodyBytes": 8388608,
     "defaultMaxRequestBodyEvents": 4096,
     "defaultMaxQueuedBodyBytesPerKey": 33554432,
-    "maxQueuedBodyBytes": 134217728
+    "maxQueuedBodyBytes": 134217728,
+    "queuedBodySpoolThresholdBytes": 1048576,
+    "queuedBodySpoolDirectory": "",
+    "defaultMaxQueuedBodySpoolBytesPerKey": 536870912,
+    "maxQueuedBodySpoolBytes": 2147483648
   },
   "concurrency":   { "enabled": true, "queueWaitSeconds": 30, "defaultMaxConcurrent": 0 },
   "errorWindows":  [1, 3, 5, 10, 15, 0],
@@ -498,6 +502,8 @@ API Key 还支持启用/停用与单 Key 请求限流：全局默认在「⚙ �
 > `quotaMonitor.enabled` **默认关闭** —— 启用后每 N 秒拉一次每个 OAuth 账号的 usage（Claude 走 `/api/oauth/usage`，OpenAI 走 Codex 探测头），频繁请求可能被风控盯上。
 
 > `apiKeys.*.allowImages` **默认关闭** —— 新建或历史 API Key 不会自动获得图片生成 / 编辑能力，必须在 TG「🔑 管理 API Key」里显式开启。
+
+> API Key 请求排队时，小于 `queuedBodySpoolThresholdBytes` 的待回放 body 保留在内存；超过阈值后自动转入临时文件。空的 `queuedBodySpoolDirectory` 表示使用数据目录下的 `queued-body-spool/`。内存预算沿用 `defaultMaxQueuedBodyBytesPerKey` / `maxQueuedBodyBytes`；磁盘临时数据另由 `defaultMaxQueuedBodySpoolBytesPerKey` / `maxQueuedBodySpoolBytes` 约束，成功、失败、取消或断开后都会关闭并删除。
 
 > `images.cacheRetentionDays=0` 表示不按时间清理；`images.cacheMaxBytes=0` 表示不按空间清理。相对 `cachePath` 会落在数据目录下，Parrot 会阻止相对路径逃逸。
 

--- a/README.md
+++ b/README.md
@@ -450,7 +450,16 @@ API Key 还支持启用/停用与单 Key 请求限流：全局默认在「⚙ �
     "dbPath": "image_logs.db"
   },
   "timeouts":      { "connect": 10, "firstByte": 30, "idle": 120, "total": 600 },
-  "apiKeyConcurrency": { "enabled": true, "defaultMaxConcurrent": 5, "defaultMaxQueue": 50, "defaultQueueWaitSeconds": 1800 },
+  "apiKeyConcurrency": {
+    "enabled": true,
+    "defaultMaxConcurrent": 5,
+    "defaultMaxQueue": 50,
+    "defaultQueueWaitSeconds": 1800,
+    "defaultMaxRequestBodyBytes": 8388608,
+    "defaultMaxRequestBodyEvents": 4096,
+    "defaultMaxQueuedBodyBytesPerKey": 33554432,
+    "maxQueuedBodyBytes": 134217728
+  },
   "concurrency":   { "enabled": true, "queueWaitSeconds": 30, "defaultMaxConcurrent": 0 },
   "errorWindows":  [1, 3, 5, 10, 15, 0],
   "oauthGraceCount": 3,

--- a/config.example.json
+++ b/config.example.json
@@ -13,7 +13,8 @@
         "enabled": null,
         "maxConcurrent": null,
         "maxQueue": null,
-        "queueWaitSeconds": null
+        "queueWaitSeconds": null,
+        "maxQueuedBodySpoolBytes": null
       }
     }
   },
@@ -25,7 +26,11 @@
     "defaultMaxRequestBodyBytes": 8388608,
     "defaultMaxRequestBodyEvents": 4096,
     "defaultMaxQueuedBodyBytesPerKey": 33554432,
-    "maxQueuedBodyBytes": 134217728
+    "maxQueuedBodyBytes": 134217728,
+    "queuedBodySpoolThresholdBytes": 1048576,
+    "queuedBodySpoolDirectory": "",
+    "defaultMaxQueuedBodySpoolBytesPerKey": 536870912,
+    "maxQueuedBodySpoolBytes": 2147483648
   },
   "oauthAccounts": [],
   "channels": [

--- a/config.example.json
+++ b/config.example.json
@@ -21,7 +21,11 @@
     "enabled": true,
     "defaultMaxConcurrent": 5,
     "defaultMaxQueue": 50,
-    "defaultQueueWaitSeconds": 1800
+    "defaultQueueWaitSeconds": 1800,
+    "defaultMaxRequestBodyBytes": 8388608,
+    "defaultMaxRequestBodyEvents": 4096,
+    "defaultMaxQueuedBodyBytesPerKey": 33554432,
+    "maxQueuedBodyBytes": 134217728
   },
   "oauthAccounts": [],
   "channels": [

--- a/docs/02-config-schema.md
+++ b/docs/02-config-schema.md
@@ -254,7 +254,7 @@
 
 `apiKeys.<name>.enabled` 控制该 Key 是否可用，缺失或 `null` 时按 `true` 处理。`apiKeyConcurrency` 是 API Key 级限流默认值；`apiKeys.<name>.limits.enabled/maxConcurrent/maxQueue/queueWaitSeconds` 是单 Key 覆盖，其中 `limits.enabled` 优先级高于全局 `apiKeyConcurrency.enabled`。默认单 Key 5 并发、50 队列、最长等待 1800 秒；队列满、等待超时或客户端断开时请求会从队列移除并返回/结束。
 
-排队期间，限流器会读取 ASGI `receive` 以尽早发现客户端断开，并把期间读到的 `http.request` 事件完整回放给下游。`defaultMaxRequestBodyBytes` 和 `defaultMaxRequestBodyEvents` 限制单个排队请求，超限返回 413；`defaultMaxQueuedBodyBytesPerKey` 和 `maxQueuedBodyBytes` 分别限制单 Key 与全进程保留的请求体估算内存（正文加每事件固定开销），达到聚合上限时返回 429。请求获得并发槽位、缓存事件回放完毕后，后续 body 由下游直接读取；取消、超时与响应结束都会释放保留内存。
+排队期间，限流器会读取 ASGI `receive` 以尽早发现客户端断开，并把期间读到的 `http.request` 事件完整回放给下游。`defaultMaxRequestBodyBytes` 和 `defaultMaxRequestBodyEvents` 是排队与非排队请求一致使用的单请求总量限制，超限返回 413；图片编辑端点会按 `images.maxInputImageBytes`、multipart/JSON（data URL 的 base64 膨胀）、标准多图与 mask 合同自动提高总 body 上限，保证合法的 20 MiB 单图不会被通用 8 MiB 默认值误拒绝。`defaultMaxQueuedBodyBytesPerKey` 和 `maxQueuedBodyBytes` 分别限制单 Key 与全进程保留的请求体估算内存（正文加每事件固定开销），达到聚合上限时返回 429 并带 `Retry-After`；旧配置名 `maxQueuedBodyBytesTotal` 仅在没有公开键 `maxQueuedBodyBytes` 时作为兼容回退。请求获得并发槽位、缓存事件回放完毕后，后续 body 由下游直接读取；multipart 继续由 Starlette 使用 spool 文件解析，取消、超时与响应结束都会释放队列保留内存。
 
 ## 2.2 字段语义详解
 

--- a/docs/02-config-schema.md
+++ b/docs/02-config-schema.md
@@ -34,7 +34,11 @@
     "enabled": true,
     "defaultMaxConcurrent": 5,
     "defaultMaxQueue": 50,
-    "defaultQueueWaitSeconds": 1800
+    "defaultQueueWaitSeconds": 1800,
+    "defaultMaxRequestBodyBytes": 8388608,       // 单个排队请求最多预读/回放 8 MiB
+    "defaultMaxRequestBodyEvents": 4096,         // 单个排队请求最多缓存 4096 个 ASGI body 事件
+    "defaultMaxQueuedBodyBytesPerKey": 33554432, // 单 Key 排队请求体估算内存上限 32 MiB
+    "maxQueuedBodyBytes": 134217728              // 全进程排队请求体估算内存上限 128 MiB
   },
 
   // ─── OAuth 账户列表 ───
@@ -249,6 +253,8 @@
 `apiKeys.<name>.key` 是下游客户端作为 Bearer / x-api-key 使用的密钥字符串。配置层不要求 `ccp-` 前缀，任意字符串都可；TG bot 自动生成时仍使用 `ccp-<48 hex>`，也可以在菜单里输入自定义 key。
 
 `apiKeys.<name>.enabled` 控制该 Key 是否可用，缺失或 `null` 时按 `true` 处理。`apiKeyConcurrency` 是 API Key 级限流默认值；`apiKeys.<name>.limits.enabled/maxConcurrent/maxQueue/queueWaitSeconds` 是单 Key 覆盖，其中 `limits.enabled` 优先级高于全局 `apiKeyConcurrency.enabled`。默认单 Key 5 并发、50 队列、最长等待 1800 秒；队列满、等待超时或客户端断开时请求会从队列移除并返回/结束。
+
+排队期间，限流器会读取 ASGI `receive` 以尽早发现客户端断开，并把期间读到的 `http.request` 事件完整回放给下游。`defaultMaxRequestBodyBytes` 和 `defaultMaxRequestBodyEvents` 限制单个排队请求，超限返回 413；`defaultMaxQueuedBodyBytesPerKey` 和 `maxQueuedBodyBytes` 分别限制单 Key 与全进程保留的请求体估算内存（正文加每事件固定开销），达到聚合上限时返回 429。请求获得并发槽位、缓存事件回放完毕后，后续 body 由下游直接读取；取消、超时与响应结束都会释放保留内存。
 
 ## 2.2 字段语义详解
 

--- a/docs/02-config-schema.md
+++ b/docs/02-config-schema.md
@@ -24,7 +24,8 @@
         "enabled": null,               // 优先级高于 apiKeyConcurrency.enabled
         "maxConcurrent": null,         // 0 = 不限并发
         "maxQueue": null,              // 0 = 不排队，满并发直接 429
-        "queueWaitSeconds": null       // 0 = 不等待，满并发直接 429
+        "queueWaitSeconds": null,      // 0 = 不等待，满并发直接 429
+        "maxQueuedBodySpoolBytes": null // 单 Key 临时磁盘预算；null 继承全局
       }
     }
   },
@@ -38,7 +39,11 @@
     "defaultMaxRequestBodyBytes": 8388608,       // 单个排队请求最多预读/回放 8 MiB
     "defaultMaxRequestBodyEvents": 4096,         // 单个排队请求最多缓存 4096 个 ASGI body 事件
     "defaultMaxQueuedBodyBytesPerKey": 33554432, // 单 Key 排队请求体估算内存上限 32 MiB
-    "maxQueuedBodyBytes": 134217728              // 全进程排队请求体估算内存上限 128 MiB
+    "maxQueuedBodyBytes": 134217728,             // 全进程排队请求体估算内存上限 128 MiB
+    "queuedBodySpoolThresholdBytes": 1048576,    // 单请求超过 1 MiB 后转入临时文件
+    "queuedBodySpoolDirectory": "",             // 空 = 数据目录/queued-body-spool
+    "defaultMaxQueuedBodySpoolBytesPerKey": 536870912, // 单 Key 临时磁盘上限 512 MiB
+    "maxQueuedBodySpoolBytes": 2147483648        // 全进程临时磁盘上限 2 GiB
   },
 
   // ─── OAuth 账户列表 ───
@@ -254,7 +259,9 @@
 
 `apiKeys.<name>.enabled` 控制该 Key 是否可用，缺失或 `null` 时按 `true` 处理。`apiKeyConcurrency` 是 API Key 级限流默认值；`apiKeys.<name>.limits.enabled/maxConcurrent/maxQueue/queueWaitSeconds` 是单 Key 覆盖，其中 `limits.enabled` 优先级高于全局 `apiKeyConcurrency.enabled`。默认单 Key 5 并发、50 队列、最长等待 1800 秒；队列满、等待超时或客户端断开时请求会从队列移除并返回/结束。
 
-排队期间，限流器会读取 ASGI `receive` 以尽早发现客户端断开，并把期间读到的 `http.request` 事件完整回放给下游。`defaultMaxRequestBodyBytes` 和 `defaultMaxRequestBodyEvents` 是排队与非排队请求一致使用的单请求总量限制，超限返回 413；图片编辑端点会按 `images.maxInputImageBytes`、multipart/JSON（data URL 的 base64 膨胀）、标准多图与 mask 合同自动提高总 body 上限，保证合法的 20 MiB 单图不会被通用 8 MiB 默认值误拒绝。`defaultMaxQueuedBodyBytesPerKey` 和 `maxQueuedBodyBytes` 分别限制单 Key 与全进程保留的请求体估算内存（正文加每事件固定开销），达到聚合上限时返回 429 并带 `Retry-After`；旧配置名 `maxQueuedBodyBytesTotal` 仅在没有公开键 `maxQueuedBodyBytes` 时作为兼容回退。请求获得并发槽位、缓存事件回放完毕后，后续 body 由下游直接读取；multipart 继续由 Starlette 使用 spool 文件解析，取消、超时与响应结束都会释放队列保留内存。
+排队期间，限流器会读取 ASGI `receive` 以尽早发现客户端断开，并把期间读到的 `http.request` 事件按原边界完整回放给下游。`defaultMaxRequestBodyBytes` 和 `defaultMaxRequestBodyEvents` 是排队与非排队请求一致使用的单请求总量限制，超限返回 413；图片编辑端点会按 `images.maxInputImageBytes`、multipart/JSON（data URL 的 base64 膨胀）、标准多图与 mask 合同自动提高总 body 上限，保证合法图片请求不会被通用 8 MiB 默认值误拒绝。
+
+待回放 body 不会全部常驻内存：单请求累计正文超过 `queuedBodySpoolThresholdBytes`（默认 1 MiB）时，已缓存和后续正文会迁移到 `tempfile.SpooledTemporaryFile` 的磁盘后端。`queuedBodySpoolDirectory` 为空时使用数据目录下的 `queued-body-spool/`，也可配置绝对路径或相对数据目录的路径。`defaultMaxQueuedBodyBytesPerKey` / `maxQueuedBodyBytes` 继续限制单 Key / 全进程的内存正文与 ASGI 事件开销；`defaultMaxQueuedBodySpoolBytesPerKey` / `maxQueuedBodySpoolBytes` 独立限制临时磁盘，单 Key 还可用 `limits.maxQueuedBodySpoolBytes` 覆盖。任一聚合资源达到上限均返回 429 并带 `Retry-After`；旧配置名 `maxQueuedBodyBytesTotal` 仅在没有公开键 `maxQueuedBodyBytes` 时作为兼容回退。请求获得并发槽位、缓存事件回放完毕后，后续 body 由下游直接读取；成功、异常、等待超时、任务取消、客户端断开、热禁用及 FIFO handoff 都会归零 accounting，并关闭临时对象（Linux 匿名临时 inode、Windows 删除即关闭语义均由标准库处理）。
 
 ## 2.2 字段语义详解
 

--- a/server.py
+++ b/server.py
@@ -274,6 +274,7 @@ async def lifespan(app: FastAPI):
         for t in _background_tasks:
             t.cancel()
         await asyncio.gather(*_background_tasks, return_exceptions=True)
+        await apikey_limiter.shutdown_spooling()
         tgbot.stop()
         await upstream.close_client()
 
@@ -338,6 +339,24 @@ def _request_body_limit_error_response(
     return resp
 
 
+def _queued_body_spool_error_response(
+    path: str, exc: apikey_limiter.QueuedBodySpoolError,
+):
+    """Return a retryable service error when bounded spool I/O is unavailable."""
+    message = str(exc) or "queued request body spool is unavailable"
+    if path == "/v1/messages":
+        resp = errors.json_error_response(
+            503, errors.ErrType.OVERLOADED, message, code="queued_body_spool_unavailable",
+        )
+    else:
+        resp = errors.json_error_openai(
+            503, errors.ErrTypeOpenAI.SERVER, message,
+            code="queued_body_spool_unavailable",
+        )
+    resp.headers["Retry-After"] = "1"
+    return resp
+
+
 def _find_request_body_limit_error(exc: BaseException) -> apikey_limiter.RequestBodyTooLarge | None:
     """Unwrap Starlette/AnyIO task-group errors without version-specific APIs."""
     if isinstance(exc, apikey_limiter.RequestBodyTooLarge):
@@ -354,6 +373,27 @@ def _find_request_body_limit_error(exc: BaseException) -> apikey_limiter.Request
     context = getattr(exc, "__context__", None)
     if context is not None and context is not exc:
         return _find_request_body_limit_error(context)
+    return None
+
+
+def _find_queued_body_spool_error(
+    exc: BaseException,
+) -> apikey_limiter.QueuedBodySpoolError | None:
+    """Unwrap task-group errors containing a spool failure."""
+    if isinstance(exc, apikey_limiter.QueuedBodySpoolError):
+        return exc
+    for nested in getattr(exc, "exceptions", ()) or ():
+        found = _find_queued_body_spool_error(nested)
+        if found is not None:
+            return found
+    cause = getattr(exc, "__cause__", None)
+    if cause is not None and cause is not exc:
+        found = _find_queued_body_spool_error(cause)
+        if found is not None:
+            return found
+    context = getattr(exc, "__context__", None)
+    if context is not None and context is not exc:
+        return _find_queued_body_spool_error(context)
     return None
 
 
@@ -386,6 +426,9 @@ async def _drain_http_middleware(request: Request, call_next):
                 except apikey_limiter.RequestBodyTooLarge as exc:
                     await lease.aclose()
                     return _request_body_limit_error_response(path, exc)
+                except apikey_limiter.QueuedBodySpoolError as exc:
+                    await lease.aclose()
+                    return _queued_body_spool_error_response(path, exc)
                 except apikey_limiter.ApiKeyLimitError as exc:
                     await lease.aclose()
                     return _api_key_limit_error_response(path, exc)
@@ -395,6 +438,11 @@ async def _drain_http_middleware(request: Request, call_next):
             await key_lease.release()
         await lease.aclose()
         return _request_body_limit_error_response(path, exc)
+    except apikey_limiter.QueuedBodySpoolError as exc:
+        if key_lease is not None:
+            await key_lease.release()
+        await lease.aclose()
+        return _queued_body_spool_error_response(path, exc)
     except BaseException as exc:
         if key_lease is not None:
             await key_lease.release()
@@ -402,6 +450,9 @@ async def _drain_http_middleware(request: Request, call_next):
         body_limit_error = _find_request_body_limit_error(exc)
         if body_limit_error is not None:
             return _request_body_limit_error_response(path, body_limit_error)
+        spool_error = _find_queued_body_spool_error(exc)
+        if spool_error is not None:
+            return _queued_body_spool_error_response(path, spool_error)
         raise
 
     if key_lease is not None:

--- a/server.py
+++ b/server.py
@@ -313,6 +313,50 @@ def _api_key_limit_error_response(path: str, exc: apikey_limiter.ApiKeyLimitErro
     return resp
 
 
+def _request_body_limit_error_response(
+    path: str, exc: apikey_limiter.RequestBodyTooLarge,
+):
+    """Map per-request limits to 413 and shared queue pressure to 429."""
+    aggregate_pressure = exc.reason in {"key_aggregate", "process_aggregate"}
+    status = 429 if aggregate_pressure else 413
+    if path == "/v1/messages":
+        resp = errors.json_error_response(
+            status,
+            errors.ErrType.RATE_LIMIT if aggregate_pressure else errors.ErrType.REQUEST_TOO_LARGE,
+            str(exc),
+            code="queued_body_capacity" if aggregate_pressure else "request_too_large",
+        )
+    else:
+        resp = errors.json_error_openai(
+            status,
+            errors.ErrTypeOpenAI.RATE_LIMIT if aggregate_pressure else errors.ErrTypeOpenAI.INVALID_REQUEST,
+            str(exc),
+            code="queued_body_capacity" if aggregate_pressure else "request_too_large",
+        )
+    if aggregate_pressure:
+        resp.headers["Retry-After"] = "1"
+    return resp
+
+
+def _find_request_body_limit_error(exc: BaseException) -> apikey_limiter.RequestBodyTooLarge | None:
+    """Unwrap Starlette/AnyIO task-group errors without version-specific APIs."""
+    if isinstance(exc, apikey_limiter.RequestBodyTooLarge):
+        return exc
+    for nested in getattr(exc, "exceptions", ()) or ():
+        found = _find_request_body_limit_error(nested)
+        if found is not None:
+            return found
+    cause = getattr(exc, "__cause__", None)
+    if cause is not None and cause is not exc:
+        found = _find_request_body_limit_error(cause)
+        if found is not None:
+            return found
+    context = getattr(exc, "__context__", None)
+    if context is not None and context is not exc:
+        return _find_request_body_limit_error(context)
+    return None
+
+
 @app.middleware("http")
 async def _drain_http_middleware(request: Request, call_next):
     """Reject new work while draining and keep active bodies counted.
@@ -341,27 +385,23 @@ async def _drain_http_middleware(request: Request, call_next):
                     key_lease = await apikey_limiter.acquire(key_name, request)
                 except apikey_limiter.RequestBodyTooLarge as exc:
                     await lease.aclose()
-                    message = str(exc)
-                    if path == "/v1/messages":
-                        return errors.json_error_response(
-                            413,
-                            errors.ErrType.REQUEST_TOO_LARGE,
-                            message,
-                        )
-                    return errors.json_error_openai(
-                        413,
-                        errors.ErrTypeOpenAI.INVALID_REQUEST,
-                        message,
-                        code="request_too_large",
-                    )
+                    return _request_body_limit_error_response(path, exc)
                 except apikey_limiter.ApiKeyLimitError as exc:
                     await lease.aclose()
                     return _api_key_limit_error_response(path, exc)
         response = await call_next(request)
-    except BaseException:
+    except apikey_limiter.RequestBodyTooLarge as exc:
         if key_lease is not None:
             await key_lease.release()
         await lease.aclose()
+        return _request_body_limit_error_response(path, exc)
+    except BaseException as exc:
+        if key_lease is not None:
+            await key_lease.release()
+        await lease.aclose()
+        body_limit_error = _find_request_body_limit_error(exc)
+        if body_limit_error is not None:
+            return _request_body_limit_error_response(path, body_limit_error)
         raise
 
     if key_lease is not None:

--- a/server.py
+++ b/server.py
@@ -339,6 +339,21 @@ async def _drain_http_middleware(request: Request, call_next):
             if not err and key_name:
                 try:
                     key_lease = await apikey_limiter.acquire(key_name, request)
+                except apikey_limiter.RequestBodyTooLarge as exc:
+                    await lease.aclose()
+                    message = str(exc)
+                    if path == "/v1/messages":
+                        return errors.json_error_response(
+                            413,
+                            errors.ErrType.REQUEST_TOO_LARGE,
+                            message,
+                        )
+                    return errors.json_error_openai(
+                        413,
+                        errors.ErrTypeOpenAI.INVALID_REQUEST,
+                        message,
+                        code="request_too_large",
+                    )
                 except apikey_limiter.ApiKeyLimitError as exc:
                     await lease.aclose()
                     return _api_key_limit_error_response(path, exc)

--- a/src/apikey_limiter.py
+++ b/src/apikey_limiter.py
@@ -8,10 +8,13 @@
   apiKeyConcurrency.enabled/defaultMaxConcurrent/defaultMaxQueue/defaultQueueWaitSeconds
   apiKeyConcurrency.defaultMaxRequestBodyBytes/defaultMaxRequestBodyEvents
   apiKeyConcurrency.defaultMaxQueuedBodyBytesPerKey/maxQueuedBodyBytes
+  apiKeyConcurrency.queuedBodySpoolThresholdBytes/queuedBodySpoolDirectory
+  apiKeyConcurrency.defaultMaxQueuedBodySpoolBytesPerKey/maxQueuedBodySpoolBytes
   (legacy maxQueuedBodyBytesTotal is accepted only as a fallback)
   apiKeys.<name>.limits may override the corresponding per-key/body defaults with
   enabled/maxConcurrent/maxQueue/queueWaitSeconds and
-  maxRequestBodyBytes/maxRequestBodyEvents/maxQueuedBodyBytes.
+  maxRequestBodyBytes/maxRequestBodyEvents/maxQueuedBodyBytes/
+  maxQueuedBodySpoolBytes.
 
 单 Key 的 limits.enabled 优先级高于全局 enabled；其它 limits 字段缺失 / null 时继承全局默认。
 """
@@ -19,9 +22,14 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import stat
+import tempfile
 import time
+import weakref
 from collections import deque
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Optional
 
 from fastapi import Request
@@ -48,6 +56,10 @@ class ResolvedLimits:
     max_request_body_events: int
     max_queued_body_bytes: int
     max_queued_body_bytes_total: int
+    queued_body_spool_threshold_bytes: int
+    max_queued_body_spool_bytes: int
+    max_queued_body_spool_bytes_total: int
+    queued_body_spool_directory: str
     enabled_source: str = "global"
     max_concurrent_source: str = "global"
     max_queue_source: str = "global"
@@ -83,6 +95,9 @@ DEFAULT_MAX_REQUEST_BODY_BYTES = 16 * 1024 * 1024
 DEFAULT_MAX_REQUEST_BODY_EVENTS = 1024
 DEFAULT_MAX_QUEUED_BODY_BYTES_PER_KEY = 32 * 1024 * 1024
 DEFAULT_MAX_QUEUED_BODY_BYTES_TOTAL = 128 * 1024 * 1024
+DEFAULT_QUEUED_BODY_SPOOL_THRESHOLD_BYTES = 1024 * 1024
+DEFAULT_MAX_QUEUED_BODY_SPOOL_BYTES_PER_KEY = 512 * 1024 * 1024
+DEFAULT_MAX_QUEUED_BODY_SPOOL_BYTES_TOTAL = 2 * 1024 * 1024 * 1024
 # Aggregate budgets include a conservative estimate for each retained ASGI dict.
 QUEUED_BODY_EVENT_OVERHEAD_BYTES = 1024
 
@@ -100,6 +115,9 @@ _IMAGE_BODY_ENVELOPE_BYTES = 1024 * 1024
 _queued_body_lock = asyncio.Lock()
 _queued_body_bytes_by_key: dict[str, int] = {}
 _queued_body_bytes_total = 0
+_queued_body_spool_bytes_by_key: dict[str, int] = {}
+_queued_body_spool_bytes_total = 0
+_active_body_guards: weakref.WeakSet[_BodyPreservingReceive] = weakref.WeakSet()
 
 
 class RequestBodyTooLarge(Exception):
@@ -124,6 +142,20 @@ class RequestBodyTooLarge(Exception):
         else:
             message = f"request body exceeds {self.max_bytes} bytes"
         super().__init__(message)
+
+
+class QueuedBodySpoolError(Exception):
+    """A queued request body could not be safely spooled."""
+
+
+@dataclass
+class _BufferedBodyEvent:
+    message_without_body: Message
+    had_body: bool
+    offset: int
+    body_bytes: int
+    memory_charge: int
+    spool_charge: int
 
 
 def _request_body_max_bytes(request: Request, limits: ResolvedLimits) -> int:
@@ -176,10 +208,15 @@ class _BodyPreservingReceive:
         self._raw_receive: Receive = request._receive
         self._key_name = key_name
         self._limits = limits
-        self._buffer: deque[tuple[Message, int]] = deque()
+        self._buffer: deque[_BufferedBodyEvent] = deque()
         self._buffered_bytes = 0
         self._buffered_events = 0
         self._reserved_bytes = 0
+        self._reserved_spool_bytes = 0
+        self._spool_size = 0
+        self._spool: Any | None = None
+        self._spooled_to_disk = False
+        self._guard_lock = asyncio.Lock()
         self._abandoned = False
 
     def validate_content_length(self) -> None:
@@ -213,17 +250,24 @@ class _BodyPreservingReceive:
 
     async def receive(self) -> Message:
         """Release accounting as each retained event is replayed, then go live."""
-        global _queued_body_bytes_total
-        async with _queued_body_lock:
+        async with self._guard_lock:
             if self._buffer:
-                message, charge = self._buffer.popleft()
-                self._reserved_bytes -= charge
-                _queued_body_bytes_total -= charge
-                key_bytes = _queued_body_bytes_by_key.get(self._key_name, 0) - charge
-                if key_bytes > 0:
-                    _queued_body_bytes_by_key[self._key_name] = key_bytes
-                else:
-                    _queued_body_bytes_by_key.pop(self._key_name, None)
+                event = self._buffer.popleft()
+                try:
+                    body = await self._read_spooled_body(event)
+                except Exception as exc:
+                    await self._release_event_accounting(event)
+                    if not self._buffer:
+                        await self._close_spool()
+                    raise QueuedBodySpoolError(
+                        f"failed to replay queued request body: {exc}"
+                    ) from exc
+                await self._release_event_accounting(event)
+                message = dict(event.message_without_body)
+                if event.had_body:
+                    message["body"] = body
+                if not self._buffer:
+                    await self._close_spool()
                 return message
         message = await self._raw_receive()
         if message.get("type") == "http.request":
@@ -233,32 +277,254 @@ class _BodyPreservingReceive:
         return message
 
     async def _reserve(self, message: Message) -> None:
-        global _queued_body_bytes_total
         body_bytes = len(message.get("body", b""))
-        charge = body_bytes + QUEUED_BODY_EVENT_OVERHEAD_BYTES
         # Body events may arrive throughout a long queue wait. Resolve the
         # effective budgets for every event so config hot reloads take effect.
         limits = _resolve_limits(self._key_name)
-        async with _queued_body_lock:
+        async with self._guard_lock:
             if self._abandoned:
                 return
             self._limits = limits
             self._account_body_event(message, limits)
-            key_bytes = _queued_body_bytes_by_key.get(self._key_name, 0)
-            if key_bytes + charge > limits.max_queued_body_bytes:
+            offset = self._spool_size
+            next_spool_size = offset + body_bytes
+            move_to_disk = (
+                self._spooled_to_disk
+                or next_spool_size > limits.queued_body_spool_threshold_bytes
+            )
+            existing_body_shift = (
+                self._spool_size if move_to_disk and not self._spooled_to_disk else 0
+            )
+            memory_charge = QUEUED_BODY_EVENT_OVERHEAD_BYTES
+            spool_charge = body_bytes if move_to_disk else 0
+            if not move_to_disk:
+                memory_charge += body_bytes
+
+            await self._reserve_accounting(
+                limits,
+                memory_delta=memory_charge - existing_body_shift,
+                spool_delta=spool_charge + existing_body_shift,
+            )
+            if existing_body_shift:
+                for buffered in self._buffer:
+                    buffered.memory_charge -= buffered.body_bytes
+                    buffered.spool_charge += buffered.body_bytes
+                self._reserved_bytes -= existing_body_shift
+                self._reserved_spool_bytes += existing_body_shift
+            self._reserved_bytes += memory_charge
+            self._reserved_spool_bytes += spool_charge
+            self._spool_size = next_spool_size
+            self._spooled_to_disk = move_to_disk
+
+            try:
+                if body_bytes:
+                    await self._write_spooled_body(
+                        message.get("body", b""),
+                        offset=offset,
+                        limits=limits,
+                        rollover=move_to_disk,
+                    )
+            except Exception as exc:
+                raise QueuedBodySpoolError(
+                    f"failed to spool queued request body: {exc}"
+                ) from exc
+
+            metadata = dict(message)
+            had_body = "body" in metadata
+            metadata.pop("body", None)
+            self._buffer.append(_BufferedBodyEvent(
+                message_without_body=metadata,
+                had_body=had_body,
+                offset=offset,
+                body_bytes=body_bytes,
+                memory_charge=memory_charge,
+                spool_charge=spool_charge,
+            ))
+
+    async def _reserve_accounting(
+        self,
+        limits: ResolvedLimits,
+        *,
+        memory_delta: int,
+        spool_delta: int,
+    ) -> None:
+        global _queued_body_bytes_total, _queued_body_spool_bytes_total
+        request_max = _request_body_max_bytes(self._request, limits)
+        one_request_memory = (
+            min(request_max, limits.queued_body_spool_threshold_bytes)
+            + limits.max_request_body_events * QUEUED_BODY_EVENT_OVERHEAD_BYTES
+        )
+        key_memory_budget = limits.max_queued_body_bytes
+        if key_memory_budget == DEFAULT_MAX_QUEUED_BODY_BYTES_PER_KEY:
+            key_memory_budget = max(key_memory_budget, one_request_memory)
+        process_memory_budget = limits.max_queued_body_bytes_total
+        if process_memory_budget == DEFAULT_MAX_QUEUED_BODY_BYTES_TOTAL:
+            process_memory_budget = max(process_memory_budget, one_request_memory)
+        key_spool_budget = limits.max_queued_body_spool_bytes
+        if key_spool_budget == DEFAULT_MAX_QUEUED_BODY_SPOOL_BYTES_PER_KEY:
+            key_spool_budget = max(key_spool_budget, request_max)
+        process_spool_budget = limits.max_queued_body_spool_bytes_total
+        if process_spool_budget == DEFAULT_MAX_QUEUED_BODY_SPOOL_BYTES_TOTAL:
+            process_spool_budget = max(process_spool_budget, request_max)
+        async with _queued_body_lock:
+            key_memory = _queued_body_bytes_by_key.get(self._key_name, 0)
+            key_spool = _queued_body_spool_bytes_by_key.get(self._key_name, 0)
+            if key_memory + memory_delta > key_memory_budget:
                 raise RequestBodyTooLarge(
-                    max_bytes=limits.max_queued_body_bytes,
+                    max_bytes=key_memory_budget,
                     reason="key_aggregate",
                 )
-            if _queued_body_bytes_total + charge > limits.max_queued_body_bytes_total:
+            if _queued_body_bytes_total + memory_delta > process_memory_budget:
                 raise RequestBodyTooLarge(
-                    max_bytes=limits.max_queued_body_bytes_total,
+                    max_bytes=process_memory_budget,
                     reason="process_aggregate",
                 )
-            self._buffer.append((message, charge))
-            self._reserved_bytes += charge
-            _queued_body_bytes_by_key[self._key_name] = key_bytes + charge
-            _queued_body_bytes_total += charge
+            if key_spool + spool_delta > key_spool_budget:
+                raise RequestBodyTooLarge(
+                    max_bytes=key_spool_budget,
+                    reason="key_aggregate",
+                )
+            if _queued_body_spool_bytes_total + spool_delta > process_spool_budget:
+                raise RequestBodyTooLarge(
+                    max_bytes=process_spool_budget,
+                    reason="process_aggregate",
+                )
+            _set_key_accounting(
+                _queued_body_bytes_by_key,
+                self._key_name,
+                key_memory + memory_delta,
+            )
+            _set_key_accounting(
+                _queued_body_spool_bytes_by_key,
+                self._key_name,
+                key_spool + spool_delta,
+            )
+            _queued_body_bytes_total += memory_delta
+            _queued_body_spool_bytes_total += spool_delta
+
+    def _open_spool(self, limits: ResolvedLimits) -> Any:
+        raw_directory = str(limits.queued_body_spool_directory or "").strip()
+        directory = Path(raw_directory) if raw_directory else Path(config.DATA_DIR) / "queued-body-spool"
+        if not directory.is_absolute():
+            directory = Path(config.DATA_DIR) / directory
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        directory_stat = directory.lstat()
+        if stat.S_ISLNK(directory_stat.st_mode) or not stat.S_ISDIR(directory_stat.st_mode):
+            raise OSError("queued body spool path is not a real directory")
+        if directory_stat.st_uid != os.geteuid():
+            raise OSError("queued body spool directory has an unsafe owner")
+        os.chmod(directory, 0o700)
+        return tempfile.SpooledTemporaryFile(
+            max_size=max(0, limits.queued_body_spool_threshold_bytes),
+            mode="w+b",
+            dir=os.fspath(directory),
+            prefix="parrot-queued-body-",
+        )
+
+    async def _write_spooled_body(
+        self,
+        body: bytes,
+        *,
+        offset: int,
+        limits: ResolvedLimits,
+        rollover: bool,
+    ) -> None:
+        if self._spool is None:
+            self._spool = self._open_spool(limits)
+
+        def _write() -> None:
+            assert self._spool is not None
+            if rollover:
+                self._spool.rollover()
+            self._spool.seek(offset)
+            written = self._spool.write(body)
+            if written != len(body):
+                raise OSError(f"short spool write: {written}/{len(body)}")
+            self._spool.flush()
+
+        if rollover:
+            await self._run_blocking_io(_write)
+        else:
+            _write()
+
+    async def _read_spooled_body(self, event: _BufferedBodyEvent) -> bytes:
+        if event.body_bytes == 0:
+            return b""
+        if self._spool is None:
+            raise OSError("queued body spool is closed")
+
+        def _read() -> bytes:
+            assert self._spool is not None
+            self._spool.seek(event.offset)
+            body = self._spool.read(event.body_bytes)
+            if len(body) != event.body_bytes:
+                raise OSError(
+                    f"short spool read: {len(body)}/{event.body_bytes}"
+                )
+            return body
+
+        if self._spooled_to_disk:
+            return await self._run_blocking_io(_read)
+        return _read()
+
+    @staticmethod
+    async def _run_blocking_io(func):
+        """Let an in-flight fd operation finish before cancellation cleanup.
+
+        ``asyncio.to_thread`` cancellation only abandons the await; it cannot
+        stop the worker thread.  Waiting for that worker here prevents abandon()
+        from closing/reusing the descriptor while a read/write is still active.
+        """
+        task = asyncio.create_task(asyncio.to_thread(func))
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            await task
+            raise
+
+    async def _release_event_accounting(self, event: _BufferedBodyEvent) -> None:
+        global _queued_body_bytes_total
+        async with _queued_body_lock:
+            self._reserved_bytes -= event.memory_charge
+            _queued_body_bytes_total -= event.memory_charge
+            _set_key_accounting(
+                _queued_body_bytes_by_key,
+                self._key_name,
+                _queued_body_bytes_by_key.get(self._key_name, 0) - event.memory_charge,
+            )
+
+    async def _close_spool(self) -> None:
+        spool, self._spool = self._spool, None
+        close_error: Exception | None = None
+        try:
+            if spool is not None:
+                if self._spooled_to_disk:
+                    await self._run_blocking_io(spool.close)
+                else:
+                    spool.close()
+        except Exception as exc:
+            close_error = exc
+        finally:
+            # A rolled temporary file keeps its full allocation until close;
+            # releasing per-event disk accounting before this point would let
+            # physical usage exceed the configured process/key budget.
+            await self._release_spool_accounting()
+        if close_error is not None:
+            raise QueuedBodySpoolError(
+                f"failed to close queued request body spool: {close_error}"
+            ) from close_error
+
+    async def _release_spool_accounting(self) -> None:
+        global _queued_body_spool_bytes_total
+        async with _queued_body_lock:
+            spool_charge = self._reserved_spool_bytes
+            self._reserved_spool_bytes = 0
+            _queued_body_spool_bytes_total -= spool_charge
+            _set_key_accounting(
+                _queued_body_spool_bytes_by_key,
+                self._key_name,
+                _queued_body_spool_bytes_by_key.get(self._key_name, 0) - spool_charge,
+            )
 
     async def wait_for_disconnect(self) -> None:
         """Consume raw events while preserving every request-body event."""
@@ -282,19 +548,31 @@ class _BodyPreservingReceive:
     async def abandon(self) -> None:
         """Release all remaining reservations exactly once."""
         global _queued_body_bytes_total
-        async with _queued_body_lock:
+        async with self._guard_lock:
             if self._abandoned:
                 return
             self._abandoned = True
-            charge = self._reserved_bytes
+            memory_charge = self._reserved_bytes
             self._reserved_bytes = 0
             self._buffer.clear()
-            _queued_body_bytes_total -= charge
-            key_bytes = _queued_body_bytes_by_key.get(self._key_name, 0) - charge
-            if key_bytes > 0:
-                _queued_body_bytes_by_key[self._key_name] = key_bytes
-            else:
-                _queued_body_bytes_by_key.pop(self._key_name, None)
+            async with _queued_body_lock:
+                _queued_body_bytes_total -= memory_charge
+                _set_key_accounting(
+                    _queued_body_bytes_by_key,
+                    self._key_name,
+                    _queued_body_bytes_by_key.get(self._key_name, 0) - memory_charge,
+                )
+            try:
+                await self._close_spool()
+            finally:
+                _active_body_guards.discard(self)
+
+
+def _set_key_accounting(mapping: dict[str, int], key_name: str, value: int) -> None:
+    if value > 0:
+        mapping[key_name] = value
+    else:
+        mapping.pop(key_name, None)
 
 
 def _body_preserving_receive(
@@ -311,6 +589,7 @@ def _body_preserving_receive(
     # This is the only private Request hook used; see the class docstring.
     request._receive = guard.receive
     setattr(request, "_parrot_body_preserving_receive", guard)
+    _active_body_guards.add(guard)
     return guard
 
 
@@ -319,6 +598,16 @@ def _request_receive_guard(request: Request | None) -> _BodyPreservingReceive | 
         return None
     guard = getattr(request, "_parrot_body_preserving_receive", None)
     return guard if isinstance(guard, _BodyPreservingReceive) else None
+
+
+async def shutdown_spooling() -> None:
+    """Close and unaccount all queued body stores during application shutdown."""
+    guards = list(_active_body_guards)
+    if guards:
+        await asyncio.gather(
+            *(guard.abandon() for guard in guards),
+            return_exceptions=True,
+        )
 
 
 class ApiKeyLease:
@@ -407,6 +696,24 @@ def _resolve_limits(key_name: str) -> ResolvedLimits:
         DEFAULT_MAX_QUEUED_BODY_BYTES_TOTAL,
         minimum=1,
     )
+    queued_body_spool_threshold_bytes = _as_int(
+        global_cfg.get("queuedBodySpoolThresholdBytes"),
+        DEFAULT_QUEUED_BODY_SPOOL_THRESHOLD_BYTES,
+        minimum=0,
+    )
+    global_queued_body_spool_bytes = _as_int(
+        global_cfg.get("defaultMaxQueuedBodySpoolBytesPerKey"),
+        DEFAULT_MAX_QUEUED_BODY_SPOOL_BYTES_PER_KEY,
+        minimum=1,
+    )
+    max_queued_body_spool_bytes_total = _as_int(
+        global_cfg.get("maxQueuedBodySpoolBytes"),
+        DEFAULT_MAX_QUEUED_BODY_SPOOL_BYTES_TOTAL,
+        minimum=1,
+    )
+    queued_body_spool_directory = str(
+        global_cfg.get("queuedBodySpoolDirectory") or ""
+    ).strip()
 
     entry = (cfg.get("apiKeys") or {}).get(key_name)
     limits = entry.get("limits") if isinstance(entry, dict) else None
@@ -456,6 +763,11 @@ def _resolve_limits(key_name: str) -> ResolvedLimits:
         global_queued_body_bytes,
         minimum=1,
     )
+    max_queued_body_spool_bytes = _as_int(
+        limits.get("maxQueuedBodySpoolBytes"),
+        global_queued_body_spool_bytes,
+        minimum=1,
+    )
 
     return ResolvedLimits(
         enabled=enabled,
@@ -466,6 +778,10 @@ def _resolve_limits(key_name: str) -> ResolvedLimits:
         max_request_body_events=max_request_body_events,
         max_queued_body_bytes=max_queued_body_bytes,
         max_queued_body_bytes_total=max_queued_body_bytes_total,
+        queued_body_spool_threshold_bytes=queued_body_spool_threshold_bytes,
+        max_queued_body_spool_bytes=max_queued_body_spool_bytes,
+        max_queued_body_spool_bytes_total=max_queued_body_spool_bytes_total,
+        queued_body_spool_directory=queued_body_spool_directory,
         enabled_source=enabled_source,
         max_concurrent_source=max_source,
         max_queue_source=queue_source,
@@ -671,7 +987,7 @@ async def _wait_for_turn_or_abort(
             # A watcher cancelled by admission may have already consumed an
             # event whose reservation then exceeded a budget.  Do not hide it.
             for result in cleanup_results:
-                if isinstance(result, RequestBodyTooLarge):
+                if isinstance(result, (RequestBodyTooLarge, QueuedBodySpoolError)):
                     raise result
 
 
@@ -683,7 +999,7 @@ async def _wait_http_disconnect(
     guard = _body_preserving_receive(request, key_name, limits)
     try:
         await guard.wait_for_disconnect()
-    except RequestBodyTooLarge:
+    except (RequestBodyTooLarge, QueuedBodySpoolError):
         raise
     except Exception:
         # A closed/broken ASGI receive channel is equivalent to disconnect.

--- a/src/apikey_limiter.py
+++ b/src/apikey_limiter.py
@@ -7,7 +7,8 @@
 配置：
   apiKeyConcurrency.enabled/defaultMaxConcurrent/defaultMaxQueue/defaultQueueWaitSeconds
   apiKeyConcurrency.defaultMaxRequestBodyBytes/defaultMaxRequestBodyEvents
-  apiKeyConcurrency.defaultMaxQueuedBodyBytesPerKey/maxQueuedBodyBytesTotal
+  apiKeyConcurrency.defaultMaxQueuedBodyBytesPerKey/maxQueuedBodyBytes
+  (legacy maxQueuedBodyBytesTotal is accepted only as a fallback)
   apiKeys.<name>.limits may override the corresponding per-key/body defaults with
   enabled/maxConcurrent/maxQueue/queueWaitSeconds and
   maxRequestBodyBytes/maxRequestBodyEvents/maxQueuedBodyBytes.
@@ -85,13 +86,24 @@ DEFAULT_MAX_QUEUED_BODY_BYTES_TOTAL = 128 * 1024 * 1024
 # Aggregate budgets include a conservative estimate for each retained ASGI dict.
 QUEUED_BODY_EVENT_OVERHEAD_BYTES = 1024
 
+# OpenAI's image edit contract allows up to 16 input images plus one mask.  A
+# legal 20 MiB image is larger on the wire when carried as a JSON data URL, so
+# the generic API-body default cannot be used as the total-body cap for these
+# endpoints.  Multipart file parts are streamed by Starlette into spooled files
+# after admission; only queued events are retained here, under the aggregate
+# budgets below.
+_COMPAT_IMAGE_EDIT_PATHS = frozenset({"/v1/images/edits", "/images/edits"})
+_SINGLE_IMAGE_EDIT_PATHS = frozenset({"/v1/images/edit"})
+_OPENAI_MAX_EDIT_IMAGES = 16
+_IMAGE_BODY_ENVELOPE_BYTES = 1024 * 1024
+
 _queued_body_lock = asyncio.Lock()
 _queued_body_bytes_by_key: dict[str, int] = {}
 _queued_body_bytes_total = 0
 
 
 class RequestBodyTooLarge(Exception):
-    """A queued request exceeded a replay-buffer byte/event budget."""
+    """A request exceeded its total-body or queued aggregate budget."""
 
     def __init__(
         self,
@@ -104,14 +116,51 @@ class RequestBodyTooLarge(Exception):
         self.max_events = None if max_events is None else int(max_events)
         self.reason = reason
         if reason == "event_count":
-            message = f"queued request has more than {self.max_events} body events"
+            message = f"request has more than {self.max_events} body events"
         elif reason == "key_aggregate":
             message = f"API key queued-body budget exceeds {self.max_bytes} accounted bytes"
         elif reason == "process_aggregate":
             message = f"process queued-body budget exceeds {self.max_bytes} accounted bytes"
         else:
-            message = f"queued request body exceeds {self.max_bytes} bytes"
+            message = f"request body exceeds {self.max_bytes} bytes"
         super().__init__(message)
+
+
+def _request_body_max_bytes(request: Request, limits: ResolvedLimits) -> int:
+    """Resolve the total wire-body contract for this endpoint.
+
+    ``images.maxInputImageBytes`` limits decoded images.  JSON/data-URL bodies
+    need base64 expansion headroom, while multipart carries raw file bytes.  The
+    standard edits endpoint supports 16 images and a mask; the legacy edit
+    endpoint supports one image.  This is a total-body bound, not an in-memory
+    allocation target: normal multipart parsing remains spooled by Starlette.
+    """
+    generic_max = int(limits.max_request_body_bytes)
+    path = str(request.scope.get("path") or "")
+    if path not in _COMPAT_IMAGE_EDIT_PATHS and path not in _SINGLE_IMAGE_EDIT_PATHS:
+        return generic_max
+
+    cfg = config.get()
+    image_cfg = cfg.get("images") or {}
+    max_image_bytes = _as_int(
+        image_cfg.get("maxInputImageBytes"),
+        20 * 1024 * 1024,
+        minimum=1,
+    )
+    image_slots = (
+        _OPENAI_MAX_EDIT_IMAGES + 1
+        if path in _COMPAT_IMAGE_EDIT_PATHS
+        else 1
+    )
+    content_type = (request.headers.get("content-type") or "").lower()
+    if content_type.startswith("multipart/form-data"):
+        per_image_wire_bytes = max_image_bytes
+    else:
+        # Exact base64 ceiling plus a small per-value allowance for the data URL
+        # prefix, JSON quoting and separators.
+        per_image_wire_bytes = 4 * ((max_image_bytes + 2) // 3) + 256
+    endpoint_max = image_slots * per_image_wire_bytes + _IMAGE_BODY_ENVELOPE_BYTES
+    return max(generic_max, endpoint_max)
 
 
 class _BodyPreservingReceive:
@@ -123,6 +172,7 @@ class _BodyPreservingReceive:
     """
 
     def __init__(self, request: Request, key_name: str, limits: ResolvedLimits):
+        self._request = request
         self._raw_receive: Receive = request._receive
         self._key_name = key_name
         self._limits = limits
@@ -131,6 +181,35 @@ class _BodyPreservingReceive:
         self._buffered_events = 0
         self._reserved_bytes = 0
         self._abandoned = False
+
+    def validate_content_length(self) -> None:
+        raw = self._request.headers.get("content-length")
+        if raw is None:
+            return
+        try:
+            content_length = int(raw)
+        except (TypeError, ValueError):
+            return
+        limits = _resolve_limits(self._key_name)
+        max_bytes = _request_body_max_bytes(self._request, limits)
+        if content_length > max_bytes:
+            raise RequestBodyTooLarge(max_bytes=max_bytes)
+
+    def _account_body_event(self, message: Message, limits: ResolvedLimits) -> None:
+        body_bytes = len(message.get("body", b""))
+        next_body_bytes = self._buffered_bytes + body_bytes
+        next_events = self._buffered_events + 1
+        max_bytes = _request_body_max_bytes(self._request, limits)
+        if next_body_bytes > max_bytes:
+            raise RequestBodyTooLarge(max_bytes=max_bytes)
+        if next_events > limits.max_request_body_events:
+            raise RequestBodyTooLarge(
+                max_bytes=max_bytes,
+                max_events=limits.max_request_body_events,
+                reason="event_count",
+            )
+        self._buffered_bytes = next_body_bytes
+        self._buffered_events = next_events
 
     async def receive(self) -> Message:
         """Release accounting as each retained event is replayed, then go live."""
@@ -146,7 +225,12 @@ class _BodyPreservingReceive:
                 else:
                     _queued_body_bytes_by_key.pop(self._key_name, None)
                 return message
-        return await self._raw_receive()
+        message = await self._raw_receive()
+        if message.get("type") == "http.request":
+            limits = _resolve_limits(self._key_name)
+            self._limits = limits
+            self._account_body_event(message, limits)
+        return message
 
     async def _reserve(self, message: Message) -> None:
         global _queued_body_bytes_total
@@ -156,18 +240,11 @@ class _BodyPreservingReceive:
         # effective budgets for every event so config hot reloads take effect.
         limits = _resolve_limits(self._key_name)
         async with _queued_body_lock:
+            if self._abandoned:
+                return
             self._limits = limits
-            next_body_bytes = self._buffered_bytes + body_bytes
-            next_events = self._buffered_events + 1
+            self._account_body_event(message, limits)
             key_bytes = _queued_body_bytes_by_key.get(self._key_name, 0)
-            if next_body_bytes > limits.max_request_body_bytes:
-                raise RequestBodyTooLarge(max_bytes=limits.max_request_body_bytes)
-            if next_events > limits.max_request_body_events:
-                raise RequestBodyTooLarge(
-                    max_bytes=limits.max_request_body_bytes,
-                    max_events=limits.max_request_body_events,
-                    reason="event_count",
-                )
             if key_bytes + charge > limits.max_queued_body_bytes:
                 raise RequestBodyTooLarge(
                     max_bytes=limits.max_queued_body_bytes,
@@ -178,11 +255,7 @@ class _BodyPreservingReceive:
                     max_bytes=limits.max_queued_body_bytes_total,
                     reason="process_aggregate",
                 )
-            if self._abandoned:
-                return
             self._buffer.append((message, charge))
-            self._buffered_bytes = next_body_bytes
-            self._buffered_events = next_events
             self._reserved_bytes += charge
             _queued_body_bytes_by_key[self._key_name] = key_bytes + charge
             _queued_body_bytes_total += charge
@@ -231,8 +304,10 @@ def _body_preserving_receive(
 ) -> _BodyPreservingReceive:
     guard = getattr(request, "_parrot_body_preserving_receive", None)
     if isinstance(guard, _BodyPreservingReceive):
+        guard.validate_content_length()
         return guard
     guard = _BodyPreservingReceive(request, key_name, limits)
+    guard.validate_content_length()
     # This is the only private Request hook used; see the class docstring.
     request._receive = guard.receive
     setattr(request, "_parrot_body_preserving_receive", guard)
@@ -322,8 +397,13 @@ def _resolve_limits(key_name: str) -> ResolvedLimits:
         DEFAULT_MAX_QUEUED_BODY_BYTES_PER_KEY,
         minimum=1,
     )
+    process_queued_body_budget = global_cfg.get("maxQueuedBodyBytes")
+    if process_queued_body_budget is None:
+        # Backward compatibility for the pre-review private spelling.  The
+        # documented/public key above always wins when both are present.
+        process_queued_body_budget = global_cfg.get("maxQueuedBodyBytesTotal")
     max_queued_body_bytes_total = _as_int(
-        global_cfg.get("maxQueuedBodyBytesTotal"),
+        process_queued_body_budget,
         DEFAULT_MAX_QUEUED_BODY_BYTES_TOTAL,
         minimum=1,
     )
@@ -432,9 +512,15 @@ async def acquire(key_name: str | None, request: Request | None = None) -> ApiKe
         _wake_eligible_waiters_locked(slot)
         if not limits.enabled:
             return ApiKeyLease(key, None, limits, noop=True)
+        replay_guard = (
+            _body_preserving_receive(request, key, limits)
+            if request is not None else None
+        )
         if limits.unlimited or slot.in_flight < limits.max_concurrent:
             slot.in_flight += 1
-            return ApiKeyLease(key, slot, limits, queue_wait_ms=0)
+            return ApiKeyLease(
+                key, slot, limits, queue_wait_ms=0, replay_guard=replay_guard
+            )
 
         if limits.max_queue <= 0 or len(slot.waiters) >= limits.max_queue:
             raise _queue_full_error(key, slot)

--- a/src/apikey_limiter.py
+++ b/src/apikey_limiter.py
@@ -6,7 +6,11 @@
 
 配置：
   apiKeyConcurrency.enabled/defaultMaxConcurrent/defaultMaxQueue/defaultQueueWaitSeconds
-  apiKeys.<name>.limits.enabled/maxConcurrent/maxQueue/queueWaitSeconds
+  apiKeyConcurrency.defaultMaxRequestBodyBytes/defaultMaxRequestBodyEvents
+  apiKeyConcurrency.defaultMaxQueuedBodyBytesPerKey/maxQueuedBodyBytesTotal
+  apiKeys.<name>.limits may override the corresponding per-key/body defaults with
+  enabled/maxConcurrent/maxQueue/queueWaitSeconds and
+  maxRequestBodyBytes/maxRequestBodyEvents/maxQueuedBodyBytes.
 
 单 Key 的 limits.enabled 优先级高于全局 enabled；其它 limits 字段缺失 / null 时继承全局默认。
 """
@@ -15,11 +19,13 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
 from fastapi import Request
 from starlette.responses import Response
+from starlette.types import Message, Receive
 
 from . import config
 
@@ -28,6 +34,7 @@ from . import config
 class Waiter:
     future: asyncio.Future
     enqueued_at: float
+    capacity_reserved: bool = False
 
 
 @dataclass
@@ -36,6 +43,10 @@ class ResolvedLimits:
     max_concurrent: int
     max_queue: int
     queue_wait_seconds: int
+    max_request_body_bytes: int
+    max_request_body_events: int
+    max_queued_body_bytes: int
+    max_queued_body_bytes_total: int
     enabled_source: str = "global"
     max_concurrent_source: str = "global"
     max_queue_source: str = "global"
@@ -67,26 +78,208 @@ class ApiKeyLimitError(Exception):
         self.headers = headers or {}
 
 
+DEFAULT_MAX_REQUEST_BODY_BYTES = 16 * 1024 * 1024
+DEFAULT_MAX_REQUEST_BODY_EVENTS = 1024
+DEFAULT_MAX_QUEUED_BODY_BYTES_PER_KEY = 32 * 1024 * 1024
+DEFAULT_MAX_QUEUED_BODY_BYTES_TOTAL = 128 * 1024 * 1024
+# Aggregate budgets include a conservative estimate for each retained ASGI dict.
+QUEUED_BODY_EVENT_OVERHEAD_BYTES = 1024
+
+_queued_body_lock = asyncio.Lock()
+_queued_body_bytes_by_key: dict[str, int] = {}
+_queued_body_bytes_total = 0
+
+
+class RequestBodyTooLarge(Exception):
+    """A queued request exceeded a replay-buffer byte/event budget."""
+
+    def __init__(
+        self,
+        *,
+        max_bytes: int,
+        reason: str = "request_bytes",
+        max_events: int | None = None,
+    ):
+        self.max_bytes = int(max_bytes)
+        self.max_events = None if max_events is None else int(max_events)
+        self.reason = reason
+        if reason == "event_count":
+            message = f"queued request has more than {self.max_events} body events"
+        elif reason == "key_aggregate":
+            message = f"API key queued-body budget exceeds {self.max_bytes} accounted bytes"
+        elif reason == "process_aggregate":
+            message = f"process queued-body budget exceeds {self.max_bytes} accounted bytes"
+        else:
+            message = f"queued request body exceeds {self.max_bytes} bytes"
+        super().__init__(message)
+
+
+class _BodyPreservingReceive:
+    """Replay body events consumed while a queued request is monitored.
+
+    Starlette exposes no public receive-interposition hook.  This class therefore
+    reads and replaces ``Request._receive`` exactly once, solely to retain unread
+    ``http.request`` messages; all buffered messages are replayed byte-for-byte.
+    """
+
+    def __init__(self, request: Request, key_name: str, limits: ResolvedLimits):
+        self._raw_receive: Receive = request._receive
+        self._key_name = key_name
+        self._limits = limits
+        self._buffer: deque[tuple[Message, int]] = deque()
+        self._buffered_bytes = 0
+        self._buffered_events = 0
+        self._reserved_bytes = 0
+        self._abandoned = False
+
+    async def receive(self) -> Message:
+        """Release accounting as each retained event is replayed, then go live."""
+        global _queued_body_bytes_total
+        async with _queued_body_lock:
+            if self._buffer:
+                message, charge = self._buffer.popleft()
+                self._reserved_bytes -= charge
+                _queued_body_bytes_total -= charge
+                key_bytes = _queued_body_bytes_by_key.get(self._key_name, 0) - charge
+                if key_bytes > 0:
+                    _queued_body_bytes_by_key[self._key_name] = key_bytes
+                else:
+                    _queued_body_bytes_by_key.pop(self._key_name, None)
+                return message
+        return await self._raw_receive()
+
+    async def _reserve(self, message: Message) -> None:
+        global _queued_body_bytes_total
+        body_bytes = len(message.get("body", b""))
+        charge = body_bytes + QUEUED_BODY_EVENT_OVERHEAD_BYTES
+        # Body events may arrive throughout a long queue wait. Resolve the
+        # effective budgets for every event so config hot reloads take effect.
+        limits = _resolve_limits(self._key_name)
+        async with _queued_body_lock:
+            self._limits = limits
+            next_body_bytes = self._buffered_bytes + body_bytes
+            next_events = self._buffered_events + 1
+            key_bytes = _queued_body_bytes_by_key.get(self._key_name, 0)
+            if next_body_bytes > limits.max_request_body_bytes:
+                raise RequestBodyTooLarge(max_bytes=limits.max_request_body_bytes)
+            if next_events > limits.max_request_body_events:
+                raise RequestBodyTooLarge(
+                    max_bytes=limits.max_request_body_bytes,
+                    max_events=limits.max_request_body_events,
+                    reason="event_count",
+                )
+            if key_bytes + charge > limits.max_queued_body_bytes:
+                raise RequestBodyTooLarge(
+                    max_bytes=limits.max_queued_body_bytes,
+                    reason="key_aggregate",
+                )
+            if _queued_body_bytes_total + charge > limits.max_queued_body_bytes_total:
+                raise RequestBodyTooLarge(
+                    max_bytes=limits.max_queued_body_bytes_total,
+                    reason="process_aggregate",
+                )
+            if self._abandoned:
+                return
+            self._buffer.append((message, charge))
+            self._buffered_bytes = next_body_bytes
+            self._buffered_events = next_events
+            self._reserved_bytes += charge
+            _queued_body_bytes_by_key[self._key_name] = key_bytes + charge
+            _queued_body_bytes_total += charge
+
+    async def wait_for_disconnect(self) -> None:
+        """Consume raw events while preserving every request-body event."""
+        while True:
+            message = await self._raw_receive()
+            message_type = message.get("type")
+            if message_type == "http.disconnect":
+                return
+            if message_type != "http.request":
+                continue
+            # Once receive() yielded an event, finish its reservation even if
+            # admission concurrently cancels this watcher; otherwise that body
+            # chunk would be consumed without being replayable.
+            reserve_task = asyncio.create_task(self._reserve(message))
+            try:
+                await asyncio.shield(reserve_task)
+            except asyncio.CancelledError:
+                await reserve_task
+                raise
+
+    async def abandon(self) -> None:
+        """Release all remaining reservations exactly once."""
+        global _queued_body_bytes_total
+        async with _queued_body_lock:
+            if self._abandoned:
+                return
+            self._abandoned = True
+            charge = self._reserved_bytes
+            self._reserved_bytes = 0
+            self._buffer.clear()
+            _queued_body_bytes_total -= charge
+            key_bytes = _queued_body_bytes_by_key.get(self._key_name, 0) - charge
+            if key_bytes > 0:
+                _queued_body_bytes_by_key[self._key_name] = key_bytes
+            else:
+                _queued_body_bytes_by_key.pop(self._key_name, None)
+
+
+def _body_preserving_receive(
+    request: Request,
+    key_name: str,
+    limits: ResolvedLimits,
+) -> _BodyPreservingReceive:
+    guard = getattr(request, "_parrot_body_preserving_receive", None)
+    if isinstance(guard, _BodyPreservingReceive):
+        return guard
+    guard = _BodyPreservingReceive(request, key_name, limits)
+    # This is the only private Request hook used; see the class docstring.
+    request._receive = guard.receive
+    setattr(request, "_parrot_body_preserving_receive", guard)
+    return guard
+
+
+def _request_receive_guard(request: Request | None) -> _BodyPreservingReceive | None:
+    if request is None:
+        return None
+    guard = getattr(request, "_parrot_body_preserving_receive", None)
+    return guard if isinstance(guard, _BodyPreservingReceive) else None
+
+
 class ApiKeyLease:
     """一次 API Key slot 占用。release 幂等。"""
 
     def __init__(self, key_name: str, slot: ApiKeySlot | None,
                  limits: ResolvedLimits | None, *, queue_wait_ms: int = 0,
-                 noop: bool = False):
+                 noop: bool = False,
+                 replay_guard: _BodyPreservingReceive | None = None):
         self.key_name = key_name
         self.slot = slot
         self.limits = limits
         self.queue_wait_ms = int(queue_wait_ms)
         self.noop = noop
+        self._replay_guard = replay_guard
         self._released = False
+        self._release_task: asyncio.Task[None] | None = None
         self.attached_to_response = False
 
     async def release(self) -> None:
-        if self.noop or self._released or self.slot is None:
-            self._released = True
+        if self._released:
             return
+        if self._release_task is None:
+            self._release_task = asyncio.create_task(self._finish_release())
+        # All callers await the same independently running cleanup. Cancelling
+        # one caller cannot strand body accounting or the concurrency slot.
+        await asyncio.shield(self._release_task)
+
+    async def _finish_release(self) -> None:
+        try:
+            if self._replay_guard is not None:
+                await self._replay_guard.abandon()
+        finally:
+            if not self.noop and self.slot is not None:
+                await _release_slot(self.slot)
         self._released = True
-        await _release_slot(self.slot)
 
 
 _slots: dict[str, ApiKeySlot] = {}
@@ -114,6 +307,26 @@ def _resolve_limits(key_name: str) -> ResolvedLimits:
     global_max = _as_int(global_cfg.get("defaultMaxConcurrent"), _DEFAULT_MAX_CONCURRENT)
     global_queue = _as_int(global_cfg.get("defaultMaxQueue"), _DEFAULT_MAX_QUEUE)
     global_wait = _as_int(global_cfg.get("defaultQueueWaitSeconds"), _DEFAULT_QUEUE_WAIT_SECONDS)
+    global_request_body_bytes = _as_int(
+        global_cfg.get("defaultMaxRequestBodyBytes"),
+        DEFAULT_MAX_REQUEST_BODY_BYTES,
+        minimum=1,
+    )
+    global_request_body_events = _as_int(
+        global_cfg.get("defaultMaxRequestBodyEvents"),
+        DEFAULT_MAX_REQUEST_BODY_EVENTS,
+        minimum=1,
+    )
+    global_queued_body_bytes = _as_int(
+        global_cfg.get("defaultMaxQueuedBodyBytesPerKey"),
+        DEFAULT_MAX_QUEUED_BODY_BYTES_PER_KEY,
+        minimum=1,
+    )
+    max_queued_body_bytes_total = _as_int(
+        global_cfg.get("maxQueuedBodyBytesTotal"),
+        DEFAULT_MAX_QUEUED_BODY_BYTES_TOTAL,
+        minimum=1,
+    )
 
     entry = (cfg.get("apiKeys") or {}).get(key_name)
     limits = entry.get("limits") if isinstance(entry, dict) else None
@@ -148,11 +361,31 @@ def _resolve_limits(key_name: str) -> ResolvedLimits:
         queue_wait = global_wait
         wait_source = "global"
 
+    max_request_body_bytes = _as_int(
+        limits.get("maxRequestBodyBytes"),
+        global_request_body_bytes,
+        minimum=1,
+    )
+    max_request_body_events = _as_int(
+        limits.get("maxRequestBodyEvents"),
+        global_request_body_events,
+        minimum=1,
+    )
+    max_queued_body_bytes = _as_int(
+        limits.get("maxQueuedBodyBytes"),
+        global_queued_body_bytes,
+        minimum=1,
+    )
+
     return ResolvedLimits(
         enabled=enabled,
         max_concurrent=max_concurrent,
         max_queue=max_queue,
         queue_wait_seconds=queue_wait,
+        max_request_body_bytes=max_request_body_bytes,
+        max_request_body_events=max_request_body_events,
+        max_queued_body_bytes=max_queued_body_bytes,
+        max_queued_body_bytes_total=max_queued_body_bytes_total,
         enabled_source=enabled_source,
         max_concurrent_source=max_source,
         max_queue_source=queue_source,
@@ -176,6 +409,8 @@ async def acquire(key_name: str | None, request: Request | None = None) -> ApiKe
     """占用一个 API Key 并发槽位；必要时进入 FIFO 队列。
 
     返回 ApiKeyLease，调用方必须在请求生命周期结束时 release。
+    Queue disconnect monitoring preserves every unread ``http.request`` event
+    and replays it to the route after admission.
     """
     key = str(key_name or "").strip()
     if not key:
@@ -192,6 +427,9 @@ async def acquire(key_name: str | None, request: Request | None = None) -> ApiKe
     async with slot.lock:
         slot.limits = _resolve_limits(key)
         limits = slot.limits
+        # Existing FIFO waiters get first claim on any newly available or
+        # hot-reloaded capacity before this fresh request may use the fast path.
+        _wake_eligible_waiters_locked(slot)
         if not limits.enabled:
             return ApiKeyLease(key, None, limits, noop=True)
         if limits.unlimited or slot.in_flight < limits.max_concurrent:
@@ -205,27 +443,86 @@ async def acquire(key_name: str | None, request: Request | None = None) -> ApiKe
         waiter = Waiter(future=fut, enqueued_at=time.monotonic())
         slot.waiters.append(waiter)
 
+    queue_deadline = start_wait + max(0, limits.queue_wait_seconds)
+    disconnect_request = request
     try:
-        await _wait_for_turn_or_abort(slot, waiter, request, limits.queue_wait_seconds)
+        await _wait_for_turn_or_abort(
+            slot,
+            waiter,
+            disconnect_request,
+            limits,
+            deadline=queue_deadline,
+        )
         queue_wait_ms = int((time.monotonic() - start_wait) * 1000)
-        # 被 release 唤醒后真正占位；若热加载导致仍无空位，则重新排队。
+        # A normal wake-up owns a reserved capacity slot.  Keeping that
+        # reservation in ``in_flight`` prevents a newly arriving request from
+        # barging ahead of the FIFO waiter before it reacquires ``slot.lock``.
         while True:
             async with slot.lock:
                 slot.limits = _resolve_limits(key)
                 limits = slot.limits
+                replay_guard = _request_receive_guard(disconnect_request)
+                if waiter.capacity_reserved:
+                    waiter.capacity_reserved = False
+                    if not limits.enabled:
+                        if slot.in_flight > 0:
+                            slot.in_flight -= 1
+                        _wake_eligible_waiters_locked(slot)
+                        return ApiKeyLease(
+                            key, None, limits, noop=True, replay_guard=replay_guard
+                        )
+                    if limits.unlimited:
+                        _wake_eligible_waiters_locked(slot)
+                    return ApiKeyLease(
+                        key,
+                        slot,
+                        limits,
+                        queue_wait_ms=queue_wait_ms,
+                        replay_guard=replay_guard,
+                    )
                 if not limits.enabled:
-                    return ApiKeyLease(key, None, limits, noop=True)
-                if limits.unlimited or slot.in_flight < limits.max_concurrent:
+                    _wake_eligible_waiters_locked(slot)
+                    return ApiKeyLease(
+                        key, None, limits, noop=True, replay_guard=replay_guard
+                    )
+                if limits.unlimited:
                     slot.in_flight += 1
-                    return ApiKeyLease(key, slot, limits, queue_wait_ms=queue_wait_ms)
+                    _wake_eligible_waiters_locked(slot)
+                    return ApiKeyLease(
+                        key,
+                        slot,
+                        limits,
+                        queue_wait_ms=queue_wait_ms,
+                        replay_guard=replay_guard,
+                    )
+                if slot.in_flight < limits.max_concurrent:
+                    slot.in_flight += 1
+                    return ApiKeyLease(
+                        key,
+                        slot,
+                        limits,
+                        queue_wait_ms=queue_wait_ms,
+                        replay_guard=replay_guard,
+                    )
                 if limits.max_queue <= 0 or len(slot.waiters) >= limits.max_queue:
                     raise _queue_full_error(key, slot)
                 fut = asyncio.get_event_loop().create_future()
                 waiter = Waiter(future=fut, enqueued_at=time.monotonic())
                 slot.waiters.append(waiter)
-            await _wait_for_turn_or_abort(slot, waiter, request, limits.queue_wait_seconds)
+            await _wait_for_turn_or_abort(
+                slot,
+                waiter,
+                disconnect_request,
+                limits,
+                deadline=queue_deadline,
+            )
     except BaseException:
-        await _drop_waiter(slot, waiter)
+        try:
+            await _drop_waiter(slot, waiter)
+        finally:
+            replay_guard = _request_receive_guard(disconnect_request)
+            if replay_guard is not None:
+                await replay_guard.abandon()
         raise
 
 
@@ -233,57 +530,133 @@ async def _wait_for_turn_or_abort(
     slot: ApiKeySlot,
     waiter: Waiter,
     request: Request | None,
-    timeout_seconds: int,
+    limits: ResolvedLimits,
+    *,
+    deadline: float | None = None,
 ) -> None:
+    timeout_seconds = limits.queue_wait_seconds
+    if deadline is None:
+        deadline = time.monotonic() + max(0, timeout_seconds)
+    remaining_seconds = max(0.0, deadline - time.monotonic())
     wait_items: list[asyncio.Future | asyncio.Task] = [waiter.future]
     timeout_task: asyncio.Task | None = None
     disconnect_task: asyncio.Task | None = None
-    if timeout_seconds <= 0:
+    limits_task: asyncio.Task | None = None
+    if remaining_seconds <= 0:
         await _drop_waiter(slot, waiter)
         raise _timeout_error(slot.key_name, slot, timeout_seconds)
-    timeout_task = asyncio.create_task(asyncio.sleep(timeout_seconds))
+    timeout_task = asyncio.create_task(asyncio.sleep(remaining_seconds))
     wait_items.append(timeout_task)
+    limits_task = asyncio.create_task(_wait_for_limit_relaxation(slot))
+    wait_items.append(limits_task)
     if request is not None:
-        disconnect_task = asyncio.create_task(_wait_http_disconnect(request))
+        disconnect_task = asyncio.create_task(
+            _wait_http_disconnect(request, slot.key_name, limits)
+        )
         wait_items.append(disconnect_task)
 
     try:
         done, _pending = await asyncio.wait(wait_items, return_when=asyncio.FIRST_COMPLETED)
-        if waiter.future in done:
-            return
-        await _drop_waiter(slot, waiter)
         if disconnect_task is not None and disconnect_task in done:
+            await _drop_waiter(slot, waiter)
+            disconnect_error = disconnect_task.exception()
+            if disconnect_error is not None:
+                raise disconnect_error
             raise ApiKeyLimitError(
                 f"API key '{slot.key_name}' queued request was cancelled because the client disconnected.",
                 reason="client_disconnected",
             )
+        if waiter.future in done:
+            return
+        await _drop_waiter(slot, waiter)
         raise _timeout_error(slot.key_name, slot, timeout_seconds)
     finally:
-        for item in wait_items:
-            if item is not waiter.future and not item.done():
-                item.cancel()
+        background_tasks = [
+            item for item in wait_items
+            if item is not waiter.future and isinstance(item, asyncio.Task)
+        ]
+        for task in background_tasks:
+            if not task.done():
+                task.cancel()
+        if background_tasks:
+            cleanup_results = await asyncio.gather(
+                *background_tasks, return_exceptions=True
+            )
+            # A watcher cancelled by admission may have already consumed an
+            # event whose reservation then exceeded a budget.  Do not hide it.
+            for result in cleanup_results:
+                if isinstance(result, RequestBodyTooLarge):
+                    raise result
 
 
-async def _wait_http_disconnect(request: Request) -> None:
+async def _wait_http_disconnect(
+    request: Request,
+    key_name: str,
+    limits: ResolvedLimits,
+) -> None:
+    guard = _body_preserving_receive(request, key_name, limits)
+    try:
+        await guard.wait_for_disconnect()
+    except RequestBodyTooLarge:
+        raise
+    except Exception:
+        # A closed/broken ASGI receive channel is equivalent to disconnect.
+        return
+
+
+def _pop_next_waiter_locked(slot: ApiKeySlot) -> Waiter | None:
+    while slot.waiters:
+        waiter = slot.waiters.pop(0)
+        if not waiter.future.done():
+            return waiter
+    return None
+
+
+def _wake_all_waiters_locked(slot: ApiKeySlot) -> None:
+    """Wake every waiter without reserving finite capacity."""
     while True:
-        try:
-            if await request.is_disconnected():
-                return
-        except Exception:
+        waiter = _pop_next_waiter_locked(slot)
+        if waiter is None:
             return
-        await asyncio.sleep(1.0)
+        waiter.future.set_result(None)
+
+
+def _wake_eligible_waiters_locked(slot: ApiKeySlot) -> None:
+    """Wake bypassed waiters or reserve each newly available finite slot."""
+    limits = slot.limits
+    if not limits.enabled or limits.unlimited:
+        _wake_all_waiters_locked(slot)
+        return
+    available = max(0, limits.max_concurrent - slot.in_flight)
+    while available > 0:
+        waiter = _pop_next_waiter_locked(slot)
+        if waiter is None:
+            return
+        waiter.capacity_reserved = True
+        slot.in_flight += 1
+        available -= 1
+        waiter.future.set_result(None)
+
+
+async def _wait_for_limit_relaxation(slot: ApiKeySlot) -> None:
+    """Poll config while queued so hot-disable/unlimited changes wake waiters."""
+    while True:
+        await asyncio.sleep(0.5)
+        try:
+            latest = _resolve_limits(slot.key_name)
+        except Exception:
+            continue
+        async with slot.lock:
+            slot.limits = latest
+            _wake_eligible_waiters_locked(slot)
 
 
 async def _release_slot(slot: ApiKeySlot) -> None:
     async with slot.lock:
+        slot.limits = _resolve_limits(slot.key_name)
         if slot.in_flight > 0:
             slot.in_flight -= 1
-        while slot.waiters:
-            waiter = slot.waiters.pop(0)
-            fut = waiter.future
-            if not fut.done():
-                fut.set_result(None)
-                break
+        _wake_eligible_waiters_locked(slot)
 
 
 async def _drop_waiter(slot: ApiKeySlot, waiter: Waiter) -> None:
@@ -292,6 +665,12 @@ async def _drop_waiter(slot: ApiKeySlot, waiter: Waiter) -> None:
             slot.waiters.remove(waiter)
         except ValueError:
             pass
+        if waiter.capacity_reserved:
+            waiter.capacity_reserved = False
+            if slot.in_flight > 0:
+                slot.in_flight -= 1
+            slot.limits = _resolve_limits(slot.key_name)
+            _wake_eligible_waiters_locked(slot)
     if not waiter.future.done():
         waiter.future.cancel()
 
@@ -326,7 +705,7 @@ def _headers(slot: ApiKeySlot | None, queue_wait_ms: int = 0) -> dict[str, str]:
 
 def attach_release_to_response(response: Response, lease: ApiKeyLease) -> Response:
     """把 lease 释放绑定到响应体发送结束；StreamingResponse 支持客户端断开释放。"""
-    if lease.noop or lease._released:
+    if lease._released or (lease.noop and lease._replay_guard is None):
         return response
     lease.attached_to_response = True
     for k, v in _headers(lease.slot, lease.queue_wait_ms).items():

--- a/src/config.py
+++ b/src/config.py
@@ -101,12 +101,16 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "defaultMaxConcurrent": 5,
         "defaultMaxQueue": 50,
         "defaultQueueWaitSeconds": 1800,
-        # 排队期间 disconnect watcher 会预读并回放请求体；以下上限避免慢排队
-        # 请求用大 body / 过度分片占满进程内存。
+        # 排队期间 disconnect watcher 会预读并回放请求体。小 body 留内存；
+        # 超过阈值后落到有界临时文件，避免合法图片 body 长时间驻留内存。
         "defaultMaxRequestBodyBytes": 8388608,
         "defaultMaxRequestBodyEvents": 4096,
         "defaultMaxQueuedBodyBytesPerKey": 33554432,
         "maxQueuedBodyBytes": 134217728,
+        "queuedBodySpoolThresholdBytes": 1048576,
+        "queuedBodySpoolDirectory": "",
+        "defaultMaxQueuedBodySpoolBytesPerKey": 536870912,
+        "maxQueuedBodySpoolBytes": 2147483648,
     },
     "oauthAccounts": [],
     "channels": [],

--- a/src/config.py
+++ b/src/config.py
@@ -101,6 +101,12 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "defaultMaxConcurrent": 5,
         "defaultMaxQueue": 50,
         "defaultQueueWaitSeconds": 1800,
+        # 排队期间 disconnect watcher 会预读并回放请求体；以下上限避免慢排队
+        # 请求用大 body / 过度分片占满进程内存。
+        "defaultMaxRequestBodyBytes": 8388608,
+        "defaultMaxRequestBodyEvents": 4096,
+        "defaultMaxQueuedBodyBytesPerKey": 33554432,
+        "maxQueuedBodyBytes": 134217728,
     },
     "oauthAccounts": [],
     "channels": [],

--- a/src/oauth_manager.py
+++ b/src/oauth_manager.py
@@ -1211,15 +1211,6 @@ def evaluate_and_toggle_by_cached_quota(account_key: str,
                 "disabled_until": None}
     return evaluate_and_toggle_by_usage(account_key, usage, threshold=threshold)
 
-def _quota_disabled_until_still_future(acc: dict) -> bool:
-    dt = _parse_iso(acc.get("disabled_until"))
-    if dt is None:
-        return False
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt > datetime.now(timezone.utc)
-
-
 def _usage_has_any_quota_signal(usage: dict) -> bool:
     return any(u is not None for u in extract_utils_percent(usage))
 
@@ -1360,8 +1351,7 @@ def _cached_openai_codex_quota_hit(account_key: str, threshold: float) -> dict:
 
 def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
                                  *, threshold: float | None = None,
-                                 fresh: bool = True,
-                                 respect_disabled_until: bool = True) -> dict:
+                                 fresh: bool = True) -> dict:
     """核心策略：拿到新鲜 usage 后评估禁用/恢复，并执行状态切换。
 
     规则：
@@ -1372,13 +1362,11 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
       • 所有窗口 util < threshold → 可用
           - OpenAI / Grok 账号若 usage 没有任何窗口指标，或这份 usage 不是本轮新鲜探测，
             不能作为恢复依据；保持原 quota 禁用状态，避免“未知=恢复”误判。
-          - OpenAI 账号若仍处于 disabled_until 冷却期，或仍有未过期的 Codex
-            响应头超限快照，继续保持 quota 禁用，避免 WHAM/Codex 边界不同步
-            导致“假恢复”。
-          - OpenAI 账号只有在冷却期/响应头快照都过期，且本轮新鲜有效 usage
-            全部低于阈值时，才 set_enabled(True) 自动恢复。
-            respect_disabled_until=False 的官方 reset credit / 手动强刷新路径例外：
-            上游已确认消耗 reset 后，可用新鲜 usage 直接覆盖本地旧冷却时间。
+          - OpenAI 账号若仍有未过期的 Codex 响应头超限快照，继续保持 quota
+            禁用，避免 WHAM/Codex 边界不同步导致“假恢复”。
+          - 若 Codex 没有活动的超限快照，且本轮新鲜有效 usage 全部低于阈值，
+            说明上游窗口已经重置；直接恢复并清除旧 disabled_until。旧时间只是
+            上次超限时的预测，不能覆盖更新后的上游事实。
           - Grok 账号使用官方 billing 月度快照，fresh usage 低于阈值即可恢复。
           - 其他账号是 quota 禁用：set_enabled(True) 自动恢复。
           - 账号未禁用：无事发生
@@ -1447,11 +1435,10 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
         return {"action": "disabled", "utils": utils, "any_over": True,
                 "hit_windows": hit_windows, "disabled_until": latest_reset}
 
-    # 全部窗口都可用。OpenAI 的 usage 来自响应头/最小 probe 的缓存合成，
-    # 空缓存或被节流跳过的旧缓存不能证明额度恢复；尤其 quota 禁用账号不能
-    # 因 [None, None, None, None] 被误恢复。若 disabled_until 仍在未来，也不
-    # 提前恢复：OpenAI WHAM 与 Codex 响应头在边界附近会不同步，提前恢复会
-    # 造成“恢复通知 → 下一次请求马上响应头禁用”的假恢复。
+    # 全部窗口都可用。空缓存或被节流跳过的旧缓存不能证明额度恢复；尤其
+    # quota 禁用账号不能因 [None, None, None, None] 被误恢复。OpenAI 若仍有
+    # 活动的 Codex 超限快照，前面的 any_over 分支已经保持禁用；否则新鲜
+    # WHAM 低用量应覆盖旧 disabled_until，因为后者只是上次超限时的预测。
     if reason == "quota":
         if provider in ("openai", "xai"):
             if not _usage_has_any_quota_signal(usage):
@@ -1460,13 +1447,6 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
                         "disabled_until": acc.get("disabled_until")}
             if not fresh:
                 return {"action": "quota_stale_keep_disabled", "utils": utils,
-                        "any_over": False, "hit_windows": [],
-                        "disabled_until": acc.get("disabled_until")}
-            # OpenAI/Codex 的 WHAM 与响应头窗口可能短暂不同步，需等本地
-            # disabled_until 过期；Grok 使用官方 billing 月度快照，fresh 数据
-            # 低于阈值即可恢复，避免充值/提额后被锁到月底。
-            if provider == "openai" and respect_disabled_until and _quota_disabled_until_still_future(acc):
-                return {"action": "quota_cooldown_keep_disabled", "utils": utils,
                         "any_over": False, "hit_windows": [],
                         "disabled_until": acc.get("disabled_until")}
         try:
@@ -2116,9 +2096,7 @@ async def redeem_openai_rate_limit_reset_credit(account_key: str,
     if isinstance(reset_credits, dict) and reset_credits.get("available_count") is not None:
         out["available_count"] = reset_credits.get("available_count")
 
-    eval_result = evaluate_and_toggle_by_usage(
-        canonical, usage, fresh=True, respect_disabled_until=False,
-    )
+    eval_result = evaluate_and_toggle_by_usage(canonical, usage, fresh=True)
     out["quota_action"] = eval_result
     if eval_result.get("action") in ("resumed", "kept_enabled") and not eval_result.get("any_over"):
         out["runtime_clear"] = _clear_oauth_runtime_state(canonical, clear_quota_cache=False)

--- a/src/oauth_manager.py
+++ b/src/oauth_manager.py
@@ -1215,6 +1215,14 @@ def _usage_has_any_quota_signal(usage: dict) -> bool:
     return any(u is not None for u in extract_utils_percent(usage))
 
 
+def _explicit_openai_wham_limit(usage: dict) -> bool:
+    """Whether a WHAM response explicitly says routing is unavailable."""
+    openai = usage.get("openai") if isinstance(usage, dict) else None
+    if not isinstance(openai, dict) or openai.get("source") != "wham_usage":
+        return False
+    return openai.get("allowed") is False or openai.get("limit_reached") is True
+
+
 def openai_plan_workspace_label(acc: dict | None) -> str:
     """Human label for OpenAI OAuth accounts.
 
@@ -1373,6 +1381,7 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
 
     返回: {
       "action": "noop_user"|"noop_auth_error"|"disabled"|"still_over_quota"|
+                "wham_limit_disabled"|"wham_limit_keep_disabled"|
                 "resumed"|"kept_enabled"|"disable_failed"|"resume_failed"|"noop_missing",
       "utils": [5h, 7d, 30d, sonnet, opus],   # None 表示该指标缺失
       "any_over": bool,
@@ -1406,6 +1415,28 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
         return {"action": f"noop_{reason}", "utils": utils, "any_over": any_over,
                 "hit_windows": hit_windows,
                 "disabled_until": acc.get("disabled_until")}
+
+    # WHAM's explicit gate is authoritative even when its percentage windows
+    # are absent or temporarily report a low number.  In particular, never turn
+    # "allowed: false" / "limit_reached: true" into quota recovery.
+    wham_limit = provider == "openai" and _explicit_openai_wham_limit(usage)
+    if wham_limit:
+        hit_windows.append("WHAM limit")
+        if reason == "quota":
+            return {"action": "wham_limit_keep_disabled", "utils": utils,
+                    "any_over": True, "hit_windows": hit_windows,
+                    "disabled_until": acc.get("disabled_until")}
+        latest_reset = reset_iso_for_hit_windows(usage, threshold)
+        try:
+            set_disabled_by_quota(account_key, latest_reset)
+        except Exception as exc:
+            print(f"[oauth] evaluate WHAM disable failed for {account_key}: {exc}")
+            return {"action": "disable_failed", "utils": utils,
+                    "any_over": True, "hit_windows": hit_windows,
+                    "disabled_until": None}
+        return {"action": "wham_limit_disabled", "utils": utils,
+                "any_over": True, "hit_windows": hit_windows,
+                "disabled_until": latest_reset}
 
     cached_codex_hit = None
     if provider_of(account_key) == "openai":
@@ -1456,8 +1487,18 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
             return {"action": "resume_failed", "utils": utils,
                     "any_over": False, "hit_windows": [],
                     "disabled_until": acc.get("disabled_until")}
+        runtime_state = None
+        if provider == "openai" and fresh:
+            # A genuine fresh recovery must also remove local cooldown/snapshot
+            # state or routing can remain blocked after the account is enabled.
+            # Preserve the just-written fresh quota cache for status and future
+            # evaluation.
+            runtime_state = _clear_oauth_runtime_state(
+                account_key, clear_quota_cache=False,
+            )
         return {"action": "resumed", "utils": utils, "any_over": False,
-                "hit_windows": [], "disabled_until": None}
+                "hit_windows": [], "disabled_until": None,
+                "runtime_state": runtime_state}
     return {"action": "kept_enabled", "utils": utils, "any_over": False,
             "hit_windows": [], "disabled_until": None}
 
@@ -2098,7 +2139,9 @@ async def redeem_openai_rate_limit_reset_credit(account_key: str,
 
     eval_result = evaluate_and_toggle_by_usage(canonical, usage, fresh=True)
     out["quota_action"] = eval_result
-    if eval_result.get("action") in ("resumed", "kept_enabled") and not eval_result.get("any_over"):
+    if eval_result.get("action") == "resumed":
+        out["runtime_clear"] = eval_result.get("runtime_state")
+    elif eval_result.get("action") == "kept_enabled" and not eval_result.get("any_over"):
         out["runtime_clear"] = _clear_oauth_runtime_state(canonical, clear_quota_cache=False)
     return out
 
@@ -2531,7 +2574,7 @@ async def quota_monitor_once() -> dict:
         elif provider == "xai":
             _plan_tag = f"\n{notifier.provider_custom_emoji_html('xai')} Grok"
 
-        if action == "disabled":
+        if action in ("disabled", "wham_limit_disabled"):
             latest_reset = result["disabled_until"]
             hit = " / ".join(result["hit_windows"]) or "?"
             out[email] = f"disabled_quota:{latest_reset}"
@@ -2543,8 +2586,8 @@ async def quota_monitor_once() -> dict:
                 f"重置时间: <code>{_to_bjt(latest_reset) if latest_reset else 'unknown'}</code>\n"
                 "所有撞到窗口恢复后即可自动解禁。"
             )
-        elif action == "still_over_quota":
-            out[email] = "still_over_quota"
+        elif action in ("still_over_quota", "wham_limit_keep_disabled"):
+            out[email] = action
         elif action == "resumed":
             out[email] = "resumed"
             notifier.throttled_notify_event_sync(

--- a/src/telegram/menus/oauth_menu.py
+++ b/src/telegram/menus/oauth_menu.py
@@ -2269,10 +2269,10 @@ def on_refresh_usage(chat_id: int, message_id: int, cb_id: str, short: str, page
             fields = metadata_action.get("fields") or {}
             if fields.get("plan_type"):
                 head += f"\n🏷 套餐信息已刷新: <code>{ui.escape_html(fields.get('plan_type'))}</code>"
-        if quota_action and quota_action.get("action") == "disabled":
+        if quota_action and quota_action.get("action") in ("disabled", "wham_limit_disabled"):
             hit = " / ".join(quota_action.get("hit_windows") or []) or "?"
             head += f"\n🔒 已自动标记为配额禁用（超限: <code>{ui.escape_html(hit)}</code>）"
-        elif quota_action and quota_action.get("action") == "still_over_quota":
+        elif quota_action and quota_action.get("action") in ("still_over_quota", "wham_limit_keep_disabled"):
             hit = " / ".join(quota_action.get("hit_windows") or []) or "?"
             head += f"\n⚠ 仍处于配额禁用（超限: <code>{ui.escape_html(hit)}</code>）"
         elif quota_action and quota_action.get("action") == "resumed":
@@ -2453,7 +2453,10 @@ def on_reset_quota(chat_id: int, message_id: int, cb_id: str, short: str, page: 
                 prefix += "✅ 已刷新最新额度，确认低于阈值；已自动解除 quota 禁用并清理模型冷却。\n"
             elif action == "kept_enabled":
                 prefix += "✅ 已刷新最新额度，账号保持可用；已清理相关模型冷却。\n"
-            elif action in ("still_over_quota", "disabled"):
+            elif action in (
+                "still_over_quota", "disabled",
+                "wham_limit_keep_disabled", "wham_limit_disabled",
+            ):
                 hit = " / ".join(quota_action.get("hit_windows") or []) or "?"
                 prefix += f"⚠️ 已刷新最新额度，但仍超限（<code>{ui.escape_html(hit)}</code>）；本地 quota 限制已保留。\n"
             elif action == "quota_unknown_keep_disabled":
@@ -2899,10 +2902,10 @@ def _run_refresh_all_legacy_panel(chat_id: int, progress_mid: int, account_keys:
                 quota_action = _evaluate_quota_action(ak, usage)
             else:
                 quota_action = None
-            if quota_action and quota_action.get("action") == "disabled":
+            if quota_action and quota_action.get("action") in ("disabled", "wham_limit_disabled"):
                 hit = " / ".join(quota_action.get("hit_windows") or []) or "?"
                 lines.append(f"  🔒 触发自动禁用（超限窗口: <code>{ui.escape_html(hit)}</code>）")
-            elif quota_action and quota_action.get("action") == "still_over_quota":
+            elif quota_action and quota_action.get("action") in ("still_over_quota", "wham_limit_keep_disabled"):
                 hit = " / ".join(quota_action.get("hit_windows") or []) or "?"
                 lines.append(f"  ⚠ 仍未恢复，维持禁用（超限: <code>{ui.escape_html(hit)}</code>）")
             elif quota_action and quota_action.get("action") == "resumed":

--- a/src/tests/test_apikey_limiter.py
+++ b/src/tests/test_apikey_limiter.py
@@ -146,7 +146,11 @@ async def test_queued_request_body_replay_is_bounded(monkeypatch):
         return chunks.pop(0)
 
     request = Request(
-        {"type": "http", "method": "POST", "path": "/v1/responses", "headers": []},
+        {
+            "type": "http", "method": "POST", "path": "/v1/responses",
+            # The actual ASGI stream, not Content-Length alone, must enforce the cap.
+            "headers": [(b"content-length", b"1")],
+        },
         receive,
     )
     queued = asyncio.create_task(apikey_limiter.acquire("k", request))
@@ -430,6 +434,51 @@ async def test_process_wide_queued_body_aggregate_budget(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_aggregate_error_survives_watcher_cancellation_and_gather(monkeypatch):
+    """Admission may win the wait race, but a watcher aggregate error must win cleanup."""
+    monkeypatch.setattr(
+        apikey_limiter, "QUEUED_BODY_EVENT_OVERHEAD_BYTES", 0, raising=False,
+    )
+    monkeypatch.setattr(
+        apikey_limiter.config,
+        "get",
+        lambda: _aggregate_budget_cfg(per_key=100, process=5),
+    )
+    original_reserve = apikey_limiter._BodyPreservingReceive._reserve
+    reserve_started = asyncio.Event()
+    allow_reserve = asyncio.Event()
+
+    async def paused_reserve(self, message):
+        reserve_started.set()
+        await allow_reserve.wait()
+        return await original_reserve(self, message)
+
+    monkeypatch.setattr(
+        apikey_limiter._BodyPreservingReceive, "_reserve", paused_reserve,
+    )
+    active = await apikey_limiter.acquire("k")
+    request = _queued_request([
+        {"type": "http.request", "body": b"12345678", "more_body": True},
+    ])
+    queued = asyncio.create_task(apikey_limiter.acquire("k", request))
+    await asyncio.wait_for(reserve_started.wait(), timeout=1)
+
+    # Wake/admit the FIFO waiter while its watcher has an event in hand.  The
+    # wait cleanup cancels that watcher and gathers it; the pending aggregate
+    # failure must not be replaced by a successful lease or CancelledError.
+    await active.release()
+    await asyncio.sleep(0.05)
+    assert not queued.done()
+    allow_reserve.set()
+
+    with pytest.raises(apikey_limiter.RequestBodyTooLarge) as exc_info:
+        await asyncio.wait_for(queued, timeout=1)
+    assert exc_info.value.reason == "process_aggregate"
+    assert apikey_limiter._queued_body_bytes_total == 0
+    assert apikey_limiter.key_snapshot("k")["in_flight"] == 0
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("body", [b"", b"x"], ids=["empty", "one-byte"])
 async def test_queued_body_event_count_is_bounded(monkeypatch, body):
     monkeypatch.setattr(
@@ -649,3 +698,124 @@ async def test_hot_disable_wakes_waiters_without_active_release(monkeypatch):
     assert all(lease.noop for lease in leases)
     assert apikey_limiter.key_snapshot("k")["waiting"] == 0
     await active.release()
+
+
+def _request(path: str, *, content_type: str = "application/json", content_length: int | None = None):
+    headers = [(b"content-type", content_type.encode())]
+    if content_length is not None:
+        headers.append((b"content-length", str(content_length).encode()))
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(
+        {"type": "http", "method": "POST", "path": path, "headers": headers},
+        receive,
+    )
+
+
+def test_public_process_aggregate_key_is_primary_with_legacy_fallback(monkeypatch):
+    current = _aggregate_budget_cfg(per_key=100, process=111)
+    current["apiKeyConcurrency"]["maxQueuedBodyBytes"] = 222
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: current)
+    assert apikey_limiter._resolve_limits("k").max_queued_body_bytes_total == 222
+
+    del current["apiKeyConcurrency"]["maxQueuedBodyBytes"]
+    assert apikey_limiter._resolve_limits("k").max_queued_body_bytes_total == 111
+
+
+@pytest.mark.asyncio
+async def test_image_total_body_contract_accepts_legal_20mib_single_images(monkeypatch):
+    current = _cfg()
+    current["apiKeyConcurrency"]["defaultMaxRequestBodyBytes"] = 8 * 1024 * 1024
+    current["images"] = {"maxInputImageBytes": 20 * 1024 * 1024}
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: current)
+
+    raw_size = 20 * 1024 * 1024
+    multipart = _request(
+        "/v1/images/edit",
+        content_type="multipart/form-data; boundary=x",
+        content_length=raw_size + 4096,
+    )
+    multipart_lease = await apikey_limiter.acquire("k", multipart)
+    await multipart_lease.release()
+
+    data_url_wire = 4 * ((raw_size + 2) // 3) + 512
+    json_request = _request(
+        "/v1/images/edit", content_length=data_url_wire,
+    )
+    json_lease = await apikey_limiter.acquire("k", json_request)
+    await json_lease.release()
+
+
+def test_compat_image_contract_covers_multi_image_and_mask(monkeypatch):
+    current = _cfg()
+    current["apiKeyConcurrency"]["defaultMaxRequestBodyBytes"] = 100
+    current["images"] = {"maxInputImageBytes": 300}
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: current)
+    limits = apikey_limiter._resolve_limits("k")
+
+    multipart_max = apikey_limiter._request_body_max_bytes(
+        _request("/v1/images/edits", content_type="multipart/form-data; boundary=x"),
+        limits,
+    )
+    json_max = apikey_limiter._request_body_max_bytes(
+        _request("/v1/images/edits"), limits,
+    )
+    # 16 legal images plus one mask, with a bounded form/JSON envelope.
+    assert multipart_max >= 17 * 300
+    assert json_max >= 17 * (4 * ((300 + 2) // 3))
+    assert json_max > multipart_max
+
+
+@pytest.mark.asyncio
+async def test_nonqueued_chunked_body_uses_same_total_byte_contract(monkeypatch):
+    current = _cfg()
+    current["apiKeyConcurrency"]["defaultMaxRequestBodyBytes"] = 5
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: current)
+    messages = [
+        {"type": "http.request", "body": b"123", "more_body": True},
+        {"type": "http.request", "body": b"456", "more_body": False},
+    ]
+
+    async def receive():
+        return messages.pop(0)
+
+    request = Request(
+        {
+            "type": "http", "method": "POST", "path": "/v1/responses",
+            # Deliberately false-low: streamed bytes remain authoritative.
+            "headers": [(b"content-length", b"1")],
+        },
+        receive,
+    )
+    lease = await apikey_limiter.acquire("k", request)
+    with pytest.raises(apikey_limiter.RequestBodyTooLarge) as exc_info:
+        await request.body()
+    assert exc_info.value.reason == "request_bytes"
+    await lease.release()
+
+
+@pytest.mark.asyncio
+async def test_nonqueued_body_event_count_uses_same_contract(monkeypatch):
+    current = _cfg()
+    current["apiKeyConcurrency"]["defaultMaxRequestBodyBytes"] = 100
+    current["apiKeyConcurrency"]["defaultMaxRequestBodyEvents"] = 1
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: current)
+    messages = [
+        {"type": "http.request", "body": b"a", "more_body": True},
+        {"type": "http.request", "body": b"b", "more_body": False},
+    ]
+
+    async def receive():
+        return messages.pop(0)
+
+    request = Request(
+        {"type": "http", "method": "POST", "path": "/v1/messages", "headers": []},
+        receive,
+    )
+    lease = await apikey_limiter.acquire("k", request)
+    with pytest.raises(apikey_limiter.RequestBodyTooLarge) as exc_info:
+        await request.body()
+    assert exc_info.value.reason == "event_count"
+    await lease.release()

--- a/src/tests/test_apikey_limiter.py
+++ b/src/tests/test_apikey_limiter.py
@@ -1,6 +1,10 @@
 import asyncio
 
+import httpx
 import pytest
+from fastapi import FastAPI
+from starlette.requests import Request
+from starlette.responses import Response
 
 from src import apikey_limiter
 
@@ -28,9 +32,13 @@ def _cfg(**limits):
 @pytest.fixture(autouse=True)
 def _reset_slots(monkeypatch):
     apikey_limiter._slots.clear()
+    apikey_limiter._queued_body_bytes_by_key.clear()
+    apikey_limiter._queued_body_bytes_total = 0
     monkeypatch.setattr(apikey_limiter.config, "get", lambda: _cfg())
     yield
     apikey_limiter._slots.clear()
+    apikey_limiter._queued_body_bytes_by_key.clear()
+    apikey_limiter._queued_body_bytes_total = 0
 
 
 @pytest.mark.asyncio
@@ -82,3 +90,562 @@ async def test_key_limits_enabled_overrides_global(monkeypatch):
     assert apikey_limiter.key_snapshot("k")["waiting"] == 1
     queued.cancel()
     await first.release()
+
+
+@pytest.mark.asyncio
+async def test_queued_disconnect_watch_preserves_unread_request_body():
+    """Disconnect monitoring may read ASGI events only if it replays them."""
+    first = await apikey_limiter.acquire("k")
+    chunks = [
+        {"type": "http.request", "body": b'{"model":"gpt-test",', "more_body": True},
+        {"type": "http.request", "body": b'"input":"hello"}', "more_body": False},
+    ]
+    body_seen_by_watcher = asyncio.Event()
+    no_more_events = asyncio.Event()
+
+    async def receive():
+        if chunks:
+            message = chunks.pop(0)
+            if not chunks:
+                body_seen_by_watcher.set()
+            return message
+        await no_more_events.wait()
+        return {"type": "http.disconnect"}
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/responses",
+            "headers": [],
+        },
+        receive,
+    )
+
+    queued = asyncio.create_task(apikey_limiter.acquire("k", request))
+    await asyncio.wait_for(body_seen_by_watcher.wait(), timeout=1)
+    await first.release()
+    second = await asyncio.wait_for(queued, timeout=1)
+
+    body = await asyncio.wait_for(request.body(), timeout=1)
+    assert body == b'{"model":"gpt-test","input":"hello"}'
+    assert apikey_limiter._queued_body_bytes_total == 0
+    await second.release()
+
+
+@pytest.mark.asyncio
+async def test_queued_request_body_replay_is_bounded(monkeypatch):
+    monkeypatch.setattr(apikey_limiter, "DEFAULT_MAX_REQUEST_BODY_BYTES", 8)
+    first = await apikey_limiter.acquire("k")
+    chunks = [
+        {"type": "http.request", "body": b"12345", "more_body": True},
+        {"type": "http.request", "body": b"67890", "more_body": False},
+    ]
+
+    async def receive():
+        return chunks.pop(0)
+
+    request = Request(
+        {"type": "http", "method": "POST", "path": "/v1/responses", "headers": []},
+        receive,
+    )
+    queued = asyncio.create_task(apikey_limiter.acquire("k", request))
+
+    with pytest.raises(apikey_limiter.RequestBodyTooLarge) as exc_info:
+        await asyncio.wait_for(queued, timeout=1)
+    assert exc_info.value.max_bytes == 8
+    assert apikey_limiter.key_snapshot("k")["waiting"] == 0
+    await first.release()
+
+
+@pytest.mark.asyncio
+async def test_queued_request_disconnects_cleanly_after_partial_body():
+    first = await apikey_limiter.acquire("k")
+    chunks = [{"type": "http.request", "body": b'{"model":', "more_body": True}]
+    disconnected = asyncio.Event()
+
+    async def receive():
+        if chunks:
+            return chunks.pop(0)
+        await disconnected.wait()
+        return {"type": "http.disconnect"}
+
+    request = Request(
+        {"type": "http", "method": "POST", "path": "/v1/responses", "headers": []},
+        receive,
+    )
+    queued = asyncio.create_task(apikey_limiter.acquire("k", request))
+    await asyncio.sleep(0.05)
+    disconnected.set()
+
+    with pytest.raises(apikey_limiter.ApiKeyLimitError) as exc_info:
+        await asyncio.wait_for(queued, timeout=1)
+    assert exc_info.value.reason == "client_disconnected"
+    assert apikey_limiter.key_snapshot("k")["waiting"] == 0
+    await first.release()
+
+
+@pytest.mark.asyncio
+async def test_fastapi_middleware_replays_queued_chunked_body_end_to_end():
+    app = FastAPI()
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    second_body_sent = asyncio.Event()
+
+    @app.middleware("http")
+    async def limit_requests(request: Request, call_next):
+        lease = await apikey_limiter.acquire("k", request)
+        try:
+            return await call_next(request)
+        finally:
+            await lease.release()
+
+    @app.post("/echo")
+    async def echo(request: Request):
+        body = await request.body()
+        if body == b"hold":
+            first_started.set()
+            await release_first.wait()
+        return Response(content=body)
+
+    async def chunked_json():
+        yield b'{"model":"gpt-test",'
+        yield b'"input":"hello"}'
+        second_body_sent.set()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        first = asyncio.create_task(client.post("/echo", content=b"hold"))
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+        second = asyncio.create_task(client.post("/echo", content=chunked_json()))
+        await asyncio.wait_for(second_body_sent.wait(), timeout=1)
+        release_first.set()
+
+        first_response, second_response = await asyncio.gather(first, second)
+
+    assert first_response.content == b"hold"
+    assert second_response.content == b'{"model":"gpt-test","input":"hello"}'
+
+
+async def _wait_for_waiters(key_name: str, count: int) -> None:
+    async def ready():
+        while apikey_limiter.key_snapshot(key_name)["waiting"] != count:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(ready(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_after_handoff_wakes_next_waiter(monkeypatch):
+    """A disconnect that wins after its waiter was signalled must pass the slot on."""
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: _cfg(maxQueue=3))
+    first = await apikey_limiter.acquire("k")
+    disconnected = asyncio.Event()
+
+    async def receive():
+        await disconnected.wait()
+        return {"type": "http.disconnect"}
+
+    request = Request(
+        {"type": "http", "method": "POST", "path": "/v1/responses", "headers": []},
+        receive,
+    )
+    original_drop = apikey_limiter._drop_waiter
+    drop_started = asyncio.Event()
+    allow_drop = asyncio.Event()
+
+    async def delayed_drop(slot, waiter):
+        if asyncio.current_task().get_name() == "disconnecting-waiter":
+            drop_started.set()
+            await allow_drop.wait()
+        await original_drop(slot, waiter)
+
+    monkeypatch.setattr(apikey_limiter, "_drop_waiter", delayed_drop)
+    disconnecting = asyncio.create_task(
+        apikey_limiter.acquire("k", request), name="disconnecting-waiter"
+    )
+    next_waiter = asyncio.create_task(apikey_limiter.acquire("k"))
+    await _wait_for_waiters("k", 2)
+
+    disconnected.set()
+    await asyncio.wait_for(drop_started.wait(), timeout=1)
+    await first.release()  # Pops/signals the disconnecting waiter before its abort cleanup.
+    allow_drop.set()
+
+    with pytest.raises(apikey_limiter.ApiKeyLimitError) as exc_info:
+        await asyncio.wait_for(disconnecting, timeout=1)
+    assert exc_info.value.reason == "client_disconnected"
+    admitted = await asyncio.wait_for(next_waiter, timeout=1)
+    await admitted.release()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_after_handoff_wakes_next_waiter(monkeypatch):
+    """Cancellation between wake-up and in_flight increment must repair handoff."""
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: _cfg(maxQueue=3))
+    original_wait = apikey_limiter._wait_for_turn_or_abort
+    woke = asyncio.Event()
+    hold_after_wakeup = asyncio.Event()
+
+    async def pause_after_wakeup(*args, **kwargs):
+        await original_wait(*args, **kwargs)
+        if asyncio.current_task().get_name() == "cancelled-after-wakeup":
+            woke.set()
+            await hold_after_wakeup.wait()
+
+    monkeypatch.setattr(apikey_limiter, "_wait_for_turn_or_abort", pause_after_wakeup)
+    first = await apikey_limiter.acquire("k")
+    cancelled = asyncio.create_task(
+        apikey_limiter.acquire("k"), name="cancelled-after-wakeup"
+    )
+    next_waiter = asyncio.create_task(apikey_limiter.acquire("k"))
+    await _wait_for_waiters("k", 2)
+
+    await first.release()
+    await asyncio.wait_for(woke.wait(), timeout=1)
+    cancelled.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled
+
+    admitted = await asyncio.wait_for(next_waiter, timeout=1)
+    await admitted.release()
+
+
+def _aggregate_budget_cfg(*, per_key: int, process: int, max_events: int = 10):
+    return {
+        "apiKeyConcurrency": {
+            "enabled": True,
+            "defaultMaxConcurrent": 1,
+            "defaultMaxQueue": 4,
+            "defaultQueueWaitSeconds": 10,
+            "defaultMaxRequestBodyBytes": 100,
+            "defaultMaxRequestBodyEvents": max_events,
+            "defaultMaxQueuedBodyBytesPerKey": per_key,
+            "maxQueuedBodyBytesTotal": process,
+        },
+        "apiKeys": {
+            name: {"key": "secret", "enabled": True, "limits": {}}
+            for name in ("k", "k2")
+        },
+    }
+
+
+def _queued_request(messages, consumed: asyncio.Event | None = None) -> Request:
+    remaining = list(messages)
+    block = asyncio.Event()
+
+    async def receive():
+        if remaining:
+            message = remaining.pop(0)
+            if not remaining and consumed is not None:
+                consumed.set()
+            return message
+        await block.wait()
+        return {"type": "http.disconnect"}
+
+    return Request(
+        {"type": "http", "method": "POST", "path": "/v1/responses", "headers": []},
+        receive,
+    )
+
+
+@pytest.mark.asyncio
+async def test_per_key_queued_body_aggregate_budget(monkeypatch):
+    monkeypatch.setattr(apikey_limiter, "QUEUED_BODY_EVENT_OVERHEAD_BYTES", 0, raising=False)
+    monkeypatch.setattr(
+        apikey_limiter.config,
+        "get",
+        lambda: _aggregate_budget_cfg(per_key=12, process=100),
+    )
+    first = await apikey_limiter.acquire("k")
+    first_body_consumed = asyncio.Event()
+    queued = asyncio.create_task(
+        apikey_limiter.acquire(
+            "k",
+            _queued_request(
+                [{"type": "http.request", "body": b"12345678", "more_body": True}],
+                first_body_consumed,
+            ),
+        )
+    )
+    await asyncio.wait_for(first_body_consumed.wait(), timeout=1)
+
+    rejected = asyncio.create_task(
+        apikey_limiter.acquire(
+            "k",
+            _queued_request(
+                [{"type": "http.request", "body": b"abcdefgh", "more_body": True}]
+            ),
+        )
+    )
+    with pytest.raises(apikey_limiter.RequestBodyTooLarge) as exc_info:
+        await asyncio.wait_for(rejected, timeout=1)
+    assert exc_info.value.reason == "key_aggregate"
+
+    queued.cancel()
+    await asyncio.gather(queued, return_exceptions=True)
+    await first.release()
+    assert apikey_limiter._queued_body_bytes_total == 0
+
+
+@pytest.mark.asyncio
+async def test_process_wide_queued_body_aggregate_budget(monkeypatch):
+    monkeypatch.setattr(apikey_limiter, "QUEUED_BODY_EVENT_OVERHEAD_BYTES", 0, raising=False)
+    monkeypatch.setattr(
+        apikey_limiter.config,
+        "get",
+        lambda: _aggregate_budget_cfg(per_key=100, process=12),
+    )
+    active_k = await apikey_limiter.acquire("k")
+    active_k2 = await apikey_limiter.acquire("k2")
+    first_body_consumed = asyncio.Event()
+    queued = asyncio.create_task(
+        apikey_limiter.acquire(
+            "k",
+            _queued_request(
+                [{"type": "http.request", "body": b"12345678", "more_body": True}],
+                first_body_consumed,
+            ),
+        )
+    )
+    await asyncio.wait_for(first_body_consumed.wait(), timeout=1)
+
+    with pytest.raises(apikey_limiter.RequestBodyTooLarge) as exc_info:
+        await asyncio.wait_for(
+            apikey_limiter.acquire(
+                "k2",
+                _queued_request(
+                    [{"type": "http.request", "body": b"abcdefgh", "more_body": True}]
+                ),
+            ),
+            timeout=1,
+        )
+    assert exc_info.value.reason == "process_aggregate"
+
+    queued.cancel()
+    await asyncio.gather(queued, return_exceptions=True)
+    await active_k.release()
+    await active_k2.release()
+    assert apikey_limiter._queued_body_bytes_total == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [b"", b"x"], ids=["empty", "one-byte"])
+async def test_queued_body_event_count_is_bounded(monkeypatch, body):
+    monkeypatch.setattr(
+        apikey_limiter.config,
+        "get",
+        lambda: _aggregate_budget_cfg(per_key=10_000, process=10_000, max_events=3),
+    )
+    first = await apikey_limiter.acquire("k")
+    request = _queued_request(
+        [
+            {"type": "http.request", "body": body, "more_body": True}
+            for _ in range(4)
+        ]
+    )
+
+    with pytest.raises(apikey_limiter.RequestBodyTooLarge) as exc_info:
+        await asyncio.wait_for(apikey_limiter.acquire("k", request), timeout=1)
+    assert exc_info.value.reason == "event_count"
+    assert apikey_limiter._queued_body_bytes_total == 0
+    await first.release()
+
+
+@pytest.mark.asyncio
+async def test_release_cancellation_during_guard_cleanup_does_not_leak_capacity():
+    lease = await apikey_limiter.acquire("k")
+    request = _queued_request([])
+    assert lease.limits is not None
+    guard = apikey_limiter._body_preserving_receive(request, "k", lease.limits)
+    await guard._reserve(
+        {"type": "http.request", "body": b"buffered", "more_body": True}
+    )
+    lease._replay_guard = guard
+
+    await apikey_limiter._queued_body_lock.acquire()
+    cleanup_task = None
+    try:
+        releasing = asyncio.create_task(lease.release())
+
+        async def cleanup_started():
+            while lease._release_task is None:
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(cleanup_started(), timeout=1)
+        cleanup_task = lease._release_task
+        assert cleanup_task is not None
+        await asyncio.sleep(0)
+        assert not cleanup_task.done()
+
+        releasing.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await releasing
+        assert not lease._released
+        assert apikey_limiter._queued_body_bytes_total > 0
+        assert apikey_limiter.key_snapshot("k")["in_flight"] == 1
+    finally:
+        apikey_limiter._queued_body_lock.release()
+
+    await asyncio.wait_for(lease.release(), timeout=1)
+    assert lease._release_task is cleanup_task
+    assert lease._released
+    assert apikey_limiter._queued_body_bytes_total == 0
+    assert apikey_limiter._queued_body_bytes_by_key == {}
+    assert apikey_limiter.key_snapshot("k")["in_flight"] == 0
+
+    replacement = await asyncio.wait_for(apikey_limiter.acquire("k"), timeout=1)
+    await replacement.release()
+
+
+@pytest.mark.asyncio
+async def test_hot_disable_releases_all_signaled_waiters(monkeypatch):
+    current = _cfg(maxQueue=4, queueWaitSeconds=10)
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: current)
+    first = await apikey_limiter.acquire("k")
+    queued = [
+        asyncio.create_task(apikey_limiter.acquire("k"))
+        for _ in range(3)
+    ]
+    await _wait_for_waiters("k", 3)
+
+    current["apiKeyConcurrency"]["enabled"] = False
+    await first.release()
+    leases = await asyncio.wait_for(asyncio.gather(*queued), timeout=1)
+
+    assert all(lease.noop for lease in leases)
+    assert apikey_limiter.key_snapshot("k")["waiting"] == 0
+    assert apikey_limiter.key_snapshot("k")["in_flight"] == 0
+
+
+@pytest.mark.asyncio
+async def test_noop_response_attachment_cleans_unread_replay_buffer():
+    limits = apikey_limiter._resolve_limits("k")
+    request = _queued_request([])
+    guard = apikey_limiter._body_preserving_receive(request, "k", limits)
+    await guard._reserve(
+        {"type": "http.request", "body": b"unread", "more_body": True}
+    )
+    lease = apikey_limiter.ApiKeyLease(
+        "k", None, limits, noop=True, replay_guard=guard
+    )
+
+    response = apikey_limiter.attach_release_to_response(Response(), lease)
+    assert response is not None
+    assert lease.attached_to_response
+    assert apikey_limiter._queued_body_bytes_total > 0
+
+    async def cleaned_up():
+        while not lease._released:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(cleaned_up(), timeout=1)
+    assert apikey_limiter._queued_body_bytes_total == 0
+    assert apikey_limiter._queued_body_bytes_by_key == {}
+
+
+@pytest.mark.asyncio
+async def test_lowered_body_budget_applies_to_next_queued_event(monkeypatch):
+    monkeypatch.setattr(
+        apikey_limiter, "QUEUED_BODY_EVENT_OVERHEAD_BYTES", 0, raising=False
+    )
+    current = _aggregate_budget_cfg(per_key=100, process=100)
+    current["apiKeyConcurrency"]["defaultMaxRequestBodyBytes"] = 20
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: current)
+    first = await apikey_limiter.acquire("k")
+    first_event_received = asyncio.Event()
+    allow_second_event = asyncio.Event()
+    block = asyncio.Event()
+    event_number = 0
+
+    async def receive():
+        nonlocal event_number
+        event_number += 1
+        if event_number == 1:
+            first_event_received.set()
+            return {"type": "http.request", "body": b"12345", "more_body": True}
+        if event_number == 2:
+            await allow_second_event.wait()
+            return {"type": "http.request", "body": b"67890", "more_body": True}
+        await block.wait()
+        return {"type": "http.disconnect"}
+
+    request = Request(
+        {"type": "http", "method": "POST", "path": "/v1/responses", "headers": []},
+        receive,
+    )
+    queued = asyncio.create_task(apikey_limiter.acquire("k", request))
+    await asyncio.wait_for(first_event_received.wait(), timeout=1)
+
+    async def first_event_accounted():
+        while apikey_limiter._queued_body_bytes_total != 5:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(first_event_accounted(), timeout=1)
+    current["apiKeyConcurrency"]["defaultMaxRequestBodyBytes"] = 8
+    allow_second_event.set()
+
+    with pytest.raises(apikey_limiter.RequestBodyTooLarge) as exc_info:
+        await asyncio.wait_for(queued, timeout=1)
+    assert exc_info.value.max_bytes == 8
+    assert apikey_limiter._queued_body_bytes_total == 0
+    assert apikey_limiter.key_snapshot("k")["waiting"] == 0
+    await first.release()
+
+
+@pytest.mark.asyncio
+async def test_handoff_reserves_capacity_against_new_arrivals(monkeypatch):
+    current = _cfg(maxQueue=4, queueWaitSeconds=10)
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: current)
+    original_wait = apikey_limiter._wait_for_turn_or_abort
+    old_woke = asyncio.Event()
+    allow_old = asyncio.Event()
+
+    async def pause_old_after_wakeup(*args, **kwargs):
+        await original_wait(*args, **kwargs)
+        current_task = asyncio.current_task()
+        if current_task is not None and current_task.get_name() == "old-waiter":
+            old_woke.set()
+            await allow_old.wait()
+
+    monkeypatch.setattr(
+        apikey_limiter,
+        "_wait_for_turn_or_abort",
+        pause_old_after_wakeup,
+    )
+    active = await apikey_limiter.acquire("k")
+    old = asyncio.create_task(apikey_limiter.acquire("k"), name="old-waiter")
+    await _wait_for_waiters("k", 1)
+
+    await active.release()
+    await asyncio.wait_for(old_woke.wait(), timeout=1)
+    newcomer = asyncio.create_task(apikey_limiter.acquire("k"), name="newcomer")
+    await asyncio.sleep(0.05)
+
+    assert not newcomer.done()
+    assert apikey_limiter.key_snapshot("k")["waiting"] == 1
+    allow_old.set()
+    old_lease = await asyncio.wait_for(old, timeout=1)
+    assert not newcomer.done()
+    await old_lease.release()
+    new_lease = await asyncio.wait_for(newcomer, timeout=1)
+    await new_lease.release()
+
+
+@pytest.mark.asyncio
+async def test_hot_disable_wakes_waiters_without_active_release(monkeypatch):
+    current = _cfg(maxQueue=4, queueWaitSeconds=10)
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: current)
+    active = await apikey_limiter.acquire("k")
+    queued = [
+        asyncio.create_task(apikey_limiter.acquire("k"))
+        for _ in range(2)
+    ]
+    await _wait_for_waiters("k", 2)
+
+    current["apiKeyConcurrency"]["enabled"] = False
+    leases = await asyncio.wait_for(asyncio.gather(*queued), timeout=2)
+
+    assert all(lease.noop for lease in leases)
+    assert apikey_limiter.key_snapshot("k")["waiting"] == 0
+    await active.release()

--- a/src/tests/test_apikey_limiter.py
+++ b/src/tests/test_apikey_limiter.py
@@ -1,4 +1,9 @@
 import asyncio
+import gc
+import os
+import stat
+import weakref
+from pathlib import Path
 
 import httpx
 import pytest
@@ -34,11 +39,17 @@ def _reset_slots(monkeypatch):
     apikey_limiter._slots.clear()
     apikey_limiter._queued_body_bytes_by_key.clear()
     apikey_limiter._queued_body_bytes_total = 0
+    apikey_limiter._queued_body_spool_bytes_by_key.clear()
+    apikey_limiter._queued_body_spool_bytes_total = 0
+    apikey_limiter._active_body_guards.clear()
     monkeypatch.setattr(apikey_limiter.config, "get", lambda: _cfg())
     yield
     apikey_limiter._slots.clear()
     apikey_limiter._queued_body_bytes_by_key.clear()
     apikey_limiter._queued_body_bytes_total = 0
+    apikey_limiter._queued_body_spool_bytes_by_key.clear()
+    apikey_limiter._queued_body_spool_bytes_total = 0
+    apikey_limiter._active_body_guards.clear()
 
 
 @pytest.mark.asyncio
@@ -332,6 +343,19 @@ def _aggregate_budget_cfg(*, per_key: int, process: int, max_events: int = 10):
             for name in ("k", "k2")
         },
     }
+
+
+def _spool_cfg(tmp_path, *, wait_seconds: int = 10):
+    cfg = _aggregate_budget_cfg(per_key=100_000, process=100_000)
+    cfg["apiKeyConcurrency"].update({
+        "defaultQueueWaitSeconds": wait_seconds,
+        "defaultMaxRequestBodyBytes": 100_000,
+        "queuedBodySpoolThresholdBytes": 1,
+        "queuedBodySpoolDirectory": str(tmp_path),
+        "defaultMaxQueuedBodySpoolBytesPerKey": 100_000,
+        "maxQueuedBodySpoolBytes": 100_000,
+    })
+    return cfg
 
 
 def _queued_request(messages, consumed: asyncio.Event | None = None) -> Request:
@@ -819,3 +843,336 @@ async def test_nonqueued_body_event_count_uses_same_contract(monkeypatch):
         await request.body()
     assert exc_info.value.reason == "event_count"
     await lease.release()
+
+
+async def _wait_for_spool_bytes(expected: int) -> None:
+    async def ready():
+        while apikey_limiter._queued_body_spool_bytes_total != expected:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(ready(), timeout=2)
+
+
+def _assert_spool_clean(tmp_path, request: Request | None = None) -> None:
+    assert apikey_limiter._queued_body_bytes_total == 0
+    assert apikey_limiter._queued_body_bytes_by_key == {}
+    assert apikey_limiter._queued_body_spool_bytes_total == 0
+    assert apikey_limiter._queued_body_spool_bytes_by_key == {}
+    assert list(Path(tmp_path).iterdir()) == []
+    if request is not None:
+        guard = apikey_limiter._request_receive_guard(request)
+        assert guard is not None
+        assert guard._spool is None
+
+
+@pytest.mark.asyncio
+async def test_spooled_body_cancellation_closes_file_and_accounting(monkeypatch, tmp_path):
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: _spool_cfg(tmp_path))
+    active = await apikey_limiter.acquire("k")
+    request = _queued_request([
+        {"type": "http.request", "body": b"cancel-me", "more_body": True},
+    ])
+    queued = asyncio.create_task(apikey_limiter.acquire("k", request))
+    await _wait_for_spool_bytes(len(b"cancel-me"))
+
+    queued.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await queued
+    _assert_spool_clean(tmp_path, request)
+    await active.release()
+
+
+@pytest.mark.asyncio
+async def test_spool_disk_budget_stays_reserved_until_file_is_closed(monkeypatch, tmp_path):
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: _spool_cfg(tmp_path))
+    active = await apikey_limiter.acquire("k")
+    chunks = (b"first-chunk", b"second-chunk")
+    request = _queued_request([
+        {"type": "http.request", "body": chunks[0], "more_body": True},
+        {"type": "http.request", "body": chunks[1], "more_body": False},
+    ])
+    queued = asyncio.create_task(apikey_limiter.acquire("k", request))
+    await _wait_for_spool_bytes(sum(map(len, chunks)))
+    await active.release()
+    lease = await asyncio.wait_for(queued, timeout=1)
+
+    first = await request.receive()
+    assert first["body"] == chunks[0]
+    # The backing file still contains both events, so its whole allocation must
+    # continue to count even though the first event has been handed downstream.
+    assert apikey_limiter._queued_body_spool_bytes_total == sum(map(len, chunks))
+    second = await request.receive()
+    assert second["body"] == chunks[1]
+    assert apikey_limiter._queued_body_spool_bytes_total == 0
+    await lease.release()
+    _assert_spool_clean(tmp_path, request)
+
+
+@pytest.mark.asyncio
+async def test_spooled_body_timeout_closes_file_and_accounting(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        apikey_limiter.config, "get", lambda: _spool_cfg(tmp_path, wait_seconds=1),
+    )
+    active = await apikey_limiter.acquire("k")
+    request = _queued_request([
+        {"type": "http.request", "body": b"timeout-body", "more_body": True},
+    ])
+    queued = asyncio.create_task(apikey_limiter.acquire("k", request))
+    await _wait_for_spool_bytes(len(b"timeout-body"))
+
+    with pytest.raises(apikey_limiter.ApiKeyLimitError) as exc_info:
+        await asyncio.wait_for(queued, timeout=2)
+    assert exc_info.value.reason == "queue_timeout"
+    _assert_spool_clean(tmp_path, request)
+    await active.release()
+
+
+@pytest.mark.asyncio
+async def test_spooled_body_disconnect_closes_file_and_accounting(monkeypatch, tmp_path):
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: _spool_cfg(tmp_path))
+    active = await apikey_limiter.acquire("k")
+    messages = [
+        {"type": "http.request", "body": b"partial-body", "more_body": True},
+        {"type": "http.disconnect"},
+    ]
+
+    async def receive():
+        return messages.pop(0)
+
+    request = Request(
+        {"type": "http", "method": "POST", "path": "/v1/responses", "headers": []},
+        receive,
+    )
+    with pytest.raises(apikey_limiter.ApiKeyLimitError) as exc_info:
+        await apikey_limiter.acquire("k", request)
+    assert exc_info.value.reason == "client_disconnected"
+    _assert_spool_clean(tmp_path, request)
+    await active.release()
+
+
+@pytest.mark.asyncio
+async def test_spooled_body_hot_disable_noop_release_cleans(monkeypatch, tmp_path):
+    current = _spool_cfg(tmp_path)
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: current)
+    active = await apikey_limiter.acquire("k")
+    request = _queued_request([
+        {"type": "http.request", "body": b"hot-disable", "more_body": True},
+    ])
+    queued = asyncio.create_task(apikey_limiter.acquire("k", request))
+    await _wait_for_spool_bytes(len(b"hot-disable"))
+
+    current["apiKeyConcurrency"]["enabled"] = False
+    lease = await asyncio.wait_for(queued, timeout=2)
+    assert lease.noop
+    # A noop lease still owns the queued replay resource until response cleanup.
+    assert apikey_limiter._queued_body_spool_bytes_total == len(b"hot-disable")
+    await lease.release()
+    _assert_spool_clean(tmp_path, request)
+    await active.release()
+
+
+@pytest.mark.asyncio
+async def test_spool_write_exception_closes_file_and_accounting(monkeypatch, tmp_path):
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: _spool_cfg(tmp_path))
+    active = await apikey_limiter.acquire("k")
+    request = _queued_request([
+        {"type": "http.request", "body": b"io-failure", "more_body": True},
+    ])
+
+    async def fail_write(self, *args, **kwargs):
+        # Open the real temporary object first so cleanup proves fd/file closure.
+        if self._spool is None:
+            self._spool = self._open_spool(self._limits)
+            self._spool.rollover()
+            self._spooled_to_disk = True
+        raise OSError("synthetic disk failure")
+
+    monkeypatch.setattr(
+        apikey_limiter._BodyPreservingReceive, "_write_spooled_body", fail_write,
+    )
+    with pytest.raises(apikey_limiter.QueuedBodySpoolError):
+        await apikey_limiter.acquire("k", request)
+    _assert_spool_clean(tmp_path, request)
+    await active.release()
+
+
+@pytest.mark.asyncio
+async def test_spool_error_wins_concurrent_admission_handoff(monkeypatch, tmp_path):
+    """A watcher spool failure must not be hidden by a simultaneous FIFO wake."""
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: _spool_cfg(tmp_path))
+    write_started = asyncio.Event()
+    allow_failure = asyncio.Event()
+
+    async def paused_failure(self, *args, **kwargs):
+        write_started.set()
+        await allow_failure.wait()
+        raise OSError("handoff disk failure")
+
+    monkeypatch.setattr(
+        apikey_limiter._BodyPreservingReceive,
+        "_write_spooled_body",
+        paused_failure,
+    )
+    active = await apikey_limiter.acquire("k")
+    request = _queued_request([
+        {"type": "http.request", "body": b"handoff-body", "more_body": True},
+    ])
+    queued = asyncio.create_task(apikey_limiter.acquire("k", request))
+    await asyncio.wait_for(write_started.wait(), timeout=1)
+
+    await active.release()
+    await asyncio.sleep(0)
+    allow_failure.set()
+    with pytest.raises(apikey_limiter.QueuedBodySpoolError):
+        await asyncio.wait_for(queued, timeout=1)
+    _assert_spool_clean(tmp_path, request)
+    assert apikey_limiter.key_snapshot("k")["in_flight"] == 0
+
+
+@pytest.mark.asyncio
+async def test_default_spool_capacity_tracks_effective_request_limit_and_stays_bounded(
+    monkeypatch, tmp_path,
+):
+    """Defaults admit one legal body, while concurrent retained bodies remain capped."""
+    monkeypatch.setattr(
+        apikey_limiter, "DEFAULT_MAX_QUEUED_BODY_SPOOL_BYTES_PER_KEY", 10,
+    )
+    monkeypatch.setattr(
+        apikey_limiter, "DEFAULT_MAX_QUEUED_BODY_SPOOL_BYTES_TOTAL", 20,
+    )
+    cfg = _aggregate_budget_cfg(per_key=100_000, process=100_000)
+    cfg["apiKeyConcurrency"].update({
+        "defaultMaxRequestBodyBytes": 100,
+        "queuedBodySpoolThresholdBytes": 1,
+        "queuedBodySpoolDirectory": str(tmp_path),
+        "defaultMaxQueuedBodySpoolBytesPerKey": 10,
+        "maxQueuedBodySpoolBytes": 20,
+    })
+    cfg["apiKeys"]["k2"] = {"key": "secret", "enabled": True, "limits": {}}
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: cfg)
+
+    first = _queued_request([])
+    first_guard = apikey_limiter._body_preserving_receive(
+        first, "k", apikey_limiter._resolve_limits("k"),
+    )
+    await first_guard._reserve(
+        {"type": "http.request", "body": b"a" * 60, "more_body": True}
+    )
+    assert apikey_limiter._queued_body_spool_bytes_total == 60
+
+    second = _queued_request([])
+    second_guard = apikey_limiter._body_preserving_receive(
+        second, "k2", apikey_limiter._resolve_limits("k2"),
+    )
+    with pytest.raises(apikey_limiter.RequestBodyTooLarge) as exc_info:
+        await second_guard._reserve(
+            {"type": "http.request", "body": b"b" * 50, "more_body": True}
+        )
+    assert exc_info.value.reason == "process_aggregate"
+    assert exc_info.value.max_bytes == 100
+
+    await second_guard.abandon()
+    await first_guard.abandon()
+    _assert_spool_clean(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_spool_directory_and_file_permissions_are_private(monkeypatch, tmp_path):
+    spool_dir = tmp_path / "spool"
+    spool_dir.mkdir(mode=0o777)
+    os.chmod(spool_dir, 0o777)
+    monkeypatch.setattr(
+        apikey_limiter.config, "get", lambda: _spool_cfg(spool_dir),
+    )
+    request = _queued_request([])
+    guard = apikey_limiter._body_preserving_receive(
+        request, "k", apikey_limiter._resolve_limits("k"),
+    )
+    await guard._reserve(
+        {"type": "http.request", "body": b"private", "more_body": True}
+    )
+    assert stat.S_IMODE(spool_dir.stat().st_mode) == 0o700
+    assert guard._spool is not None
+    assert stat.S_IMODE(os.fstat(guard._spool.fileno()).st_mode) == 0o600
+    await guard.abandon()
+    _assert_spool_clean(spool_dir, request)
+
+
+@pytest.mark.asyncio
+async def test_spool_directory_symlink_fails_closed_and_cleans(monkeypatch, tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "spool-link"
+    link.symlink_to(target, target_is_directory=True)
+    monkeypatch.setattr(
+        apikey_limiter.config, "get", lambda: _spool_cfg(link),
+    )
+    request = _queued_request([])
+    guard = apikey_limiter._body_preserving_receive(
+        request, "k", apikey_limiter._resolve_limits("k"),
+    )
+    with pytest.raises(apikey_limiter.QueuedBodySpoolError):
+        await guard._reserve(
+            {"type": "http.request", "body": b"blocked", "more_body": True}
+        )
+    await guard.abandon()
+    assert list(target.iterdir()) == []
+    assert apikey_limiter._queued_body_bytes_total == 0
+    assert apikey_limiter._queued_body_spool_bytes_total == 0
+
+
+@pytest.mark.asyncio
+async def test_shutdown_spooling_closes_all_live_guards(monkeypatch, tmp_path):
+    cfg = _spool_cfg(tmp_path)
+    cfg["apiKeys"]["k2"] = {"key": "secret", "enabled": True, "limits": {}}
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: cfg)
+    guards = []
+    for key, body in (("k", b"first"), ("k2", b"second")):
+        request = _queued_request([])
+        guard = apikey_limiter._body_preserving_receive(
+            request, key, apikey_limiter._resolve_limits(key),
+        )
+        await guard._reserve(
+            {"type": "http.request", "body": body, "more_body": True}
+        )
+        guards.append(guard)
+
+    assert apikey_limiter._queued_body_spool_bytes_total == 11
+    assert len(apikey_limiter._active_body_guards) == 2
+    await apikey_limiter.shutdown_spooling()
+    await apikey_limiter.shutdown_spooling()  # repeated shutdown is harmless
+
+    assert all(guard._spool is None for guard in guards)
+    assert len(apikey_limiter._active_body_guards) == 0
+    _assert_spool_clean(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_repeated_spool_cleanup_releases_fds_files_and_guard_memory(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: _spool_cfg(tmp_path))
+    fd_dir = Path("/proc/self/fd")
+    before_fds = len(list(fd_dir.iterdir())) if fd_dir.exists() else None
+    guard_refs = []
+
+    for _ in range(40):
+        request = _queued_request([])
+        guard = apikey_limiter._body_preserving_receive(
+            request, "k", apikey_limiter._resolve_limits("k"),
+        )
+        guard_refs.append(weakref.ref(guard))
+        await guard._reserve(
+            {"type": "http.request", "body": b"retained", "more_body": True}
+        )
+        await guard.abandon()
+        await guard.abandon()
+
+    del guard, request
+    gc.collect()
+    after_fds = len(list(fd_dir.iterdir())) if fd_dir.exists() else None
+    if before_fds is not None and after_fds is not None:
+        assert after_fds <= before_fds + 1
+    assert all(ref() is None for ref in guard_refs)
+    assert len(apikey_limiter._active_body_guards) == 0
+    _assert_spool_clean(tmp_path)

--- a/src/tests/test_apikey_limiter_middleware.py
+++ b/src/tests/test_apikey_limiter_middleware.py
@@ -1,0 +1,130 @@
+"""Production HTTP middleware coverage for API-key body-limit responses."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+import server as parrot_server
+from src import apikey_limiter, drain
+
+
+def _config(*, request_bytes: int = 100, events: int = 10,
+            per_key: int = 100, process: int = 100) -> dict:
+    return {
+        "apiKeyConcurrency": {
+            "enabled": True,
+            "defaultMaxConcurrent": 1,
+            "defaultMaxQueue": 2,
+            "defaultQueueWaitSeconds": 2,
+            "defaultMaxRequestBodyBytes": request_bytes,
+            "defaultMaxRequestBodyEvents": events,
+            "defaultMaxQueuedBodyBytesPerKey": per_key,
+            "maxQueuedBodyBytes": process,
+        },
+        "apiKeys": {"k": {"key": "secret", "enabled": True, "limits": {}}},
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime(monkeypatch):
+    drain.reset_for_tests()
+    apikey_limiter._slots.clear()
+    apikey_limiter._queued_body_bytes_by_key.clear()
+    apikey_limiter._queued_body_bytes_total = 0
+    monkeypatch.setattr(parrot_server.auth, "validate", lambda _headers: ("k", [], None))
+    monkeypatch.setattr(
+        apikey_limiter, "QUEUED_BODY_EVENT_OVERHEAD_BYTES", 0, raising=False,
+    )
+    yield
+    drain.reset_for_tests()
+    apikey_limiter._slots.clear()
+    apikey_limiter._queued_body_bytes_by_key.clear()
+    apikey_limiter._queued_body_bytes_total = 0
+
+
+async def _post(path: str, content) -> httpx.Response:
+    transport = httpx.ASGITransport(app=parrot_server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        return await client.post(
+            path,
+            headers={"authorization": "Bearer secret", "content-type": "application/json"},
+            content=content,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "expected_type"),
+    [
+        ("/v1/messages", "request_too_large"),
+        ("/v1/responses", "invalid_request_error"),
+    ],
+)
+async def test_production_middleware_request_bytes_returns_413_schema(
+    monkeypatch, path, expected_type,
+):
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: _config(request_bytes=5))
+    response = await _post(path, b"123456")
+    assert response.status_code == 413
+    payload = response.json()
+    if path == "/v1/messages":
+        assert payload["type"] == "error"
+        assert payload["error"]["type"] == expected_type
+    else:
+        assert payload["error"]["type"] == expected_type
+    assert payload["error"]["code"] == "request_too_large"
+    assert "retry-after" not in response.headers
+
+
+class _TwoChunks(httpx.AsyncByteStream):
+    async def __aiter__(self):
+        yield b"a"
+        await asyncio.sleep(0)
+        yield b"b"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/v1/messages", "/v1/responses"])
+async def test_production_middleware_event_count_returns_413(monkeypatch, path):
+    monkeypatch.setattr(
+        apikey_limiter.config, "get", lambda: _config(request_bytes=100, events=1),
+    )
+    response = await _post(path, _TwoChunks())
+    assert response.status_code == 413
+    assert response.json()["error"]["code"] == "request_too_large"
+    assert "body events" in response.json()["error"]["message"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "pressure", "expected_type"),
+    [
+        ("/v1/messages", "key", "rate_limit_error"),
+        ("/v1/messages", "process", "rate_limit_error"),
+        ("/v1/responses", "key", "rate_limit_exceeded"),
+        ("/v1/responses", "process", "rate_limit_exceeded"),
+    ],
+)
+async def test_production_middleware_aggregate_pressure_returns_429_retry_after(
+    monkeypatch, path, pressure, expected_type,
+):
+    cfg = _config(
+        request_bytes=100,
+        per_key=5 if pressure == "key" else 100,
+        process=5 if pressure == "process" else 100,
+    )
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: cfg)
+    active = await apikey_limiter.acquire("k")
+    try:
+        response = await _post(path, b"123456")
+    finally:
+        await active.release()
+
+    assert response.status_code == 429
+    assert response.headers["retry-after"] == "1"
+    payload = response.json()
+    assert payload["error"]["type"] == expected_type
+    assert payload["error"]["code"] == "queued_body_capacity"

--- a/src/tests/test_apikey_limiter_middleware.py
+++ b/src/tests/test_apikey_limiter_middleware.py
@@ -3,16 +3,24 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+from pathlib import Path
 
 import httpx
 import pytest
+from starlette.responses import Response
+from starlette.requests import Request
 
 import server as parrot_server
 from src import apikey_limiter, drain
 
 
 def _config(*, request_bytes: int = 100, events: int = 10,
-            per_key: int = 100, process: int = 100) -> dict:
+            per_key: int = 100, process: int = 100,
+            spool_threshold: int = 1024 * 1024,
+            spool_per_key: int = 512 * 1024 * 1024,
+            spool_process: int = 2 * 1024 * 1024 * 1024,
+            spool_directory: str = "") -> dict:
     return {
         "apiKeyConcurrency": {
             "enabled": True,
@@ -23,6 +31,10 @@ def _config(*, request_bytes: int = 100, events: int = 10,
             "defaultMaxRequestBodyEvents": events,
             "defaultMaxQueuedBodyBytesPerKey": per_key,
             "maxQueuedBodyBytes": process,
+            "queuedBodySpoolThresholdBytes": spool_threshold,
+            "queuedBodySpoolDirectory": spool_directory,
+            "defaultMaxQueuedBodySpoolBytesPerKey": spool_per_key,
+            "maxQueuedBodySpoolBytes": spool_process,
         },
         "apiKeys": {"k": {"key": "secret", "enabled": True, "limits": {}}},
     }
@@ -34,6 +46,8 @@ def _reset_runtime(monkeypatch):
     apikey_limiter._slots.clear()
     apikey_limiter._queued_body_bytes_by_key.clear()
     apikey_limiter._queued_body_bytes_total = 0
+    apikey_limiter._queued_body_spool_bytes_by_key.clear()
+    apikey_limiter._queued_body_spool_bytes_total = 0
     monkeypatch.setattr(parrot_server.auth, "validate", lambda _headers: ("k", [], None))
     monkeypatch.setattr(
         apikey_limiter, "QUEUED_BODY_EVENT_OVERHEAD_BYTES", 0, raising=False,
@@ -43,6 +57,8 @@ def _reset_runtime(monkeypatch):
     apikey_limiter._slots.clear()
     apikey_limiter._queued_body_bytes_by_key.clear()
     apikey_limiter._queued_body_bytes_total = 0
+    apikey_limiter._queued_body_spool_bytes_by_key.clear()
+    apikey_limiter._queued_body_spool_bytes_total = 0
 
 
 async def _post(path: str, content) -> httpx.Response:
@@ -128,3 +144,199 @@ async def test_production_middleware_aggregate_pressure_returns_429_retry_after(
     payload = response.json()
     assert payload["error"]["type"] == expected_type
     assert payload["error"]["code"] == "queued_body_capacity"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pressure", ["key", "process"])
+async def test_production_middleware_disk_aggregate_pressure_returns_429_and_cleans(
+    monkeypatch, tmp_path, pressure,
+):
+    cfg = _config(
+        request_bytes=100,
+        per_key=100,
+        process=100,
+        spool_threshold=1,
+        spool_per_key=5 if pressure == "key" else 100,
+        spool_process=5 if pressure == "process" else 100,
+        spool_directory=str(tmp_path),
+    )
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: cfg)
+    active = await apikey_limiter.acquire("k")
+    try:
+        response = await _post("/v1/responses", b"123456")
+    finally:
+        await active.release()
+
+    assert response.status_code == 429
+    assert response.headers["retry-after"] == "1"
+    assert response.json()["error"]["code"] == "queued_body_capacity"
+    assert apikey_limiter._queued_body_bytes_total == 0
+    assert apikey_limiter._queued_body_spool_bytes_total == 0
+    assert list(Path(tmp_path).iterdir()) == []
+
+
+def _multipart_multi_image_body(total_bytes: int) -> bytes:
+    boundary = b"parrot-spool-regression"
+    prefix = (
+        b"--" + boundary + b"\r\n"
+        b'Content-Disposition: form-data; name="prompt"\r\n\r\nedit\r\n'
+        b"--" + boundary + b"\r\n"
+        b'Content-Disposition: form-data; name="images[]"; filename="one.png"\r\n'
+        b"Content-Type: image/png\r\n\r\n"
+    )
+    between = (
+        b"\r\n--" + boundary + b"\r\n"
+        b'Content-Disposition: form-data; name="images[]"; filename="two.png"\r\n'
+        b"Content-Type: image/png\r\n\r\n"
+    )
+    before_mask = (
+        b"\r\n--" + boundary + b"\r\n"
+        b'Content-Disposition: form-data; name="mask"; filename="mask.png"\r\n'
+        b"Content-Type: image/png\r\n\r\n"
+    )
+    suffix = b"\r\n--" + boundary + b"--\r\n"
+    first_size = 16 * 1024 * 1024
+    mask = b"M" * 1024
+    second_size = (
+        total_bytes - len(prefix) - first_size - len(between)
+        - len(before_mask) - len(mask) - len(suffix)
+    )
+    assert second_size > 0
+    return (
+        prefix + (b"A" * first_size) + between + (b"B" * second_size)
+        + before_mask + mask + suffix
+    )
+
+
+@pytest.mark.asyncio
+async def test_production_middleware_queued_33mib_multi_image_spools_and_replays_exactly(
+    monkeypatch, tmp_path,
+):
+    """The real production middleware must treat queued/nonqueued edits alike."""
+    cfg = _config(
+        request_bytes=8 * 1024 * 1024,
+        events=32,
+        per_key=32 * 1024 * 1024,
+        process=128 * 1024 * 1024,
+        spool_threshold=1024 * 1024,
+        spool_directory=str(tmp_path),
+    )
+    cfg["images"] = {"maxInputImageBytes": 20 * 1024 * 1024}
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: cfg)
+
+    from src.openai import images_openai_compat
+
+    seen: list[bytes] = []
+
+    async def exact_echo(request):
+        body = await request.body()
+        seen.append(body)
+        return Response(
+            content=hashlib.sha256(body).hexdigest(), media_type="text/plain"
+        )
+
+    monkeypatch.setattr(images_openai_compat, "handle_edits", exact_echo)
+    body = _multipart_multi_image_body(33 * 1024 * 1024)
+    expected_digest = hashlib.sha256(body).hexdigest()
+    headers = {
+        "authorization": "Bearer secret",
+        "content-type": "multipart/form-data; boundary=parrot-spool-regression",
+    }
+    transport = httpx.ASGITransport(app=parrot_server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        nonqueued = await client.post("/v1/images/edits", headers=headers, content=body)
+        assert nonqueued.status_code == 200
+        assert nonqueued.text == expected_digest
+        assert apikey_limiter._queued_body_spool_bytes_total == 0
+
+        active = await apikey_limiter.acquire("k")
+        queued_task = asyncio.create_task(
+            client.post("/v1/images/edits", headers=headers, content=body)
+        )
+
+        async def body_spooled():
+            while apikey_limiter._queued_body_spool_bytes_total != len(body):
+                if queued_task.done():
+                    await queued_task
+                    pytest.fail("queued request completed before its body was spooled")
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(body_spooled(), timeout=10)
+        assert apikey_limiter._queued_body_bytes_total < 1024 * 1024
+        await active.release()
+        queued = await asyncio.wait_for(queued_task, timeout=10)
+
+    assert queued.status_code == 200
+    assert queued.text == expected_digest
+    assert seen == [body, body]
+    assert apikey_limiter._queued_body_bytes_total == 0
+    assert apikey_limiter._queued_body_bytes_by_key == {}
+    assert apikey_limiter._queued_body_spool_bytes_total == 0
+    assert apikey_limiter._queued_body_spool_bytes_by_key == {}
+    assert list(Path(tmp_path).iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_image_endpoint_absolute_cap_is_413_queued_and_nonqueued_and_never_spools(
+    monkeypatch, tmp_path,
+):
+    cfg = _config(
+        request_bytes=100,
+        per_key=1024,
+        process=4096,
+        spool_threshold=16,
+        spool_directory=str(tmp_path),
+    )
+    cfg["images"] = {"maxInputImageBytes": 64}
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: cfg)
+    limits = apikey_limiter._resolve_limits("k")
+    request_for_limit = Request(
+        {
+            "type": "http", "method": "POST", "path": "/v1/images/edits",
+            "headers": [(b"content-type", b"application/json")],
+        }
+    )
+    endpoint_max = apikey_limiter._request_body_max_bytes(request_for_limit, limits)
+    body = b"x" * (endpoint_max + 1)
+
+    nonqueued = await _post("/v1/images/edits", body)
+    assert nonqueued.status_code == 413
+    active = await apikey_limiter.acquire("k")
+    try:
+        queued = await _post("/v1/images/edits", body)
+    finally:
+        await active.release()
+    assert queued.status_code == 413
+    assert nonqueued.json()["error"]["code"] == "request_too_large"
+    assert queued.json()["error"]["code"] == "request_too_large"
+    assert apikey_limiter._queued_body_bytes_total == 0
+    assert apikey_limiter._queued_body_spool_bytes_total == 0
+    assert list(Path(tmp_path).iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_small_queued_body_stays_in_memory_without_disk_rollover(
+    monkeypatch, tmp_path,
+):
+    cfg = _config(
+        request_bytes=1024,
+        per_key=4096,
+        process=4096,
+        spool_threshold=1024,
+        spool_directory=str(tmp_path),
+    )
+    monkeypatch.setattr(apikey_limiter.config, "get", lambda: cfg)
+    active = await apikey_limiter.acquire("k")
+    request = asyncio.create_task(_post("/v1/responses", b"small-body"))
+
+    async def retained_in_memory():
+        while apikey_limiter._queued_body_bytes_total != len(b"small-body"):
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(retained_in_memory(), timeout=1)
+    assert apikey_limiter._queued_body_spool_bytes_total == 0
+    await active.release()
+    await request
+    assert apikey_limiter._queued_body_bytes_total == 0
+    assert apikey_limiter._queued_body_spool_bytes_total == 0
+    assert list(Path(tmp_path).iterdir()) == []

--- a/src/tests/test_config_backfill.py
+++ b/src/tests/test_config_backfill.py
@@ -68,6 +68,10 @@ def test_old_config_file_is_backfilled_with_new_defaults():
             assert cfg["apiKeyConcurrency"]["defaultMaxRequestBodyEvents"] == 4096
             assert cfg["apiKeyConcurrency"]["defaultMaxQueuedBodyBytesPerKey"] == 32 * 1024 * 1024
             assert cfg["apiKeyConcurrency"]["maxQueuedBodyBytes"] == 128 * 1024 * 1024
+            assert cfg["apiKeyConcurrency"]["queuedBodySpoolThresholdBytes"] == 1024 * 1024
+            assert cfg["apiKeyConcurrency"]["queuedBodySpoolDirectory"] == ""
+            assert cfg["apiKeyConcurrency"]["defaultMaxQueuedBodySpoolBytesPerKey"] == 512 * 1024 * 1024
+            assert cfg["apiKeyConcurrency"]["maxQueuedBodySpoolBytes"] == 2 * 1024 * 1024 * 1024
 
         # 旧路径保留，不删除用户原配置，方便兼容和人工核对。
         assert saved["oauth"]["providers"]["openai"]["defaultModels"] == ["legacy-model"]

--- a/src/tests/test_config_backfill.py
+++ b/src/tests/test_config_backfill.py
@@ -64,6 +64,10 @@ def test_old_config_file_is_backfilled_with_new_defaults():
             assert cfg["openaiOAuth"]["forceCodexCLI"] is False
             assert cfg["openaiOAuth"]["defaultModels"] == ["legacy-model"]
             assert cfg["openaiOAuth"]["codexUpstreamUrl"].startswith("https://chatgpt.com/")
+            assert cfg["apiKeyConcurrency"]["defaultMaxRequestBodyBytes"] == 8 * 1024 * 1024
+            assert cfg["apiKeyConcurrency"]["defaultMaxRequestBodyEvents"] == 4096
+            assert cfg["apiKeyConcurrency"]["defaultMaxQueuedBodyBytesPerKey"] == 32 * 1024 * 1024
+            assert cfg["apiKeyConcurrency"]["maxQueuedBodyBytes"] == 128 * 1024 * 1024
 
         # 旧路径保留，不删除用户原配置，方便兼容和人工核对。
         assert saved["oauth"]["providers"]["openai"]["defaultModels"] == ["legacy-model"]

--- a/src/tests/test_openai_oauth_quota.py
+++ b/src/tests/test_openai_oauth_quota.py
@@ -734,6 +734,104 @@ def test_status_menu_quota_warnings_tags_openai(m):
     print("  [PASS] status_menu _quota_warnings: openai accounts get custom emoji tag")
 
 
+def _low_wham(**openai_overrides):
+    openai = {"source": "wham_usage", "allowed": True, "limit_reached": False}
+    openai.update(openai_overrides)
+    return {
+        "five_hour": {"utilization": 1.0, "resets_at": "2099-01-01T00:01:00Z"},
+        "seven_day": {"utilization": 2.0, "resets_at": "2099-01-01T01:00:00Z"},
+        "seven_day_sonnet": {},
+        "seven_day_opus": {},
+        "extra_usage": {"is_enabled": False},
+        "openai": openai,
+    }
+
+
+def test_fresh_openai_recovery_clears_runtime_but_preserves_fresh_quota(m):
+    """A real recovery must unblock routing without deleting the new WHAM row."""
+    from src import cooldown
+
+    _setup(m)
+    email = "runtime-recovery@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    channel_key = f"oauth:{key}"
+    _add_openai(m, email)
+    m["oauth_manager"].set_disabled_by_quota(key, "2099-01-01T00:00:00Z")
+    usage = _low_wham()
+    m["state_db"].quota_save(
+        key, m["oauth_manager"].flatten_usage(usage), email=email,
+    )
+    cooldown.record_error(
+        channel_key, "gpt-test", "429", cooldown_until=m["state_db"].now_ms() + 60_000,
+    )
+    assert cooldown.is_blocked(channel_key, "gpt-test")
+
+    result = m["oauth_manager"].evaluate_and_toggle_by_usage(
+        key, usage, threshold=95, fresh=True,
+    )
+
+    assert result["action"] == "resumed", result
+    assert result["runtime_state"]["cooldown_cleared"] is True, result
+    assert not cooldown.is_blocked(channel_key, "gpt-test")
+    assert m["state_db"].quota_load(key) is not None
+    assert result["runtime_state"]["quota_cache_cleared"] is False
+    print("  [PASS] fresh OpenAI recovery clears runtime and preserves fresh quota")
+
+
+def test_non_genuine_openai_recovery_never_clears_runtime(m):
+    """Stale, unknown and still-over-limit observations must leave cooldowns intact."""
+    from src import cooldown
+
+    scenarios = [
+        ("stale", _low_wham(), False, "quota_stale_keep_disabled"),
+        ("unknown", {"openai": {"source": "wham_usage"}}, True, "quota_unknown_keep_disabled"),
+        (
+            "over",
+            {**_low_wham(), "five_hour": {"utilization": 99.0}},
+            True,
+            "still_over_quota",
+        ),
+    ]
+    for suffix, usage, fresh, expected_action in scenarios:
+        _setup(m)
+        email = f"no-runtime-clear-{suffix}@openai.test"
+        key = f"openai:{email}:acct-{email}"
+        channel_key = f"oauth:{key}"
+        _add_openai(m, email)
+        m["oauth_manager"].set_disabled_by_quota(key, "2099-01-01T00:00:00Z")
+        cooldown.record_error(
+            channel_key, "gpt-test", "429",
+            cooldown_until=m["state_db"].now_ms() + 60_000,
+        )
+
+        result = m["oauth_manager"].evaluate_and_toggle_by_usage(
+            key, usage, threshold=95, fresh=fresh,
+        )
+        assert result["action"] == expected_action, result
+        assert cooldown.is_blocked(channel_key, "gpt-test"), (suffix, result)
+        cooldown.clear(channel_key, model=None)
+    print("  [PASS] stale/unknown/over-limit observations never clear runtime")
+
+
+def test_explicit_wham_gate_keeps_quota_disabled_with_distinct_action(m):
+    for field, value in (("allowed", False), ("limit_reached", True)):
+        _setup(m)
+        email = f"wham-{field}@openai.test"
+        key = f"openai:{email}:acct-{email}"
+        _add_openai(m, email)
+        m["oauth_manager"].set_disabled_by_quota(key, "2099-01-01T00:00:00Z")
+        usage = _low_wham(**{field: value})
+
+        result = m["oauth_manager"].evaluate_and_toggle_by_usage(
+            key, usage, threshold=95, fresh=True,
+        )
+        acc = m["oauth_manager"].get_account(key)
+        assert result["action"] == "wham_limit_keep_disabled", result
+        assert result["any_over"] is True, result
+        assert acc["enabled"] is False and acc["disabled_reason"] == "quota", acc
+    print("  [PASS] explicit WHAM gate keeps quota disabled with distinct action")
+
+
 # ─── main ────────────────────────────────────────────────────────
 
 def main():
@@ -765,6 +863,9 @@ def main():
         test_delete_account_clears_codex_snapshot_throttle,
         test_on_refresh_token_openai_updates_usage_via_wham,
         test_status_menu_quota_warnings_tags_openai,
+        test_fresh_openai_recovery_clears_runtime_but_preserves_fresh_quota,
+        test_non_genuine_openai_recovery_never_clears_runtime,
+        test_explicit_wham_gate_keeps_quota_disabled_with_distinct_action,
     ]
 
     passed = 0

--- a/src/tests/test_openai_oauth_quota.py
+++ b/src/tests/test_openai_oauth_quota.py
@@ -495,8 +495,8 @@ def test_openai_quota_ignores_expired_codex_snapshot_missing_reset(m):
     print("  [PASS] OpenAI quota ignores stale Codex over-threshold snapshot without reset")
 
 
-def test_openai_quota_resume_waits_for_future_disabled_until(m):
-    """OpenAI quota-disabled accounts must not resume before disabled_until expires."""
+def test_openai_quota_resume_uses_fresh_usage_over_future_disabled_until(m):
+    """Fresh low usage must override an obsolete predicted disabled_until."""
     _setup(m)
     email = "cooldown@openai.test"
     key = f"openai:{email}:acct-{email}"
@@ -515,11 +515,11 @@ def test_openai_quota_resume_waits_for_future_disabled_until(m):
         key, wham_below_threshold, threshold=95, fresh=True,
     )
     acc = m["oauth_manager"].get_account(key)
-    assert result["action"] == "quota_cooldown_keep_disabled", result
-    assert acc.get("disabled_reason") == "quota", acc
-    assert acc.get("enabled") is False, acc
-    assert acc.get("disabled_until") == "2099-01-01T00:00:00Z", acc
-    print("  [PASS] OpenAI quota resume waits for future disabled_until")
+    assert result["action"] == "resumed", result
+    assert acc.get("disabled_reason") is None, acc
+    assert acc.get("enabled") is True, acc
+    assert acc.get("disabled_until") is None, acc
+    print("  [PASS] OpenAI quota resume trusts fresh low usage over old disabled_until")
 
 
 def test_quota_monitor_notifies_when_openai_quota_really_resumes(m):
@@ -757,7 +757,7 @@ def main():
         test_oauth_menu_refresh_usage_openai_auto_disables_over_quota,
         test_openai_quota_resume_respects_active_codex_snapshot,
         test_openai_quota_ignores_expired_codex_snapshot_missing_reset,
-        test_openai_quota_resume_waits_for_future_disabled_until,
+        test_openai_quota_resume_uses_fresh_usage_over_future_disabled_until,
         test_quota_monitor_notifies_when_openai_quota_really_resumes,
         test_openai_plan_workspace_label_disambiguates_same_email,
         test_oauth_menu_refresh_all_uses_wham_for_openai,

--- a/src/tests/test_unified_usage_and_auto_disable.py
+++ b/src/tests/test_unified_usage_and_auto_disable.py
@@ -438,7 +438,7 @@ def test_openai_cached_thirty_day_over_threshold_sets_disabled_until(m):
     print("  [PASS] openai: cached 30d over threshold carries disabled_until")
 
 
-def test_openai_quota_disabled_waits_for_disabled_until_even_with_fresh_low_usage(m):
+def test_openai_quota_disabled_resumes_from_fresh_low_usage_before_disabled_until(m):
     _setup(m)
     _add_openai(m, "future@o.io")
     ak = "openai:future@o.io:acct-123"
@@ -455,10 +455,11 @@ def test_openai_quota_disabled_waits_for_disabled_until_even_with_fresh_low_usag
     }, fresh=True)
 
     acc_after = m["oauth_manager"].get_account(ak)
-    assert result["action"] == "quota_cooldown_keep_disabled", result
-    assert acc_after.get("disabled_reason") == "quota"
-    assert acc_after["enabled"] is False
-    print("  [PASS] openai: fresh low usage waits for disabled_until cooldown")
+    assert result["action"] == "resumed", result
+    assert acc_after.get("disabled_reason") is None
+    assert acc_after["enabled"] is True
+    assert acc_after.get("disabled_until") is None
+    print("  [PASS] openai: fresh low usage overrides obsolete disabled_until")
 
 
 def test_openai_quota_disabled_keeps_waiting_on_stale_low_usage(m):
@@ -684,7 +685,7 @@ def main():
         test_openai_user_disabled_not_touched,
         test_openai_quota_disabled_not_resumed_from_unknown_usage,
         test_openai_cached_thirty_day_over_threshold_sets_disabled_until,
-        test_openai_quota_disabled_waits_for_disabled_until_even_with_fresh_low_usage,
+        test_openai_quota_disabled_resumes_from_fresh_low_usage_before_disabled_until,
         test_openai_quota_disabled_keeps_waiting_on_stale_low_usage,
         test_openai_quota_disabled_resumes_after_reset_with_fresh_low_usage,
         test_openai_official_reset_credit_clears_local_quota_after_upstream_success,


### PR DESCRIPTION
## 问题

本 PR 修复两个已在生产中复现的问题：

1. OpenAI OAuth 账号在上游额度窗口已重置后，仍可能被旧 `disabled_until` 或 model cooldown 阻止恢复。
2. API Key 并发满进入 FIFO 队列时，断开检测可能提前读取 ASGI `receive`；旧实现会丢失请求体事件，或让同一合法大请求因是否排队而得到不同结果。

## 修改

### OpenAI 额度恢复

- 只在 WHAM 用量新鲜、窗口信号有效、全部低于阈值，且未明确 `allowed=false` / `limit_reached=true` 时恢复账号。
- 恢复 quota-disabled 账号时同步清理 OAuth model cooldown，并保留刚写入的 fresh quota cache，使 scheduler 立即重新产生候选。
- stale、unknown、仍超限或明确 denied 的用量不会清理 cooldown，也不会提前恢复。
- 保留 Codex 响应头保护，避免 WHAM/Codex 窗口短暂不同步造成假恢复。

### API Key 排队请求体回放

- 严格保留 ASGI `http.request` 事件顺序、字段和 `more_body` 语义，获准后逐事件精确回放。
- 使用有界两级 spooling：小请求保留在内存，超过阈值后写入安全临时文件；FIFO deque 只保留元数据、offset 和 length，不让大 body 常驻内存。
- endpoint-aware 请求上限同时作用于 queued / non-queued 路径；合法 33 MiB 多图 + mask multipart 在两条路径均成功，超过统一上限均返回 413。
- 内存和临时磁盘分别设置单 Key/全进程聚合预算；真实单请求过大返回 413，临时聚合容量不足返回 429 + `Retry-After`。
- 公开配置键 `maxQueuedBodyBytes` 优先生效，旧 `maxQueuedBodyBytesTotal` 仅作为兼容 fallback。
- 覆盖成功、取消、超时、断连、热关闭、handoff race、spool 读写/关闭失败与应用 shutdown；所有路径均幂等清理临时文件、fd 和 accounting。
- spool 目录拒绝 symlink，目录权限 0700、临时描述符权限 0600；阻塞文件 I/O 移出 event loop。

### 配置和文档

新增并回填：

- `queuedBodySpoolThresholdBytes`
- `queuedBodySpoolDirectory`
- `defaultMaxQueuedBodySpoolBytesPerKey`
- `maxQueuedBodySpoolBytes`
- `apiKeys.<name>.limits.maxQueuedBodySpoolBytes`

原有内存预算配置继续兼容，没有被改成无界值。

## Review 修复

已逐项处理上次 review 的 5 项缺陷：

1. quota 恢复清理 OAuth cooldown；
2. 合法图片请求 queued/non-queued 入口契约一致，并增加磁盘 spooling；
3. WHAM denied 不再提前恢复；
4. 公开进程 body cap 配置键正确生效；
5. aggregate 压力改为 429，单请求超限保持 413。

Starlette `Request._receive` 私有接口仍作为已知非阻断兼容性风险保留，并新增 production middleware 集成回归；当前锁定依赖组合完整通过。

## 验证

- 全量 pytest：`1280 passed, 18 skipped`
- 专项回归：`103 passed`
- limiter / middleware / config 定向：`51 passed`
- 33 MiB 多图 + mask multipart：queued / non-queued 均 200，完整字节和 SHA-256 一致
- 50 轮 fd/resource stress：fd 前后相同，accounting 归零
- `compileall`、JSON、Compose、shell `bash -n`、`pip check`、`git diff --check`：通过
- Docker no-cache build：通过
- 隔离容器：health、UID/GID 1000、挂载写入、SIGTERM 优雅退出均通过

18 项 skip 仅为环境中不可用的外部 Claude Code fixture，不是本 PR 失败。