### PR TITLE
fix: correct OAuth proxy routing and named SOCKS5 monitoring

### DIFF
--- a/src/network_monitor.py
+++ b/src/network_monitor.py
@@ -141,6 +141,10 @@ def update_settings(mutator) -> None:
         except Exception:
             mon["intervalSeconds"] = 60
     config.update(_mut)
+    # monitor_loop intentionally skips run_once() while disabled, so it cannot
+    # perform run_once's stale-row cleanup after the master switch is turned off.
+    if not cfg().get("enabled", True):
+        state_db.network_check_delete_stale(set())
 
 
 def set_channel_enabled(channel_key: str, enabled: bool) -> None:
@@ -228,9 +232,26 @@ def _dns_check(timeout: float) -> CheckResult:
 
 
 async def _socks5_check(timeout: float) -> CheckResult:
+    targets: list[tuple[str, str]] = []
+
+    # Legacy global SOCKS5 setting.
     s5 = network.socks5_cfg()
     raw = str(s5.get("url") or "").strip()
-    if not (bool(s5.get("enabled")) and raw):
+    if bool(s5.get("enabled")) and raw:
+        targets.append(("全局", raw))
+
+    # Named proxies used by account/channel/model routing.
+    net = config.get().get("network") or {}
+    for name, proxy_cfg in (net.get("proxies") or {}).items():
+        if not isinstance(proxy_cfg, dict):
+            continue
+        if str(proxy_cfg.get("type") or "").strip().lower() != "socks5":
+            continue
+        url = str(proxy_cfg.get("url") or "").strip()
+        if url:
+            targets.append((str(name), url))
+
+    if not targets:
         return CheckResult(
             key="socks5",
             label="SOCKS5 代理",
@@ -238,29 +259,29 @@ async def _socks5_check(timeout: float) -> CheckResult:
             ok=False,
             detail="SOCKS5 未配置或未启用",
         )
-    try:
-        norm = network.normalize_socks5_url(raw)
-    except Exception as exc:
-        return CheckResult("socks5", "SOCKS5 代理", "socks5", False, f"配置错误: {exc}")
+
     t0 = time.time()
-    try:
-        if not network._is_ip_literal(norm.host) and norm.host != "localhost":
-            network.resolve_host(norm.host, timeout=timeout, use_cache=False)
-        async with httpx.AsyncClient(
-            proxy=norm.url,
-            trust_env=False,
-            http2=False,
-            timeout=httpx.Timeout(connect=timeout, read=timeout, write=timeout, pool=timeout),
-            follow_redirects=False,
-        ) as client:
-            resp = await client.get(_SOCKS5_TEST_URL, headers={"User-Agent": "parrot-network-monitor/0.1"})
-            ok = resp.status_code < 500
-            detail = "" if ok else f"HTTP {resp.status_code}"
-    except Exception as exc:
-        ok = False
-        detail = str(exc)[:180]
+    failures: list[str] = []
+    for name, url in targets:
+        try:
+            norm = network.normalize_socks5_url(url)
+            if not network._is_ip_literal(norm.host) and norm.host != "localhost":
+                network.resolve_host(norm.host, timeout=timeout, use_cache=False)
+            async with httpx.AsyncClient(
+                proxy=norm.url,
+                trust_env=False,
+                http2=False,
+                timeout=httpx.Timeout(connect=timeout, read=timeout, write=timeout, pool=timeout),
+                follow_redirects=False,
+            ) as client:
+                resp = await client.get(_SOCKS5_TEST_URL, headers={"User-Agent": "parrot-network-monitor/0.1"})
+                if resp.status_code >= 500:
+                    failures.append(f"{name}: HTTP {resp.status_code}")
+        except Exception as exc:
+            failures.append(f"{name}: {str(exc)[:120]}")
     latency = int((time.time() - t0) * 1000)
-    return CheckResult("socks5", "SOCKS5 代理", "socks5", ok, detail, latency)
+    detail = "; ".join(failures[:4])
+    return CheckResult("socks5", "SOCKS5 代理", "socks5", not failures, detail, latency)
 
 
 def _tcp_connect(host: str, port: int, timeout: float) -> int:

--- a/src/proxy/manager.py
+++ b/src/proxy/manager.py
@@ -148,9 +148,15 @@ def resolve_proxy_target(*, channel_key: str = "", model: str = "",
 
     # 1. Account/channel-level override (same priority; account wins ties)
     acct_routes = r.get("accounts") or {}
-    acct_key = account_key or channel_key
-    if acct_key and acct_key in acct_routes:
-        return acct_routes[acct_key]
+    if account_key and account_key in acct_routes:
+        return acct_routes[account_key]
+    # The Telegram account-routing UI stores OAuth channel keys (``oauth:...``),
+    # while transports also pass the provider account key (without that prefix).
+    # Account keys still win when both routes exist, but a missing account-key
+    # route must fall back to the saved channel key instead of silently going
+    # direct.
+    if channel_key and channel_key in acct_routes:
+        return acct_routes[channel_key]
 
     # 1b. Channel-level override
     ch_routes = r.get("channels") or {}

--- a/src/tests/test_m9_stats_logs.py
+++ b/src/tests/test_m9_stats_logs.py
@@ -828,13 +828,17 @@ def test_proxy_routing_priority_and_legacy_socks5(m):
             "oauth_openai": "p2",
             "models": {"gpt-x": "p1"},
             "channels": {"oauth:openai:a:old": "p2"},
-            "accounts": {"openai:a:new": "g"},
+            "accounts": {
+                "openai:a:new": "g",
+                "oauth:openai:a:fallback": "p2",
+            },
         }
     cfg.update(add_proxy_config)
     pm.init()
     assert pm.is_configured() is True
     assert pm.resolve_proxy_target(account_key="openai:a:new", channel_key="oauth:openai:a:old", model="gpt-x") == "g"
     assert pm.resolve_proxy_chain(account_key="openai:a:new", channel_key="oauth:openai:a:old", model="gpt-x") == ["p1", "direct"]
+    assert pm.resolve_proxy_target(account_key="openai:a:missing", channel_key="oauth:openai:a:fallback", model="gpt-x") == "p2"
     assert pm.resolve_proxy_target(channel_key="oauth:openai:a:old", model="gpt-x") == "p2"
     assert pm.resolve_proxy_target(model="gpt-x") == "p1"
     assert pm.resolve_proxy_target(purpose="oauth_openai") == "p2"

--- a/src/tests/test_network_monitor.py
+++ b/src/tests/test_network_monitor.py
@@ -62,6 +62,60 @@ def test_state_and_summary(m):
     assert nm.active_summary() is None
 
 
+def test_disabling_monitor_clears_persisted_banner(m):
+    st = m["state_db"]
+    nm = m["network_monitor"]
+    st.init()
+    st.network_check_save({
+        "key": "socks5",
+        "label": "SOCKS5 代理",
+        "category": "socks5",
+        "ok": False,
+        "detail": "old failure",
+        "latency_ms": None,
+        "checked_at": 1,
+    })
+    assert nm.active_summary() is not None
+    nm.update_settings(lambda mon: mon.__setitem__("enabled", False))
+    assert nm.active_summary() is None
+
+
+def test_socks5_check_recognizes_named_proxy(m, monkeypatch):
+    import asyncio
+
+    nm = m["network_monitor"]
+    cfg = m["config"]
+
+    def _set(c):
+        net = c.setdefault("network", {})
+        net["socks5"] = {"enabled": False, "url": ""}
+        net["proxies"] = {
+            "ipv6-1": {"type": "socks5", "url": "socks5://127.0.0.1:52081"},
+        }
+    cfg.update(_set)
+
+    class _Response:
+        status_code = 200
+
+    class _Client:
+        def __init__(self, **kwargs):
+            assert kwargs["proxy"] == "socks5://127.0.0.1:52081"
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def get(self, *_args, **_kwargs):
+            return _Response()
+
+    monkeypatch.setattr(nm.httpx, "AsyncClient", _Client)
+    result = asyncio.run(nm._socks5_check(5))
+    assert result.ok is True
+    assert result.detail == ""
+
+
 # ─── 新增：core 检测家族过滤 + 孤儿渠道清理 ──────────────────
 
 def _import_modules_for_family():


### PR DESCRIPTION
## 问题描述

这个 PR 修复新版命名代理/账号路由中的两个相关问题：

1. **OAuth 账号路由在主 HTTP/WS 请求中可能静默回退到 `direct`**
   - TG「账号路由」使用 OAuth channel key 保存规则，例如 `oauth:openai:<identity>`。
   - 主 transport 同时传入不带 `oauth:` 前缀的 `account_key` 和带前缀的 `channel_key`。
   - 旧解析逻辑使用 `account_key or channel_key`，只检查第一个非空键；如果 `account_key` 没有对应规则，就不会继续检查 TG 面板实际保存的 `channel_key`，最终可能落到默认直连。

2. **网络检测误报命名 SOCKS5 未配置，并在关闭监控后保留红色 banner**
   - `_socks5_check()` 只读取旧版全局 `network.socks5`，不识别账号/渠道/模型路由使用的 `network.proxies.*` 命名 SOCKS5。
   - 因此命名代理本身可用、真实模型请求也在使用时，网络检测仍会写入“SOCKS5 未配置或未启用”。
   - 关闭网络监控总开关后，`monitor_loop()` 不再调用 `run_once()`，历史失败记录无法走原有 stale cleanup，主菜单会一直显示网络异常。

## 根本原因

- 账号路由存在两种合法标识：provider account key 与 OAuth channel key；解析器只做了二选一，没有在首选键未命中时回退。
- 网络监控仍按 legacy SOCKS5 单入口设计，没有跟随命名代理子系统更新。
- 关闭 monitor 后检测循环停止，清理逻辑没有其他触发入口。

## 修复内容

- 账号路由解析改为：
  1. `account_key` 存在且命中时优先；
  2. 未命中时继续检查 `channel_key`；
  3. 两者均未命中后再走 channel/model/purpose/default。
- `_socks5_check()` 同时检测：
  - 旧版已启用的全局 SOCKS5；
  - `network.proxies` 中所有有效的命名 SOCKS5。
- 多个 SOCKS5 中任意一个失败时，在 detail 中标明代理名称和失败原因。
- 关闭网络监控总开关时立即清除持久化检测状态，避免关闭状态下继续显示历史红色 banner。
- 增加账号键回退、命名 SOCKS5 识别、关闭监控清状态的回归测试。

## 验证方式

修复前，以下组合会解析为 `direct`：

```python
account_key = "openai:a:missing"
channel_key = "oauth:openai:a:fallback"
routing.accounts[channel_key] = "proxy-1"
```

修复后会正确解析为 `proxy-1`，同时如果两种键都配置，仍保持 `account_key` 优先。

命名 SOCKS5 场景下，即使 legacy `network.socks5.enabled == false`，检测器也会读取并测试：

```json
{
  "network": {
    "proxies": {
      "ipv6-1": {
        "type": "socks5",
        "url": "socks5://127.0.0.1:52081"
      }
    }
  }
}
```

## 测试

```text
python -m pytest -q src/tests/test_m9_stats_logs.py src/tests/test_network_monitor.py
44 passed
```

另外使用真实命名 SOCKS5 和 OpenAI OAuth 请求路径验证过：账号路由命中指定代理、代理出口生效、上游返回 HTTP 200；关闭网络监控后主菜单不再渲染历史网络异常 banner。

## 风险评估

低：

- 保留原有 legacy 全局 SOCKS5 检测。
- `account_key` 的优先级没有变化，只补充未命中时的 `channel_key` 回退。
- 只有用户明确关闭网络监控总开关时才清空检测状态；监控重新开启后会重新生成状态。
