### PR TITLE
fix: isolate SQLite state writes and channel lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,13 +524,13 @@ API Key 还支持启用/停用与单 Key 请求限流：全局默认在「⚙ �
 
 > `images.cacheRetentionDays=0` 表示不按时间清理；`images.cacheMaxBytes=0` 表示不按空间清理。相对 `cachePath` 会落在数据目录下，Parrot 会阻止相对路径逃逸。
 
-**不可热加载字段**（改后需重启容器）：`listen.host` / `listen.port` / `stateDbPath` / `logDir` / `telegram.botToken` / `telegram.adminIds`。
+**不可热加载字段**（改后需重启容器）：`listen.host` / `listen.port` / `stateDbPath` / `openai.store.dbPath` / `logDir` / `telegram.botToken` / `telegram.adminIds`。
 
 ---
 
 ## 🛠 运维
 
-所有持久化数据集中在 `<安装目录>/data/`：`config.json` / `state.db` / `image_logs.db` / `logs/` / `images/` / `.anthropic_proxy_ids.json`。
+所有持久化数据集中在 `<安装目录>/data/`：`config.json` / `state.db` / `openai_response_store.db` / `image_logs.db` / `logs/` / `images/` / `.anthropic_proxy_ids.json`。
 
 ### 启动 / 停止 / 重启 / 状态（Docker Compose）
 
@@ -574,7 +574,11 @@ GPT/Grok 图片及 Grok 视频任务使用独立日志库 `data/image_logs.db`�
 
 ### 状态数据
 
-`data/state.db`（SQLite）：performance_stats / channel_errors / cache_affinities / oauth_quota_cache / openai_response_store。永久保留。
+`data/state.db`（SQLite）：performance_stats / channel_errors / cache_affinities / oauth_quota_cache 等轻量运行时状态，永久保留。
+
+`data/openai_response_store.db`（SQLite）：`previous_response_id` history 表
+`openai_response_store`。升级自旧版本时不在线迁移旧表；新库 miss 会只读回退
+`state.db`，让旧 id 在原 TTL 内继续可用。
 
 ### 配置备份
 
@@ -619,6 +623,7 @@ Parrot/
 ├── data/                        ← 运行时持久化（容器挂载点；源码模式不存在）
 │   ├── config.json              ← 唯一配置文件
 │   ├── state.db                 ← 运行时状态（永久）
+│   ├── openai_response_store.db ← previous_response_id history（TTL）
 │   ├── image_logs.db            ← 图片/视频统一多媒体任务日志（兼容旧图片历史）
 │   ├── logs/YYYY-MM.db          ← 按月分库业务日志
 │   ├── images/                  ← 图片/视频缓存（开启后，保留兼容目录名）
@@ -628,6 +633,8 @@ Parrot/
     ├── auth.py                  ← 下游 API Key 验证
     ├── errors.py                ← 标准错误响应
     ├── state_db.py              ← state.db 读写
+    ├── channel_state.py         ← 运行期渠道改名的配置/DB/内存原子协调
+    ├── sqlite_errors.py         ← SQLite 可用性错误精确分类
     ├── log_db.py                ← 按月日志库读写 + 跨月聚合（支持 family 过滤）
     ├── image_db.py              ← 兼容旧库的多媒体日志底层 + GPT 图片尝试统计
     ├── media_db.py              ← 统一图片/视频日志门面

--- a/config.example.json
+++ b/config.example.json
@@ -355,8 +355,13 @@
   "openai": {
     "store": {
       "enabled": true,
+      "dbPath": "openai_response_store.db",
       "ttlMinutes": 60,
-      "cleanupIntervalSeconds": 300
+      "cleanupIntervalSeconds": 300,
+      "cleanupBatchSize": 100,
+      "cleanupBatchBytes": 8388608,
+      "cleanupMaxBatches": 100,
+      "cleanupTimeBudgetSeconds": 10
     },
     "reasoningBridge": "passthrough",
     "autoPromptCacheKey": {

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,7 @@
 # → 若挂载了 docker.sock，把它的 gid 加到 app 的补充组（自更新 sidecar 需要）
 # → 用 gosu 降权到 app 启动。
 set -e
+umask 077
 
 DATA_DIR="${ANTHROPIC_PROXY_DATA_DIR:-/app/data}"
 DOCKER_SOCK="/var/run/docker.sock"
@@ -18,6 +19,25 @@ if [ "$(id -u)" = "0" ]; then
         chown app:app "$DATA_DIR/backups" 2>/dev/null || true
         chown app:app "$DATA_DIR/backups/"* 2>/dev/null || true
     fi
+    if [ "$(stat -c %u "$DATA_DIR/logs" 2>/dev/null)" != "1000" ]; then
+        chown app:app "$DATA_DIR/logs"
+    fi
+
+    # The response Store contains complete request/output history. Repair the
+    # default DB files before dropping privileges, but reject symlinks or
+    # non-files instead of following them as root. Custom absolute dbPath
+    # values are validated by src/openai/store.py after gosu.
+    for suffix in "" "-wal" "-shm"; do
+        store_file="$DATA_DIR/openai_response_store.db$suffix"
+        if [ -e "$store_file" ] || [ -L "$store_file" ]; then
+            if [ -L "$store_file" ] || [ ! -f "$store_file" ]; then
+                echo "OpenAI Store path is not a regular file: $store_file" >&2
+                exit 1
+            fi
+            chown app:app "$store_file"
+            chmod 600 "$store_file"
+        fi
+    done
 
     # 自更新支持：若挂载了 docker.sock，让降权后的 app 用户能访问它。
     # gosu 会重置补充组，所以必须把 sock 的 gid 注册成一个组并把 app 加进去，
@@ -39,6 +59,18 @@ if [ "$(id -u)" = "0" ]; then
         fi
     fi
 
+fi
+
+# UMask protects all newly created DB/WAL/SHM files.  The directory modes are
+# explicit so a normal source/container umask cannot make sensitive data
+# traversable by another local user.
+for private_dir in "$DATA_DIR" "$DATA_DIR/logs" "$DATA_DIR/backups"; do
+    if [ -d "$private_dir" ]; then
+        chmod 700 "$private_dir"
+    fi
+done
+
+if [ "$(id -u)" = "0" ]; then
     exec gosu app "$@"
 else
     exec "$@"

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -57,6 +57,7 @@ anthropic-proxy/
 │
 ├── config.json                       # 唯一配置文件（含所有 OAuth 账号、渠道、密钥、调参）
 ├── state.db                          # 运行时状态（perf_stats / cooldown / affinity / quota_cache）
+├── openai_response_store.db          # previous_response_id history（TTL 清理）
 ├── logs/
 │   ├── 2026-04.db                    # 当月业务日志
 │   └── 2026-05.db                    # 跨月自动切换
@@ -73,6 +74,8 @@ anthropic-proxy/
     ├── errors.py                     # Anthropic 标准错误响应
     │
     ├── state_db.py                   # state.db 的所有读写接口
+    ├── channel_state.py              # 运行期渠道改名的配置/DB/内存协调锁
+    ├── sqlite_errors.py              # SQLite 可用性错误分类（不吞编程/Schema 错误）
     ├── log_db.py                     # 按月日志库的所有读写接口
     │
     ├── fingerprint.py                # 会话亲和指纹（query / write 两个函数）

--- a/docs/02-config-schema.md
+++ b/docs/02-config-schema.md
@@ -363,7 +363,7 @@ GLM-5:glm-5, GLM-5-Turbo:glm-5-turbo ; gpt-5.4 ， gpt-5.3-codex:codex
 - 大部分字段（channels / oauthAccounts / timeouts / scoring / ...）热加载即生效
 - **不热加载**：
   - `listen.host` / `listen.port`（需重启）
-  - `stateDbPath` / `logDir`（需重启）
+  - `stateDbPath` / `logDir` / `openai.store.dbPath`（需重启）
   - `telegram.botToken` / `telegram.adminIds`（需重启）
 
 ## 2.4 TG Bot 对 config.json 的写入

--- a/docs/03-database.md
+++ b/docs/03-database.md
@@ -1,11 +1,13 @@
 # 03 — 数据库设计
 
-两套独立的 SQLite 库：
+三套独立的 SQLite 库：
 
 - **state.db** — 运行时状态，**永久保留**（性能统计、错误冷却、亲和、配额缓存）
+- **openai_response_store.db** — OpenAI `previous_response_id` history（TTL 清理）
 - **logs/YYYY-MM.db** — 业务日志，**按月分库**（请求流水、重试链、完整 body）
 
-两者均启用 WAL 模式，定时 checkpoint。
+各库均启用 WAL 模式。OpenAI history 与 `state.db` 分库，避免大表清理长时间
+占用轻量状态写锁；旧版 `state.db.openai_response_store` 只用于升级后的只读 fallback。
 
 ## 3.1 state.db Schema
 
@@ -101,9 +103,12 @@ def quota_save(email, data: dict)
 def quota_load(email) -> Row | None
 def quota_load_all() -> list[Row]
 def quota_delete(email)
+
+# coordinated live rename (performance/errors/fp/client/quota in one transaction)
+def rename_runtime_channel_state(old_channel_key, new_channel_key, ...)
 ```
 
-所有写操作由单一 `_write_lock`（threading.Lock）序列化，避免跨协程冲突。
+所有 state.db 写操作由单一 `_write_lock`（`threading.RLock`）序列化。运行期渠道改名不直接逐表调用这些接口，而由 `src/channel_state.py` 协调：配置写入和 reload、单个 SQLite 事务、scorer/cooldown/两类 affinity 内存发布共用同一生命周期锁；失败时在释放过渡 key 前恢复旧配置。这样 reload cleanup 不会把改名中的 old/new 状态误判为 stale，也不会留下只更新 DB 或只更新内存的中间态。
 
 ## 3.2 logs/YYYY-MM.db Schema
 
@@ -251,10 +256,12 @@ def retry_chain_of(request_id) -> list[Row]
 | 错误冷却 | state.db | 否 | 临时（cooldown 到期清除） |
 | 亲和绑定 | state.db | 否 | TTL 30min |
 | OAuth 配额缓存 | state.db | 否 | 实时覆盖写 |
+| OpenAI response history | openai_response_store.db | 否 | TTL 60min（默认） |
 | 请求流水 | logs/YYYY-MM.db | 是 | 默认永久保留；可由 `logRetention` 按天清理 |
 | 重试链 | logs/YYYY-MM.db | 是 | 与所属请求流水同生命周期 |
 | 请求/响应 body | logs/YYYY-MM.db | 是 | 与所属请求流水同生命周期 |
 
-原则：**状态数据需要快速读写且重启恢复**，放 state.db；**业务日志写多读少且数据量大**，按月分库便于归档与迁移。
+原则：**轻量状态数据需要快速读写且重启恢复**，放 state.db；体积可能很大的
+OpenAI history 独立分库；**业务日志写多读少且数据量大**，按月分库便于归档与迁移。
 
 当 `logRetention.mode="days"` 时，完整过期月份直接删除整库；留存临界所在月份会删除过期请求及 `request_detail` / retry / proxy / local-web 关联行，再压缩 SQLite 以实际回收磁盘空间。TG Bot 必须经两次确认后才会保存该策略并执行首次清理；之后由后台维护循环每天最多检查一次。

--- a/docs/04-channel-abstraction.md
+++ b/docs/04-channel-abstraction.md
@@ -302,8 +302,8 @@ def parse_models_input(raw: str) -> list[dict]:
 | 操作 | state.db 需要做 |
 |---|---|
 | 新增 | 无（新渠道无历史） |
-| 重命名（改 name/email） | `perf_rename_channel`、`error_rename_channel`、`affinity_rename_channel` |
-| 删除 | `perf_delete(key)`、`error_delete(key)`、`affinity_delete_by_channel(key)` |
+| 重命名（改 name/email） | 通过 `channel_state.rename_with_config()` 串行配置/reload、单个 DB 事务和内存镜像发布 |
+| 删除 | 原子发布 config + priorityOrders 删除，给在途 generation 加 tombstone，再通过各运行时模块同步删除 DB 与内存镜像 |
 | 修改 URL / Key / 模型 | 性能/错误数据可保留（但若模型列表变化，旧模型不再被调度） |
 | 禁用 | 不清数据（重新启用可复用） |
 
@@ -312,17 +312,26 @@ def parse_models_input(raw: str) -> list[dict]:
 ```python
 def _sync_state_db_with_channels():
     """config 重建后，清理 state.db 中已不存在的 channel_key 记录。"""
-    live_keys = set(_channels.keys())
-    # perf
-    for row in state_db.perf_load_all():
-        if row["channel_key"] not in live_keys:
-            state_db.perf_delete(row["channel_key"])
-    # errors
-    for row in state_db.error_load_all():
-        if row["channel_key"] not in live_keys:
-            state_db.error_delete(row["channel_key"])
+    live_keys = channel_state.include_transitions(set(_channels.keys()))
+    # 所有带内存镜像的状态都通过模块层清理。scorer 在可选 DB 写
+    # 不可用时会保留 memory-only 评分，因此 stale 集取 DB∪内存。
+    stale_perf = {r["channel_key"] for r in state_db.perf_load_all()
+                  if r["channel_key"] not in live_keys}
+    stale_perf |= {key for key in scorer.channel_keys()
+                   if key not in live_keys}
+    stale_errors = {r["channel_key"] for r in state_db.error_load_all()
+                    if r["channel_key"] not in live_keys}
+    for channel_key in stale_perf:
+        scorer.clear_stats(channel_key)
+    for channel_key in stale_errors:
+        cooldown.clear(channel_key, notify_recovered=False)
     # affinity
-    state_db.affinity_delete_stale_channels(live_keys)
+    affinity.delete_stale_channels(live_keys)
+    affinity.client_delete_stale_channels(live_keys)
 ```
 
 这样渠道删除后，state.db 不会遗留孤儿数据。
+
+运行期改名后，旧 key 会在当前进程内保留为 late-write alias：改名前已经在途的请求仍把评分、冷却和两类 affinity 写到新 key。旧 concurrency slot 按旧 key 原地排空，并冻结改名前的 `maxConcurrent`；即使 slot 先清除、稍后才有旧请求进入，也继续使用冻结值。为避免字符串 key 无法区分旧/新 generation，当前进程内禁止立刻重新创建同名旧 key；重启后不存在旧在途请求和 alias，才可安全复用。
+
+删除渠道时，目标 key 会在 config 删除前进入进程级 tombstone。旧请求的 scorer/cooldown/两类 affinity 与 OAuth quota 副作用都会被丢弃；即使没有 concurrency slot，也可能存在“已选中渠道但尚未 acquire”或关闭并发限制的旧请求，因此 tombstone 必须保留到进程重启，不能仅凭 slot 排空解除。同名渠道只能在重启后安全复用；配置删除失败则立即撤销 tombstone，不改变原渠道。

--- a/docs/04-channel-abstraction.md
+++ b/docs/04-channel-abstraction.md
@@ -334,4 +334,4 @@ def _sync_state_db_with_channels():
 
 运行期改名后，旧 key 会在当前进程内保留为 late-write alias：改名前已经在途的请求仍把评分、冷却和两类 affinity 写到新 key。旧 concurrency slot 按旧 key 原地排空，并冻结改名前的 `maxConcurrent`；即使 slot 先清除、稍后才有旧请求进入，也继续使用冻结值。为避免字符串 key 无法区分旧/新 generation，当前进程内禁止立刻重新创建同名旧 key；重启后不存在旧在途请求和 alias，才可安全复用。
 
-删除渠道时，目标 key 会在 config 删除前进入进程级 tombstone。旧请求的 scorer/cooldown/两类 affinity 与 OAuth quota 副作用都会被丢弃；即使没有 concurrency slot，也可能存在“已选中渠道但尚未 acquire”或关闭并发限制的旧请求，因此 tombstone 必须保留到进程重启，不能仅凭 slot 排空解除。同名渠道只能在重启后安全复用；配置删除失败则立即撤销 tombstone，不改变原渠道。
+删除渠道时，目标 key 会在 config 删除前进入进程级 tombstone。已经 acquire 的请求可按旧 generation 收尾，但 FIFO 中尚未 acquire 的 waiter 会被取消；它被唤醒后必须重查 tombstone，不能再使用已删除凭据。`try_acquire()` 在检查“并发限制已关闭”捷径之前也必须先拒绝 deleted generation。旧请求的 scorer/cooldown/两类 affinity 与 OAuth quota 副作用都会被丢弃；即使没有 concurrency slot，也可能存在“已选中渠道但尚未 acquire”或关闭并发限制的旧请求，因此 tombstone 必须保留到进程重启，不能仅凭 slot 排空解除。同名渠道只能在重启后安全复用；配置删除失败则立即撤销 tombstone，不改变原渠道。

--- a/docs/06-scheduler.md
+++ b/docs/06-scheduler.md
@@ -207,7 +207,7 @@ def record_success(channel_key, model, connect_ms, first_byte_ms, total_ms):
     #    满了则用"滑出旧平均成功率 + 滑入一次成功"等效 EMA
     # 3. EMA 更新 avg_connect_ms / avg_first_byte_ms / avg_total_ms（α=0.25）
     # 4. lastUpdated = now_ms()
-    # 5. state_db.perf_save
+    # 5. 由 scorer 模块在同一 mutation lifecycle 内持久化并发布内存快照
 
 def record_failure(channel_key, model, connect_ms):
     # 1. totalRequests++

--- a/docs/08-oauth-multi.md
+++ b/docs/08-oauth-multi.md
@@ -137,6 +137,13 @@ def _do_refresh_sync(email: str) -> str:
     return data["access_token"]
 ```
 
+> 当前实现以 canonical `account_key`（provider + identity/workspace）而不是裸
+> email 作为 refresh lock 和保存目标。远端请求返回后，保存阶段在
+> `config.serialized_updates()` + `channel_state.mutation_lock` 内重新核对该
+> generation：改名 generation 可通过 alias 精确转发到新 canonical key；删除、
+> 缺失或 provider 不匹配时直接丢弃结果。禁止回退到 email 匹配，因为同一邮箱
+> 可以合法同时存在 Claude 与 OpenAI 账户。
+
 ### 8.2.3 用量拉取
 
 ```python
@@ -207,6 +214,11 @@ def set_disabled_by_quota(email: str, resets_at: str):
 ```
 
 ### 8.2.5 配额监控
+
+响应头实时超限判定与 quota snapshot 持久化相互独立：先直接根据本次响应头
+执行 auto-disable，再 best-effort 写 cache。SQLite `BUSY/LOCKED/FULL/READONLY`
+不能阻止禁用；30 秒持久化节流只在写入成功后推进，写失败允许下一次响应立即
+重试。这样明确超限的账号不会因辅助缓存故障继续消耗上游额度。
 
 ```python
 async def quota_monitor_loop():

--- a/docs/08-oauth-multi.md
+++ b/docs/08-oauth-multi.md
@@ -172,18 +172,27 @@ def add_account(entry: dict):
         config.save()
     registry.rebuild_from_config()
 
-def delete_account(email: str):
-    with _account_lock:
-        cfg = config.get()
-        accounts = cfg.get("oauthAccounts", [])
-        cfg["oauthAccounts"] = [a for a in accounts if a["email"] != email]
-        config.save()
-    # 清理 state.db
-    state_db.perf_delete(f"oauth:{email}")
-    state_db.error_delete(f"oauth:{email}")
-    state_db.affinity_delete_by_channel(f"oauth:{email}")
-    state_db.quota_delete(email)
-    registry.rebuild_from_config()
+def delete_account(account_key: str):
+    # 先解析真正删除的 canonical keys；裸 email 兼容匹配多个 provider。
+    cleanup_keys = resolve_delete_targets(account_key)
+    channel_keys = {f"oauth:{key}" for key in cleanup_keys}
+    with config.serialized_updates(), channel_state.mutation_lock:
+        # 账户与 priorityOrders 在同一次 config update 中发布。
+        for channel in channel_keys:
+            channel_state.retire_deleted(channel)
+        config.update(lambda cfg: remove_accounts_and_priorities(cfg, cleanup_keys))
+        # 进程重启前保留 tombstone；不能仅凭 concurrency slot 排空判断
+        # 已无旧请求。丢弃迟到的评分、冷却、两类 affinity 和 quota 写入。
+        for channel in channel_keys:
+            for generation in channel_state.alias_sources(channel) | {channel}:
+                concurrency.retire_channel(generation, deleted_target=channel)
+        for key in cleanup_keys:
+            channel = f"oauth:{key}"
+            scorer.clear_stats(channel)
+            cooldown.clear(channel, notify_recovered=False, resolve_alias=False)
+            affinity.delete_by_channel(channel)
+            affinity.client_delete_by_channel(channel)
+            state_db.quota_delete(key)
 
 def set_enabled(email: str, enabled: bool, reason: str | None = None):
     """

--- a/docs/openai/02-config-schema.md
+++ b/docs/openai/02-config-schema.md
@@ -10,8 +10,13 @@
     // previous_response_id 本地 store 相关（见 05）
     "store": {
       "enabled": true,              // 关闭则下游 responses 调 chat 上游时拒绝带 previous_response_id 的请求
+      "dbPath": "openai_response_store.db", // 相对路径以 DATA_DIR 为根；必须与 stateDbPath 不同
       "ttlMinutes": 60,             // 记录 TTL
-      "cleanupIntervalSeconds": 300 // 后台清理周期
+      "cleanupIntervalSeconds": 300, // 后台清理周期
+      "cleanupBatchSize": 100,      // 单个短事务候选行数上限
+      "cleanupBatchBytes": 8388608, // 单个事务 payload 上限；超大单行仍会单独删除
+      "cleanupMaxBatches": 100,     // 每轮清理最多提交批次数
+      "cleanupTimeBudgetSeconds": 10 // 每轮清理时间预算
     },
     // reasoning 跨协议桥接（见 06）
     "reasoningBridge": "passthrough",  // "passthrough" | "drop"
@@ -79,9 +84,10 @@
 
 ## 2.5 不可热加载的字段
 
-与现状一致：`listen.*` / `stateDbPath` / `logDir` / `telegram.*`。
+`listen.*` / `stateDbPath` / `openai.store.dbPath` / `logDir` / `telegram.*`
+需重启。其余 `openai.*` 字段支持热加载。
 
-新增字段 `openai.*` / `channels[].protocol` / `apiKeys[].allowedProtocols` **全部支持热加载**（`config.update` 触发 `registry.rebuild_from_config`，后者按新 `protocol` 重新实例化渠道）。
+除 `openai.store.dbPath` 外，新增的 `openai.*` / `channels[].protocol` / `apiKeys[].allowedProtocols` 支持热加载（`config.update` 触发 `registry.rebuild_from_config`，后者按新 `protocol` 重新实例化渠道）。
 
 ## 2.6 默认值清单（加到 `config.DEFAULT_CONFIG`）
 
@@ -89,8 +95,13 @@
 DEFAULT_CONFIG["openai"] = {
     "store": {
         "enabled": True,
+        "dbPath": "openai_response_store.db",
         "ttlMinutes": 60,
         "cleanupIntervalSeconds": 300,
+        "cleanupBatchSize": 100,
+        "cleanupBatchBytes": 8388608,
+        "cleanupMaxBatches": 100,
+        "cleanupTimeBudgetSeconds": 10,
     },
     "reasoningBridge": "passthrough",
     "translation": {
@@ -126,7 +137,10 @@ DEFAULT_CONFIG["openai"] = {
       "enabled": true }
   ],
   "openai": {
-    "store": { "enabled": true, "ttlMinutes": 60, "cleanupIntervalSeconds": 300 },
+    "store": { "enabled": true, "dbPath": "openai_response_store.db", "ttlMinutes": 60,
+               "cleanupIntervalSeconds": 300, "cleanupBatchSize": 100,
+               "cleanupBatchBytes": 8388608, "cleanupMaxBatches": 100,
+               "cleanupTimeBudgetSeconds": 10 },
     "reasoningBridge": "passthrough",
     "translation": { "enabled": true, "rejectOnBuiltinTools": true, "rejectOnMultiCandidate": true }
   }

--- a/docs/openai/05-store.md
+++ b/docs/openai/05-store.md
@@ -34,7 +34,9 @@ CREATE INDEX IF NOT EXISTS idx_resp_store_key     ON openai_response_store(api_k
 升级不会在线搬迁大表，也不会再写 legacy `state.db`。新库查不到 id 时，
 Store 会只读查询旧 `state.db.openai_response_store`；因此升级前创建的
 `previous_response_id` 可继续使用到原 TTL 到期。旧库不存在或没有该表时
-按普通 miss 处理；新库记录始终优先，可自然覆盖同 id 的旧记录。
+按普通 miss 处理；同一 API Key 的新库记录优先，可自然覆盖同 id 的旧记录。
+如果另一个 Key 已在新库或 legacy 表中拥有同一个 `response_id`，写入会明确
+失败，不能覆盖原 owner 的 history。
 
 ## 5.2 Store 接口
 
@@ -57,6 +59,7 @@ class StoredResponse:
 class ResponseNotFound(Exception): ...
 class ResponseExpired(Exception): ...
 class ResponseForbidden(Exception): ...   # key 不一致
+class ResponseIdConflict(Exception): ...  # 写入 id 已属于另一个 key
 
 def init() -> None: ...
 
@@ -144,9 +147,17 @@ def expand_history(response_id, *, api_key_name, max_depth=50):
 
 - 独立库使用自己的 `_write_lock`（RLock）与 thread-local 连接，不和 `state.db` 写锁耦合
 - 读取无锁（SQLite WAL 模式已够）
+- `response_id` 冲突更新带 owner 条件；只有原 `api_key_name` 才能更新同 id，
+  另一个 Key 会得到 `ResponseIdConflict`，不会发生 `INSERT OR REPLACE` 跨租户覆盖
 - legacy `state.db` 仅以 SQLite `mode=ro` 打开，且只在新库 miss 时查询
 - `save()` 失败会 rollback 后重新抛出，由协议收尾层限频告警，不把半开事务留在线程连接中
 - `api_key_name` 字段用来防误读：Key A 看不到 Key B 的 response_id（即使碰撞）
+- 默认容器入口使用 `umask 077` 并把 data 目录固定为 `0700`；Store 目录必须
+  由当前进程 uid 持有且不可被 group/world 写入（源码部署兼容 owner 持有的
+  `0755` 仓库根目录），数据库、`-wal`、`-shm` 必须是同 uid 的普通文件且
+  mode 不宽于 `0600`。新数据库用显式 `0600` 原子预创建，不依赖调用方
+  umask；已有路径若是 symlink、外部 owner 或文件权限过宽，启动会 fail closed
+- WAL 配置 `journal_size_limit=64 MiB`，避免突发写入后长期保留无界高水位
 
 升级后 legacy 表不再由在线清理任务写入或删除。记录超过 TTL 后会立即变为
 不可读，但物理页面仍留在旧 `state.db`。如需回收，应至少等待一个完整 TTL，

--- a/docs/openai/05-store.md
+++ b/docs/openai/05-store.md
@@ -9,7 +9,11 @@ Responses API 是**有状态**的：客户端可以用 `previous_response_id` �
 
 实现：`src/openai/store.py`。
 
-## 5.1 存储表（挂在既有 `state.db` 里，命名空间隔离）
+## 5.1 存储表（独立 SQLite）
+
+默认写入 `DATA_DIR/openai_response_store.db`（可用
+`openai.store.dbPath` 指定；相对路径仍以 `DATA_DIR` 为根）。它必须与
+`stateDbPath` 不同，避免大 history 表的写入和清理阻塞评分、冷却与亲和状态。
 
 ```sql
 CREATE TABLE IF NOT EXISTS openai_response_store (
@@ -27,9 +31,10 @@ CREATE INDEX IF NOT EXISTS idx_resp_store_expires ON openai_response_store(expir
 CREATE INDEX IF NOT EXISTS idx_resp_store_key     ON openai_response_store(api_key_name);
 ```
 
-为什么挂 `state.db` 而不是新开一个库：
-- 状态数据库的运维逻辑（WAL checkpoint、备份）已经成熟
-- openai-专属的表名前缀隔离，不污染 Anthropic 表
+升级不会在线搬迁大表，也不会再写 legacy `state.db`。新库查不到 id 时，
+Store 会只读查询旧 `state.db.openai_response_store`；因此升级前创建的
+`previous_response_id` 可继续使用到原 TTL 到期。旧库不存在或没有该表时
+按普通 miss 处理；新库记录始终优先，可自然覆盖同 id 的旧记录。
 
 ## 5.2 Store 接口
 
@@ -67,8 +72,12 @@ def expand_history(response_id: str, *, api_key_name: str) -> list[dict]:
     """返回按链条展开的 items：最老的在前，`input_items + output_items` 拼起来。
        内部递归沿 parent_id 向上，直到 None 或命中循环（防御）。"""
 
-def cleanup_expired(now: float | None = None) -> int: ...
-"""返回清理数。每次 ~几十 ms。"""
+def cleanup_expired(now: float | None = None, *,
+                    batch_size: int | None = None,
+                    max_batches: int | None = None,
+                    batch_bytes: int | None = None,
+                    time_budget_seconds: float | None = None) -> int: ...
+"""返回清理数；每批独立短事务，并受行数、payload 字节数、批数和时间预算限制。"""
 ```
 
 ## 5.3 链展开算法
@@ -115,19 +124,34 @@ def expand_history(response_id, *, api_key_name, max_depth=50):
 | `ResponseNotFound` | 404 | `{error:{message:"response not found", type:"not_found_error"}}` |
 | `ResponseExpired` | 410 | `{error:{message:"response expired", ...}}` |
 | `ResponseForbidden` | 403 | `{error:{message:"response does not belong to this api key",...}}` |
+| legacy/new Store 暂时不可用（BUSY/LOCKED/I/O/FULL） | 503 | `server_error`；不得伪装成 404 |
 
 ## 5.6 TTL 与清理
 
 - 默认 `openai.store.ttlMinutes = 60`
 - 每次 save 时写 `expires_at = now + ttl`
 - 后台 `cleanup_expired` 循环每 `openai.store.cleanupIntervalSeconds`（默认 300）跑一次
+- 每批候选最多 `cleanupBatchSize`（默认 100）条，并受
+  `cleanupBatchBytes`（默认 8 MiB）约束；单条超大 history 仍会独立删除，
+  避免单次事务制造超大 WAL
+- 每批立即提交并释放 Store 写锁，让并发 save 有机会插队
+- 每轮最多提交 `cleanupMaxBatches`（默认 100）批，并受
+  `cleanupTimeBudgetSeconds`（默认 10 秒）约束；默认每轮最多可追赶
+  10,000 条小记录，积压由后续轮次继续处理
 - 清理任务挂在 `server.py` lifespan 的 `_background_tasks`（见 [07-anthropic-touchpoints.md](./07-anthropic-touchpoints.md)）
 
 ## 5.7 并发与隔离
 
-- 写入用 `state_db` 现有的 `_write_lock`（RLock）复用
+- 独立库使用自己的 `_write_lock`（RLock）与 thread-local 连接，不和 `state.db` 写锁耦合
 - 读取无锁（SQLite WAL 模式已够）
+- legacy `state.db` 仅以 SQLite `mode=ro` 打开，且只在新库 miss 时查询
+- `save()` 失败会 rollback 后重新抛出，由协议收尾层限频告警，不把半开事务留在线程连接中
 - `api_key_name` 字段用来防误读：Key A 看不到 Key B 的 response_id（即使碰撞）
+
+升级后 legacy 表不再由在线清理任务写入或删除。记录超过 TTL 后会立即变为
+不可读，但物理页面仍留在旧 `state.db`。如需回收，应至少等待一个完整 TTL，
+在维护窗口停止 Parrot、备份并校验旧库后离线删除 legacy 表/记录；不得在运行中
+执行 `VACUUM` 或大事务清理。
 
 ## 5.8 `conversation` 资源
 

--- a/docs/openai/08-openai-tree.md
+++ b/docs/openai/08-openai-tree.md
@@ -128,7 +128,8 @@ async def handle(request: Request, *, ingress_protocol: str) -> Response:
 
 ## 8.3 `store.py` （~180 行）
 
-见 [05-store.md](./05-store.md)。挂在 state.db 上的一张表 + CRUD + 后台清理 loop。
+见 [05-store.md](./05-store.md)。使用独立 `openai_response_store.db`，提供 CRUD、
+旧 `state.db` 只读 fallback 与有界后台清理 loop。
 
 ## 8.4 `channel/api_channel.py` （~200 行）
 

--- a/server.py
+++ b/server.py
@@ -237,7 +237,7 @@ async def lifespan(app: FastAPI):
     from src.openai.channel.registration import register_factories as _openai_register_factories
     _openai_register_factories()
 
-    # OpenAI previous_response_id Store（挂在同一张 state.db，独立表）
+    # OpenAI previous_response_id Store（独立 SQLite；旧 state.db 只读兼容）
     from src.openai import store as openai_store
     openai_store.init()
 

--- a/src/affinity.py
+++ b/src/affinity.py
@@ -4,39 +4,79 @@
   - 内存：快速查找
   - state.db：重启恢复
 
-首次调用 init() 从 state.db 全量加载到内存。之后所有写操作双写。
+首次调用 init() 从 state.db 全量加载到内存。成功路径的 upsert 先持久化再
+发布到内存；SQLite 可用性失败时跳过内存更新，避免进程状态与重启状态分叉。
 过期清理由后台 loop 调用 cleanup()。
 """
 
 from __future__ import annotations
 
+import logging
+import sqlite3
 import threading
-from typing import Optional
+import time
+from typing import Iterable, Optional
 
-from . import config, state_db
+from . import channel_state, config, state_db
+from .sqlite_errors import is_availability_error
 
 
 _lock = threading.Lock()
+# Serialize DB commit + matching memory publication without blocking read-only get().
+# state_db already serializes physical writes globally; this lock additionally
+# preserves the order observed by this module's in-memory mirror.
+_mutation_lock = channel_state.mutation_lock
 _entries: dict[str, dict] = {}  # fingerprint -> {channel_key, model, last_used}
 _initialized = False
+_logger = logging.getLogger(__name__)
+_warning_lock = threading.Lock()
+_last_warning_at: dict[str, float] = {}
+_WARNING_INTERVAL_SECONDS = 60.0
+
+
+def _persist_optional(name: str, effect) -> bool:
+    """Persist optional affinity state without corrupting in-memory state.
+
+    Availability failures skip the matching memory mutation so both layers
+    remain consistent. Programming/schema/constraint failures stay visible.
+    """
+    try:
+        with state_db.optional_write_timeout():
+            effect()
+        return True
+    except sqlite3.Error as exc:
+        if not is_availability_error(exc):
+            raise
+        now = time.monotonic()
+        with _warning_lock:
+            last = _last_warning_at.get(name, 0.0)
+            should_warn = not last or now - last >= _WARNING_INTERVAL_SECONDS
+            if should_warn:
+                _last_warning_at[name] = now
+        if should_warn:
+            _logger.warning(
+                "affinity persistence %s failed; memory update skipped: %s", name, exc,
+            )
+        return False
 
 
 def init() -> None:
     """从 state.db 加载全部亲和记录到内存。"""
     global _initialized
-    if _initialized:
-        return
-    rows = state_db.affinity_load_all()
-    with _lock:
-        _entries.clear()
-        for row in rows:
-            _entries[row["fingerprint"]] = {
-                "channel_key": row["channel_key"],
-                "model": row["model"],
-                "last_used": row["last_used"],
-                "prompt_cache_key": row.get("prompt_cache_key"),
-            }
-    _initialized = True
+    with _mutation_lock:
+        if _initialized:
+            return
+        rows = state_db.affinity_load_all()
+        with _lock:
+            _entries.clear()
+            for row in rows:
+                _entries[row["fingerprint"]] = {
+                    "channel_key": row["channel_key"],
+                    "model": row["model"],
+                    "last_used": row["last_used"],
+                    "prompt_cache_key": row.get("prompt_cache_key"),
+                }
+        _initialized = True
     print(f"[affinity] loaded {len(rows)} entries from state.db")
 
 
@@ -55,7 +95,22 @@ def get(fingerprint: Optional[str]) -> Optional[dict]:
         return None
     now = state_db.now_ms()
     if now - entry["last_used"] > _ttl_ms():
-        delete(fingerprint)
+        # Re-check while excluding mutations.  An upsert may have refreshed the
+        # same fingerprint after the optimistic read above; never delete that
+        # freshly published binding based on the stale snapshot.
+        with _mutation_lock:
+            with _lock:
+                current = _entries.get(fingerprint)
+            if current is None:
+                return None
+            if now - current["last_used"] <= _ttl_ms():
+                return dict(current)
+            if _persist_optional(
+                "delete_expired", lambda: state_db.affinity_delete(fingerprint),
+            ):
+                with _lock:
+                    if _entries.get(fingerprint) is current:
+                        _entries.pop(fingerprint, None)
         return None
     return dict(entry)
 
@@ -70,22 +125,30 @@ def upsert(fingerprint: Optional[str], channel_key: str, model: str,
     if not fingerprint:
         return
     now = state_db.now_ms()
-    with _lock:
-        prev = _entries.get(fingerprint) or {}
-        entry = {
-            "channel_key": channel_key,
-            "model": model,
-            "last_used": now,
-            "prompt_cache_key": (
-                prompt_cache_key if prompt_cache_key is not None
-                else prev.get("prompt_cache_key")
+    with _mutation_lock:
+        channel_key = channel_state.resolve(channel_key)
+        if channel_state.is_deleted(channel_key):
+            return
+        if not _persist_optional(
+            "upsert",
+            lambda: state_db.affinity_upsert(
+                fingerprint, channel_key, model, last_used=now,
+                prompt_cache_key=prompt_cache_key,
             ),
-        }
-        _entries[fingerprint] = entry
-    state_db.affinity_upsert(
-        fingerprint, channel_key, model, last_used=now,
-        prompt_cache_key=prompt_cache_key,
-    )
+        ):
+            return
+        with _lock:
+            prev = _entries.get(fingerprint) or {}
+            entry = {
+                "channel_key": channel_key,
+                "model": model,
+                "last_used": now,
+                "prompt_cache_key": (
+                    prompt_cache_key if prompt_cache_key is not None
+                    else prev.get("prompt_cache_key")
+                ),
+            }
+            _entries[fingerprint] = entry
 
 
 def touch(fingerprint: Optional[str]) -> None:
@@ -93,36 +156,71 @@ def touch(fingerprint: Optional[str]) -> None:
     if not fingerprint:
         return
     now = state_db.now_ms()
-    changed = False
-    with _lock:
-        entry = _entries.get(fingerprint)
-        if entry is not None:
-            entry["last_used"] = now
-            changed = True
-    if changed:
-        state_db.affinity_touch(fingerprint, last_used=now)
+    with _mutation_lock:
+        with _lock:
+            exists = fingerprint in _entries
+        if not exists:
+            return
+        if not _persist_optional(
+            "touch",
+            lambda: state_db.affinity_touch(fingerprint, last_used=now),
+        ):
+            return
+        with _lock:
+            entry = _entries.get(fingerprint)
+            if entry is not None:
+                entry["last_used"] = now
 
 
 def delete(fingerprint: Optional[str]) -> None:
     if not fingerprint:
         return
-    with _lock:
-        _entries.pop(fingerprint, None)
-    state_db.affinity_delete(fingerprint)
+    with _mutation_lock:
+        if not _persist_optional(
+            "delete", lambda: state_db.affinity_delete(fingerprint),
+        ):
+            return
+        with _lock:
+            _entries.pop(fingerprint, None)
 
 
 def delete_all() -> None:
-    with _lock:
-        _entries.clear()
-    state_db.affinity_delete(None)
+    with _mutation_lock:
+        if not _persist_optional("delete_all", lambda: state_db.affinity_delete(None)):
+            return
+        with _lock:
+            _entries.clear()
 
 
 def delete_by_channel(channel_key: str) -> None:
-    with _lock:
-        keys = [k for k, v in _entries.items() if v["channel_key"] == channel_key]
-        for k in keys:
-            _entries.pop(k, None)
-    state_db.affinity_delete_by_channel(channel_key)
+    with _mutation_lock:
+        if not _persist_optional(
+            "delete_by_channel",
+            lambda: state_db.affinity_delete_by_channel(channel_key),
+        ):
+            return
+        with _lock:
+            keys = [k for k, v in _entries.items() if v["channel_key"] == channel_key]
+            for k in keys:
+                _entries.pop(k, None)
+
+
+def delete_stale_channels(live_keys: Iterable[str]) -> int:
+    live_set = set(live_keys)
+    with _mutation_lock:
+        if not _persist_optional(
+            "delete_stale_channels",
+            lambda: state_db.affinity_delete_stale_channels(live_set),
+        ):
+            return 0
+        with _lock:
+            stale = [
+                key for key, value in _entries.items()
+                if value["channel_key"] not in live_set
+            ]
+            for key in stale:
+                _entries.pop(key, None)
+        return len(stale)
 
 
 def delete_by_protocol(protocol_family: str) -> int:
@@ -139,23 +237,39 @@ def delete_by_protocol(protocol_family: str) -> int:
     }
     if not keys:
         return 0
-    with _lock:
-        targets = [k for k, v in _entries.items() if v["channel_key"] in keys]
-        for k in targets:
-            _entries.pop(k, None)
-    for ch_key in keys:
-        state_db.affinity_delete_by_channel(ch_key)
-    return len(targets)
+    removed = 0
+    with _mutation_lock:
+        for ch_key in keys:
+            if not _persist_optional(
+                "delete_by_protocol",
+                lambda ch_key=ch_key: state_db.affinity_delete_by_channel(ch_key),
+            ):
+                continue
+            with _lock:
+                targets = [
+                    k for k, v in _entries.items()
+                    if v["channel_key"] == ch_key
+                ]
+                for key in targets:
+                    _entries.pop(key, None)
+                removed += len(targets)
+    return removed
 
 
-def rename_channel(old_key: str, new_key: str) -> None:
+def rename_channel(old_key: str, new_key: str, *, persist: bool = True) -> bool:
     if old_key == new_key:
-        return
-    with _lock:
-        for entry in _entries.values():
-            if entry["channel_key"] == old_key:
-                entry["channel_key"] = new_key
-    state_db.affinity_rename_channel(old_key, new_key)
+        return True
+    with _mutation_lock:
+        if persist and not _persist_optional(
+            "rename_channel",
+            lambda: state_db.affinity_rename_channel(old_key, new_key),
+        ):
+            return False
+        with _lock:
+            for entry in _entries.values():
+                if entry["channel_key"] == old_key:
+                    entry["channel_key"] = new_key
+        return True
 
 
 def cleanup(ttl_ms: Optional[int] = None) -> int:
@@ -163,13 +277,17 @@ def cleanup(ttl_ms: Optional[int] = None) -> int:
     if ttl_ms is None:
         ttl_ms = _ttl_ms()
     cutoff = state_db.now_ms() - ttl_ms
-    with _lock:
-        stale = [k for k, v in _entries.items() if v["last_used"] < cutoff]
-        for k in stale:
-            _entries.pop(k, None)
-    # state.db 单独清（避免每条都调一次 DELETE）
-    state_db.affinity_cleanup(ttl_ms)
-    return len(stale)
+    with _mutation_lock:
+        if not _persist_optional(
+            "cleanup",
+            lambda: state_db.affinity_cleanup(ttl_ms, cutoff_ms=cutoff),
+        ):
+            return 0
+        with _lock:
+            stale = [k for k, v in _entries.items() if v["last_used"] < cutoff]
+            for k in stale:
+                _entries.pop(k, None)
+        return len(stale)
 
 
 def count() -> int:
@@ -195,6 +313,7 @@ def snapshot() -> dict[str, dict]:
 # ═══════════════════════════════════════════════════════════════
 
 _client_lock = threading.Lock()
+_client_mutation_lock = channel_state.mutation_lock
 _client_entries: dict[str, dict] = {}  # client_key -> {channel_key, model, last_used}
 _client_initialized = False
 
@@ -207,18 +326,19 @@ def _client_ttl_ms() -> int:
 def client_init() -> None:
     """从 state.db 加载全部 client 亲和记录到内存。"""
     global _client_initialized
-    if _client_initialized:
-        return
-    rows = state_db.client_affinity_load_all()
-    with _client_lock:
-        _client_entries.clear()
-        for row in rows:
-            _client_entries[row["client_key"]] = {
-                "channel_key": row["channel_key"],
-                "model": row["model"],
-                "last_used": row["last_used"],
-            }
-    _client_initialized = True
+    with _client_mutation_lock:
+        if _client_initialized:
+            return
+        rows = state_db.client_affinity_load_all()
+        with _client_lock:
+            _client_entries.clear()
+            for row in rows:
+                _client_entries[row["client_key"]] = {
+                    "channel_key": row["channel_key"],
+                    "model": row["model"],
+                    "last_used": row["last_used"],
+                }
+        _client_initialized = True
     print(f"[affinity] loaded {len(rows)} client entries from state.db")
 
 
@@ -237,7 +357,20 @@ def client_get(client_key: str) -> Optional[dict]:
         return None
     now = state_db.now_ms()
     if now - entry["last_used"] > _client_ttl_ms():
-        client_delete(client_key)
+        with _client_mutation_lock:
+            with _client_lock:
+                current = _client_entries.get(client_key)
+            if current is None:
+                return None
+            if now - current["last_used"] <= _client_ttl_ms():
+                return dict(current)
+            if _persist_optional(
+                "client_delete_expired",
+                lambda: state_db.client_affinity_delete(client_key),
+            ):
+                with _client_lock:
+                    if _client_entries.get(client_key) is current:
+                        _client_entries.pop(client_key, None)
         return None
     return dict(entry)
 
@@ -247,35 +380,79 @@ def client_upsert(client_key: str, channel_key: str, model: str) -> None:
     if not client_key:
         return
     now = state_db.now_ms()
-    with _client_lock:
-        _client_entries[client_key] = {
-            "channel_key": channel_key,
-            "model": model,
-            "last_used": now,
-        }
-    state_db.client_affinity_upsert(client_key, channel_key, model, last_used=now)
+    with _client_mutation_lock:
+        channel_key = channel_state.resolve(channel_key)
+        if channel_state.is_deleted(channel_key):
+            return
+        if not _persist_optional(
+            "client_upsert",
+            lambda: state_db.client_affinity_upsert(
+                client_key, channel_key, model, last_used=now,
+            ),
+        ):
+            return
+        with _client_lock:
+            _client_entries[client_key] = {
+                "channel_key": channel_key,
+                "model": model,
+                "last_used": now,
+            }
 
 
 def client_delete(client_key: str) -> None:
     if not client_key:
         return
-    with _client_lock:
-        _client_entries.pop(client_key, None)
-    state_db.client_affinity_delete(client_key)
+    with _client_mutation_lock:
+        if not _persist_optional(
+            "client_delete", lambda: state_db.client_affinity_delete(client_key),
+        ):
+            return
+        with _client_lock:
+            _client_entries.pop(client_key, None)
 
 
 def client_delete_all() -> None:
-    with _client_lock:
-        _client_entries.clear()
-    state_db.client_affinity_delete(None)
+    with _client_mutation_lock:
+        if not _persist_optional(
+            "client_delete_all", lambda: state_db.client_affinity_delete(None),
+        ):
+            return
+        with _client_lock:
+            _client_entries.clear()
 
 
 def client_delete_by_channel(channel_key: str) -> None:
-    with _client_lock:
-        keys = [k for k, v in _client_entries.items() if v["channel_key"] == channel_key]
-        for k in keys:
-            _client_entries.pop(k, None)
-    state_db.client_affinity_delete_by_channel(channel_key)
+    with _client_mutation_lock:
+        if not _persist_optional(
+            "client_delete_by_channel",
+            lambda: state_db.client_affinity_delete_by_channel(channel_key),
+        ):
+            return
+        with _client_lock:
+            keys = [
+                k for k, v in _client_entries.items()
+                if v["channel_key"] == channel_key
+            ]
+            for key in keys:
+                _client_entries.pop(key, None)
+
+
+def client_delete_stale_channels(live_keys: Iterable[str]) -> int:
+    live_set = set(live_keys)
+    with _client_mutation_lock:
+        if not _persist_optional(
+            "client_delete_stale_channels",
+            lambda: state_db.client_affinity_delete_stale_channels(live_set),
+        ):
+            return 0
+        with _client_lock:
+            stale = [
+                key for key, value in _client_entries.items()
+                if value["channel_key"] not in live_set
+            ]
+            for key in stale:
+                _client_entries.pop(key, None)
+        return len(stale)
 
 
 def client_delete_by_protocol(protocol_family: str) -> int:
@@ -288,35 +465,56 @@ def client_delete_by_protocol(protocol_family: str) -> int:
     }
     if not keys:
         return 0
-    with _client_lock:
-        targets = [k for k, v in _client_entries.items() if v["channel_key"] in keys]
-        for k in targets:
-            _client_entries.pop(k, None)
-    for ch_key in keys:
-        state_db.client_affinity_delete_by_channel(ch_key)
-    return len(targets)
+    removed = 0
+    with _client_mutation_lock:
+        for ch_key in keys:
+            if not _persist_optional(
+                "client_delete_by_protocol",
+                lambda ch_key=ch_key: state_db.client_affinity_delete_by_channel(ch_key),
+            ):
+                continue
+            with _client_lock:
+                targets = [
+                    k for k, v in _client_entries.items()
+                    if v["channel_key"] == ch_key
+                ]
+                for key in targets:
+                    _client_entries.pop(key, None)
+                removed += len(targets)
+    return removed
 
 
-def client_rename_channel(old_key: str, new_key: str) -> None:
+def client_rename_channel(old_key: str, new_key: str, *, persist: bool = True) -> bool:
     if old_key == new_key:
-        return
-    with _client_lock:
-        for entry in _client_entries.values():
-            if entry["channel_key"] == old_key:
-                entry["channel_key"] = new_key
-    state_db.client_affinity_rename_channel(old_key, new_key)
+        return True
+    with _client_mutation_lock:
+        if persist and not _persist_optional(
+            "client_rename_channel",
+            lambda: state_db.client_affinity_rename_channel(old_key, new_key),
+        ):
+            return False
+        with _client_lock:
+            for entry in _client_entries.values():
+                if entry["channel_key"] == old_key:
+                    entry["channel_key"] = new_key
+        return True
 
 
 def client_cleanup(ttl_ms: Optional[int] = None) -> int:
     if ttl_ms is None:
         ttl_ms = _client_ttl_ms()
     cutoff = state_db.now_ms() - ttl_ms
-    with _client_lock:
-        stale = [k for k, v in _client_entries.items() if v["last_used"] < cutoff]
-        for k in stale:
-            _client_entries.pop(k, None)
-    state_db.client_affinity_cleanup(ttl_ms)
-    return len(stale)
+    with _client_mutation_lock:
+        if not _persist_optional(
+            "client_cleanup",
+            lambda: state_db.client_affinity_cleanup(ttl_ms, cutoff_ms=cutoff),
+        ):
+            return 0
+        with _client_lock:
+            stale = [k for k, v in _client_entries.items() if v["last_used"] < cutoff]
+            for k in stale:
+                _client_entries.pop(k, None)
+        return len(stale)
 
 
 def client_count() -> int:

--- a/src/channel/registry.py
+++ b/src/channel/registry.py
@@ -5,10 +5,11 @@
 
 from __future__ import annotations
 
+import copy
 import threading
 from typing import Optional
 
-from .. import config, cooldown, load_balancing, state_db
+from .. import affinity, channel_state, config, cooldown, load_balancing, scorer, state_db
 from ..oauth import normalize_provider as _normalize_provider
 from .api_channel import ApiChannel
 from .base import Channel
@@ -23,7 +24,7 @@ from .url_utils import (
 )
 
 
-_lock = threading.Lock()
+_lock = channel_state.mutation_lock
 _channels: dict[str, Channel] = {}
 
 # 按 protocol 名分派到 Channel 子类的 factory。未注册的 protocol 回落到 ApiChannel
@@ -39,6 +40,13 @@ def register_channel_factory(protocol: str, cls: type[Channel]) -> None:
 
 
 def rebuild_from_config() -> None:
+    # Snapshot, generation validation, publication, and stale cleanup are one
+    # lifecycle. A paused old rebuild must not overwrite a completed rename.
+    with channel_state.mutation_lock:
+        _rebuild_from_config_locked()
+
+
+def _rebuild_from_config_locked() -> None:
     """根据当前 config 重建所有渠道实例。"""
     cfg = config.get()
     default_models = list(cfg.get("oauthDefaultModels") or [])
@@ -54,6 +62,9 @@ def rebuild_from_config() -> None:
                 ch = XAIOAuthChannel(acc)
             else:
                 ch = OAuthChannel(acc, default_models)
+            if channel_state.is_retired_source(ch.key):
+                print(f"[registry] skip reused retired channel key: {ch.key}")
+                continue
             new[ch.key] = ch
         except Exception as exc:
             print(f"[registry] skip invalid OAuth account (provider={provider}): {exc}")
@@ -63,6 +74,9 @@ def rebuild_from_config() -> None:
         cls = _channel_factories.get(proto, ApiChannel)
         try:
             ch = cls(entry)
+            if channel_state.is_retired_source(ch.key):
+                print(f"[registry] skip reused retired channel key: {ch.key}")
+                continue
             new[ch.key] = ch
         except Exception as exc:
             print(f"[registry] skip invalid API channel (protocol={proto}): {exc}")
@@ -75,68 +89,84 @@ def rebuild_from_config() -> None:
 
 
 def _sync_state_db_with_channels() -> None:
-    """清理 state.db 中不再存在的 channel_key。"""
-    with _lock:
-        live_keys = set(_channels.keys())
+    """清理 state.db 和内存镜像中不再存在的 channel_key。"""
+    with channel_state.mutation_lock:
+        with _lock:
+            live_keys = channel_state.include_transitions(set(_channels.keys()))
 
-    for row in state_db.perf_load_all():
-        if row["channel_key"] not in live_keys:
-            state_db.perf_delete(row["channel_key"])
+        stale_perf = {
+            row["channel_key"] for row in state_db.perf_load_all()
+            if row["channel_key"] not in live_keys
+        }
+        # 可选 SQLite 写失败时 scorer 会合法地保留 memory-only 评分；
+        # stale 集必须同时覆盖 DB 和内存，否则同名渠道重建会继承旧分数。
+        stale_perf.update(
+            channel_key for channel_key in scorer.channel_keys()
+            if channel_key not in live_keys
+        )
+        for channel_key in stale_perf:
+            scorer.clear_stats(channel_key)
 
-    for row in state_db.error_load_all():
-        if row["channel_key"] not in live_keys:
+        stale_errors = {
+            row["channel_key"] for row in state_db.error_load_all()
+            if row["channel_key"] not in live_keys
+        }
+        for channel_key in stale_errors:
             # cooldown 的内存态与 state.db 必须通过同一个提交点删除。
-            # 直接删 DB 会让同 key 在当前进程内重新出现时仍被旧内存态拦截，
-            # 只能靠重启恢复。
-            cooldown.clear(row["channel_key"], notify_recovered=False)
+            # resolve_alias=False 清理的就是被判定为 stale 的旧 generation。
+            cooldown.clear(
+                channel_key, notify_recovered=False, resolve_alias=False,
+            )
 
-    state_db.affinity_delete_stale_channels(live_keys)
-    state_db.client_affinity_delete_stale_channels(live_keys)
+        affinity.delete_stale_channels(live_keys)
+        affinity.client_delete_stale_channels(live_keys)
 
 
 def all_channels() -> list[Channel]:
-    with _lock:
-        return list(_channels.values())
+    with channel_state.mutation_lock:
+        with _lock:
+            return list(_channels.values())
 
 
 def get_channel(key: str) -> Optional[Channel]:
-    with _lock:
-        ch = _channels.get(key)
-        if ch is not None:
-            return ch
-        # 兼容：调用方可能还在传老格式 "oauth:<email>"（不含 provider 段）
-        if key.startswith("oauth:") and key.count(":") == 1:
-            email = key[len("oauth:"):]
-            matches = [
-                c for c in _channels.values()
-                if getattr(c, "email", None) == email and c.type == "oauth"
-            ]
-            return matches[0] if len(matches) == 1 else None
-        if key.startswith("oauth:openai:"):
-            identity = key[len("oauth:openai:"):]
-            matches = [
-                c for c in _channels.values()
-                if c.type == "oauth"
-                and getattr(c, "protocol", "") == "openai-responses"
-                and getattr(c, "email", None) == identity
-            ]
-            return matches[0] if len(matches) == 1 else None
-        if key.startswith("oauth:xai:"):
-            identity = key[len("oauth:xai:"):]
-            legacy_email = ""
-            legacy_subject = ""
-            if ":" in identity:
-                legacy_email, _, legacy_subject = identity.partition(":")
-            matches = []
-            for c in _channels.values():
-                if c.type != "oauth" or getattr(c, "provider", "") != "xai":
-                    continue
-                email = str(getattr(c, "email", "") or "")
-                subject = str(getattr(c, "subject", "") or "")
-                if identity in (email, subject) or (legacy_email == email and legacy_subject == subject):
-                    matches.append(c)
-            return matches[0] if len(matches) == 1 else None
-        return None
+    with channel_state.mutation_lock:
+        with _lock:
+            ch = _channels.get(key)
+            if ch is not None:
+                return ch
+            # 兼容：调用方可能还在传老格式 "oauth:<email>"（不含 provider 段）
+            if key.startswith("oauth:") and key.count(":") == 1:
+                email = key[len("oauth:"):]
+                matches = [
+                    c for c in _channels.values()
+                    if getattr(c, "email", None) == email and c.type == "oauth"
+                ]
+                return matches[0] if len(matches) == 1 else None
+            if key.startswith("oauth:openai:"):
+                identity = key[len("oauth:openai:"):]
+                matches = [
+                    c for c in _channels.values()
+                    if c.type == "oauth"
+                    and getattr(c, "protocol", "") == "openai-responses"
+                    and getattr(c, "email", None) == identity
+                ]
+                return matches[0] if len(matches) == 1 else None
+            if key.startswith("oauth:xai:"):
+                identity = key[len("oauth:xai:"):]
+                legacy_email = ""
+                legacy_subject = ""
+                if ":" in identity:
+                    legacy_email, _, legacy_subject = identity.partition(":")
+                matches = []
+                for c in _channels.values():
+                    if c.type != "oauth" or getattr(c, "provider", "") != "xai":
+                        continue
+                    email = str(getattr(c, "email", "") or "")
+                    subject = str(getattr(c, "subject", "") or "")
+                    if identity in (email, subject) or (legacy_email == email and legacy_subject == subject):
+                        matches.append(c)
+                return matches[0] if len(matches) == 1 else None
+            return None
 
 
 def enabled_channels() -> list[Channel]:
@@ -198,6 +228,11 @@ def install_config_reload_hook() -> None:
 # ─── 添加 / 更新 / 删除 API 渠道 ─────────────────────────────────
 
 def add_api_channel(entry: dict) -> dict:
+    with config.serialized_updates():
+        return _add_api_channel_serialized(entry)
+
+
+def _add_api_channel_serialized(entry: dict) -> dict:
     """
     添加一个 API 渠道（type="api"），写入 config 并触发重建。
     entry 需含 name/baseUrl/apiKey/models；可含 cc_mimicry/enabled/apiPath，
@@ -214,6 +249,7 @@ def add_api_channel(entry: dict) -> dict:
     name = entry.get("name")
     if not name:
         raise ValueError("channel name is required")
+    channel_state.assert_reusable(f"api:{name}")
 
     protocol = entry.get("protocol") or "anthropic"
     # openai-* 渠道不走 Claude Code 伪装，强制 False
@@ -273,6 +309,11 @@ def add_api_channel(entry: dict) -> dict:
 
 
 def update_api_channel(name: str, patch: dict) -> dict | None:
+    with config.serialized_updates():
+        return _update_api_channel_serialized(name, patch)
+
+
+def _update_api_channel_serialized(name: str, patch: dict) -> dict | None:
     """
     编辑渠道。patch 可含 name/baseUrl/apiKey/models/cc_mimicry/enabled/apiPath/protocol，
     以及 omitTemperature/omitThinking/context1m*/fast* 兼容策略字段。
@@ -290,6 +331,10 @@ def update_api_channel(name: str, patch: dict) -> dict | None:
     old_entry = next(
         (c for c in config.get().get("channels", []) if c.get("name") == name),
         {},
+    )
+    old_entry_snapshot = copy.deepcopy(old_entry)
+    old_priority_orders = copy.deepcopy(
+        config.get().get("loadBalancing", {}).get("priorityOrders", {})
     )
     old_family = load_balancing.family_for_protocol(old_entry.get("protocol", "anthropic"))
 
@@ -387,41 +432,62 @@ def update_api_channel(name: str, patch: dict) -> dict | None:
         if "name" in patch:
             target["name"] = patch["name"]
 
+        final_name = target.get("name", name)
+        final_family = load_balancing.family_for_protocol(
+            target.get("protocol", "anthropic")
+        )
+        final_key = f"api:{final_name}"
+        if load_balancing.is_initialized(cfg) and (
+            final_key != old_key or final_family != old_family
+        ):
+            load_balancing.mutate_channel_renamed(
+                cfg, old_key, final_key, final_family,
+            )
+
+    new_name = patch.get("name", name)
+    new_key = f"api:{new_name}"
+    if new_key != old_key:
+        channel_state.assert_reusable(new_key)
+
+    def _rollback(cfg):
+        channels = cfg.get("channels", [])
+        for index, entry in enumerate(channels):
+            if entry.get("name") == new_name:
+                channels[index] = copy.deepcopy(old_entry_snapshot)
+                break
+        cfg.setdefault("loadBalancing", {})["priorityOrders"] = copy.deepcopy(
+            old_priority_orders
+        )
+
     try:
-        config.update(_mutate)
+        if new_key != old_key:
+            channel_state.rename_with_config(
+                old_channel_key=old_key,
+                new_channel_key=new_key,
+                config_mutator=_mutate,
+                rollback_mutator=_rollback,
+            )
+        else:
+            config.update(_mutate)
     except (KeyError, ValueError) as exc:
         raise exc
-
-    # 若改了名，做级联迁移（scorer/cooldown/affinity 内部各自负责把 state.db 同步改名）
-    new_name = patch.get("name", name)
-    new_entry = next(
-        (c for c in config.get().get("channels", []) if c.get("name") == new_name),
-        {},
-    )
-    new_family = load_balancing.family_for_protocol(new_entry.get("protocol", "anthropic"))
-    if new_name != name:
-        from .. import scorer, affinity, cooldown
-        new_key = f"api:{new_name}"
-        scorer.rename_channel(old_key, new_key)
-        cooldown.rename_channel(old_key, new_key)
-        affinity.rename_channel(old_key, new_key)
-        affinity.client_rename_channel(old_key, new_key)
-        from .. import concurrency
-        concurrency.rename_channel(old_key, new_key)
-        # 维护用户优先级表；family 用更新后的 protocol 推导
-        load_balancing.sync_channel_renamed(old_key, new_key, new_family)
-    elif "protocol" in patch and old_family != new_family:
-        # 只有协议 family 实际变化时，才从旧 family 移除并追加到新 family 队尾。
-        # 菜单保存时可能把当前 protocol 原样带回，不能因此打乱用户优先级。
-        load_balancing.sync_channel_removed(old_key)
-        load_balancing.sync_channel_added(old_key, new_family)
 
     rebuild_from_config()
     return {"name": new_name}
 
 
 def delete_api_channel(name: str) -> bool:
+    with config.serialized_updates():
+        return _delete_api_channel_serialized(name)
+
+
+def _delete_api_channel_serialized(name: str) -> bool:
     key = f"api:{name}"
+    if not any(
+        channel.get("name") == name
+        for channel in config.get().get("channels", [])
+    ):
+        return False
     found = {"ok": False}
 
     def _mutate(cfg):
@@ -430,19 +496,34 @@ def delete_api_channel(name: str) -> bool:
             if c.get("name") == name:
                 channels.pop(i)
                 found["ok"] = True
+                load_balancing.mutate_channels_removed(cfg, {key})
                 return
-    config.update(_mutate)
-    if not found["ok"]:
-        return False
 
-    # 级联清理（scorer/cooldown/affinity 内部各自负责把 state.db 一并清掉）
-    from .. import scorer, affinity, cooldown
-    scorer.clear_stats(key)
-    cooldown.clear(key)
-    affinity.delete_by_channel(key)
-    affinity.client_delete_by_channel(key)
-    load_balancing.sync_channel_removed(key)
-    from .. import concurrency
-    concurrency.forget_channel(key)
-    rebuild_from_config()
+    # Config removal, priority removal, and tombstoning are one lifecycle.
+    # Requests already using the old Channel object may finish later; their
+    # scorer/cooldown/affinity side effects must not recreate deleted state.
+    from .. import affinity, concurrency, cooldown, scorer
+    with channel_state.mutation_lock:
+        generation_keys = sorted(channel_state.alias_sources(key)) + [key]
+        frozen_limits = {
+            generation_key: concurrency.capture_rename_limit(generation_key)
+            for generation_key in generation_keys
+        }
+        channel_state.retire_deleted(key)
+        try:
+            config.update(_mutate)
+        except BaseException:
+            channel_state.restore_deleted(key)
+            raise
+        for generation_key in generation_keys:
+            concurrency.retire_channel(
+                generation_key,
+                frozen_max=frozen_limits[generation_key],
+                deleted_target=key,
+            )
+        scorer.clear_stats(key)
+        cooldown.clear(key, notify_recovered=False, resolve_alias=False)
+        affinity.delete_by_channel(key)
+        affinity.client_delete_by_channel(key)
+        rebuild_from_config()
     return True

--- a/src/channel_state.py
+++ b/src/channel_state.py
@@ -1,0 +1,176 @@
+"""Cross-module coordination for live channel state mutations.
+
+Scorer, cooldown, affinity, and registry cleanup all mirror channel-keyed state.
+A single re-entrant lock keeps runtime channel renames from interleaving with
+normal mutations or stale-channel cleanup.  Transition keys remain temporarily
+live while config reload callbacks observe a rename in progress.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from typing import Callable, Iterator
+
+
+mutation_lock = threading.RLock()
+_transition_keys: set[str] = set()
+_aliases: dict[str, str] = {}
+_deleted_keys: set[str] = set()
+
+
+@contextmanager
+def transition(old_key: str, new_key: str) -> Iterator[None]:
+    """Serialize one rename and protect both keys from reload cleanup."""
+    with mutation_lock:
+        keys = {key for key in (old_key, new_key) if key}
+        _transition_keys.update(keys)
+        try:
+            yield
+        finally:
+            _transition_keys.difference_update(keys)
+
+
+def include_transitions(live_keys: set[str]) -> set[str]:
+    """Return a live-key snapshot including in-progress rename endpoints."""
+    with mutation_lock:
+        return set(live_keys) | set(_transition_keys)
+
+
+def resolve(channel_key: str) -> str:
+    """Map late writes from an in-flight old channel to its renamed key."""
+    with mutation_lock:
+        current = channel_key
+        seen: set[str] = set()
+        while current in _aliases and current not in seen:
+            seen.add(current)
+            current = _aliases[current]
+        return current
+
+
+def alias_sources(channel_key: str) -> set[str]:
+    """Return every retired source generation that resolves to channel_key."""
+    with mutation_lock:
+        target = resolve(channel_key)
+        return {
+            source for source in _aliases
+            if resolve(source) == target
+        }
+
+
+def _install_alias(old_key: str, new_key: str) -> None:
+    target = resolve(new_key)
+    _aliases[old_key] = target
+    for source, current in list(_aliases.items()):
+        if current == old_key:
+            _aliases[source] = target
+
+
+def is_retired_source(channel_key: str) -> bool:
+    with mutation_lock:
+        return channel_key in _aliases or channel_key in _deleted_keys
+
+
+def is_deleted(channel_key: str) -> bool:
+    """Return whether a channel generation was deleted in this process."""
+    with mutation_lock:
+        return channel_key in _deleted_keys
+
+
+def retire_deleted(channel_key: str) -> None:
+    """Tombstone a deleted generation so late request side effects are dropped."""
+    with mutation_lock:
+        _deleted_keys.add(channel_key)
+
+
+def restore_deleted(channel_key: str) -> None:
+    """Undo a tombstone only when the matching config deletion did not commit."""
+    with mutation_lock:
+        _deleted_keys.discard(channel_key)
+
+
+def assert_reusable(channel_key: str) -> None:
+    if is_retired_source(channel_key):
+        raise ValueError(
+            f"channel key {channel_key!r} belongs to a retired generation; "
+            "restart before reusing the key"
+        )
+
+
+def rename_with_config(*, old_channel_key: str, new_channel_key: str,
+                       config_mutator: Callable[[dict], None],
+                       rollback_mutator: Callable[[dict], None],
+                       old_account_key: str | None = None,
+                       new_account_key: str | None = None,
+                       email: str | None = None) -> None:
+    """Publish config + every persisted/in-memory channel mirror as one lifecycle.
+
+    Config is written first while both rename endpoints are protected from the
+    synchronous reload cleanup.  Routing and mirrored mutations share this
+    lock, so no request can observe the short config/state transition.  A
+    failed SQLite transaction restores the previous config before releasing
+    the transition.
+    """
+    if old_channel_key == new_channel_key:
+        from . import config
+        config.update(config_mutator)
+        return
+
+    from . import affinity, concurrency, config, cooldown, scorer, state_db
+
+    # Global order is config lifecycle → channel-state lifecycle. Normal
+    # config.update callbacks take the same order, avoiding cross-thread
+    # config/reload races and lock inversion.
+    with config.serialized_updates(), transition(old_channel_key, new_channel_key):
+        frozen_concurrency_max = concurrency.capture_rename_limit(old_channel_key)
+        config.update(config_mutator)
+        try:
+            with state_db.optional_write_timeout():
+                state_db.rename_runtime_channel_state(
+                    old_channel_key,
+                    new_channel_key,
+                    old_account_key=old_account_key,
+                    new_account_key=new_account_key,
+                    email=email,
+                )
+        except BaseException:
+            # The single SQLite transaction has already rolled back; restore
+            # config before exposing routing again.
+            config.update(rollback_mutator)
+            raise
+
+        # The state.db transaction above is the only persistence commit.
+        # Install generation routing first, then attempt every deterministic
+        # memory publication.  A broken publisher stays loud but cannot let
+        # late old-generation writes recreate old state or lose concurrency
+        # release accounting.
+        _install_alias(old_channel_key, new_channel_key)
+        concurrency.rename_channel(
+            old_channel_key, new_channel_key,
+            frozen_max=frozen_concurrency_max,
+        )
+        publication_errors: list[Exception] = []
+        publishers = (
+            lambda: scorer.rename_channel(
+                old_channel_key, new_channel_key, persist=False,
+            ),
+            lambda: cooldown.rename_channel(
+                old_channel_key, new_channel_key, persist=False,
+            ),
+            lambda: affinity.rename_channel(
+                old_channel_key, new_channel_key, persist=False,
+            ),
+            lambda: affinity.client_rename_channel(
+                old_channel_key, new_channel_key, persist=False,
+            ),
+        )
+        for publish in publishers:
+            try:
+                publish()
+            except Exception as exc:
+                publication_errors.append(exc)
+        if publication_errors:
+            raise ExceptionGroup(
+                "channel state committed but memory publication failed",
+                publication_errors,
+            )

--- a/src/concurrency.py
+++ b/src/concurrency.py
@@ -15,11 +15,12 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Optional
 
-from . import config
+from . import channel_state, config
 
 
 @dataclass
@@ -47,6 +48,13 @@ class ChannelSlot:
 # 全局 slot 表。key = channel.key（"api:xxx" 或 "oauth:provider:email"）。
 _slots: dict[str, ChannelSlot] = {}
 _slots_lock = asyncio.Lock()
+_slots_guard = threading.RLock()
+# Renamed keys are allowed to drain in place. Moving a live slot would make
+# existing requests release the old key while its counter lives under the new
+# key, permanently leaking in_flight and waiters.
+_retired_keys: set[str] = set()
+_retired_limits: dict[str, int] = {}
+_deleted_retire_targets: dict[str, str] = {}
 
 # 全局"释放事件"：任一渠道 release 时 set 一次，用来唤醒"跨候选"排队方
 # （acquire_from_candidates 会注册到多个 slot 的 waiter 队列里，任一 slot 释放都要醒）。
@@ -73,16 +81,19 @@ def _get_channel_max(ch_key: str) -> int:
     return mc if mc > 0 else default_max
 
 
-async def _get_or_create_slot(ch_key: str) -> ChannelSlot:
-    async with _slots_lock:
-        slot = _slots.get(ch_key)
-        if slot is None:
-            slot = ChannelSlot(key=ch_key, max_concurrent=_get_channel_max(ch_key))
-            _slots[ch_key] = slot
-        else:
-            # 热加载可能改了 max_concurrent；只更新 max，不动 in_flight
-            slot.max_concurrent = _get_channel_max(ch_key)
-        return slot
+def _get_or_create_slot_locked(ch_key: str) -> ChannelSlot:
+    slot = _slots.get(ch_key)
+    if slot is None:
+        max_concurrent = (
+            _retired_limits[ch_key]
+            if ch_key in _retired_keys and ch_key in _retired_limits
+            else _get_channel_max(ch_key)
+        )
+        slot = ChannelSlot(key=ch_key, max_concurrent=max_concurrent)
+        _slots[ch_key] = slot
+    elif ch_key not in _retired_keys:
+        slot.max_concurrent = _get_channel_max(ch_key)
+    return slot
 
 
 def _enabled() -> bool:
@@ -98,18 +109,24 @@ async def try_acquire(ch_key: str) -> bool:
     """
     if not _enabled():
         return True
-    slot = await _get_or_create_slot(ch_key)
-    if slot.is_unlimited():
-        slot.in_flight += 1
-        return True
-    async with slot.lock:
-        if slot.in_flight < slot.max_concurrent:
-            slot.in_flight += 1
-            return True
+    async with _slots_lock:
+        with channel_state.mutation_lock, _slots_guard:
+            slot = _get_or_create_slot_locked(ch_key)
+            if slot.is_unlimited():
+                slot.in_flight += 1
+                return True
+            if slot.in_flight < slot.max_concurrent:
+                slot.in_flight += 1
+                return True
     return False
 
 
 def release(ch_key: str) -> None:
+    with channel_state.mutation_lock, _slots_guard:
+        _release_locked(ch_key)
+
+
+def _release_locked(ch_key: str) -> None:
     """释放一个位置，唤醒该 slot 的 FIFO 队头（若有）。
 
     同步函数，可在 try/finally 里直接调用。
@@ -121,22 +138,60 @@ def release(ch_key: str) -> None:
         # 不限制的渠道仅做 in_flight 计数回减，无需唤醒
         if slot.in_flight > 0:
             slot.in_flight -= 1
+        _cleanup_retired_slot(ch_key, slot)
         return
     if slot.in_flight > 0:
         slot.in_flight -= 1
     # 唤醒队头 waiter（只唤醒一个；FIFO 语义）
     # 注意：即使没 waiter，也要 set 一次 _release_event，唤醒 acquire_from_candidates
     # 里跨 slot 轮询的等待方。
+    woke_waiter = False
     while slot.waiters:
         fut = slot.waiters.pop(0)
         if not fut.done():
             fut.set_result(None)
+            woke_waiter = True
             break
         # done 的是被别处取消 / 已超时的，继续找下一个
     try:
         _release_event.set()
     except Exception:
         pass
+    if not woke_waiter:
+        _cleanup_retired_slot(ch_key, slot)
+
+
+def _cleanup_retired_slot(ch_key: str, slot: ChannelSlot) -> None:
+    with channel_state.mutation_lock, _slots_guard:
+        if (
+            ch_key in _retired_keys
+            and slot.in_flight == 0
+            and not slot.waiters
+            and _slots.get(ch_key) is slot
+        ):
+            _slots.pop(ch_key, None)
+            if _deleted_retire_targets.pop(ch_key, None) is not None:
+                _retired_keys.discard(ch_key)
+                _retired_limits.pop(ch_key, None)
+                # Keep the deleted target tombstoned until process restart.
+                # A request can exist before acquire (or concurrency can be
+                # disabled), so an empty slot is not proof that no old
+                # generation can publish late side effects.
+
+
+async def _acquire_or_register_waiter(
+    ch_key: str,
+) -> tuple[ChannelSlot, asyncio.Future | None, bool]:
+    """Atomically acquire available capacity or append one waiter."""
+    async with _slots_lock:
+        with channel_state.mutation_lock, _slots_guard:
+            slot = _get_or_create_slot_locked(ch_key)
+            if slot.is_unlimited() or slot.in_flight < slot.max_concurrent:
+                slot.in_flight += 1
+                return slot, None, True
+            fut: asyncio.Future = asyncio.get_event_loop().create_future()
+            slot.waiters.append(fut)
+            return slot, fut, False
 
 
 async def acquire_from_candidates(
@@ -173,21 +228,13 @@ async def acquire_from_candidates(
 
         # step 2: 为每个 slot 注册 waiter
         futures: list[tuple[ChannelSlot, asyncio.Future]] = []
-        for ch_key, _ in candidates:
-            slot = await _get_or_create_slot(ch_key)
-            if slot.is_unlimited():
-                # 不限制的渠道几乎不会到这里（前面 try_acquire 已成），
-                # 兜底再试一次
-                if await try_acquire(ch_key):
-                    for s, fut in futures:
-                        _drop_waiter(s, fut)
-                    for _, payload in candidates:
-                        if _ == ch_key:
-                            return (ch_key, payload)
-                    return (ch_key, candidates[0][1])
-                continue
-            fut: asyncio.Future = asyncio.get_event_loop().create_future()
-            slot.waiters.append(fut)
+        for ch_key, payload in candidates:
+            slot, fut, acquired = await _acquire_or_register_waiter(ch_key)
+            if acquired:
+                for previous_slot, previous_fut in futures:
+                    _drop_waiter(previous_slot, previous_fut)
+                return (ch_key, payload)
+            assert fut is not None
             futures.append((slot, fut))
 
         # 同时等 _release_event 作为兜底唤醒源（覆盖 slot 被重建等极端情况）
@@ -195,21 +242,30 @@ async def acquire_from_candidates(
         global_wake = asyncio.create_task(_release_event.wait())
         wait_futs = [fut for _, fut in futures] + [global_wake]
 
+        cancelled = False
         try:
             done, _pending = await asyncio.wait(
                 wait_futs,
                 timeout=remaining,
                 return_when=asyncio.FIRST_COMPLETED,
             )
+        except asyncio.CancelledError:
+            cancelled = True
+            raise
         finally:
             # 不管怎么样都要把自己从所有 slot 的 waiter 队列里摘掉，避免泄漏
             for slot, fut in futures:
                 _drop_waiter(slot, fut)
             if not global_wake.done():
                 global_wake.cancel()
+            if cancelled:
+                for slot, _ in futures:
+                    _cleanup_retired_slot(slot.key, slot)
 
         if not done:
             # 超时
+            for slot, _ in futures:
+                _cleanup_retired_slot(slot.key, slot)
             return None
 
         # step 3: 被唤醒，挨个候选再试一次
@@ -221,74 +277,109 @@ async def acquire_from_candidates(
 
 
 def _drop_waiter(slot: ChannelSlot, fut: asyncio.Future) -> None:
-    try:
-        slot.waiters.remove(fut)
-    except ValueError:
-        pass
-    if not fut.done():
+    with channel_state.mutation_lock, _slots_guard:
         try:
-            fut.cancel()
-        except Exception:
+            slot.waiters.remove(fut)
+        except ValueError:
             pass
+        if not fut.done():
+            try:
+                fut.cancel()
+            except Exception:
+                pass
 
 
 def is_saturated(ch_key: str) -> bool:
     """同步查询是否饱和（用于 scheduler filter 的快速路径）。"""
     if not _enabled():
         return False
-    slot = _slots.get(ch_key)
-    if slot is None:
-        # 未构造过 → 必然空闲（除非 max=0 也算空闲）
-        return False
-    slot.max_concurrent = _get_channel_max(ch_key)
-    return slot.is_saturated()
+    with channel_state.mutation_lock, _slots_guard:
+        slot = _slots.get(ch_key)
+        if slot is None:
+            return False
+        if ch_key not in _retired_keys:
+            slot.max_concurrent = _get_channel_max(ch_key)
+        return slot.is_saturated()
 
 
 def snapshot() -> list[dict]:
     """供 TG Bot 展示：[{ch_key, in_flight, max, waiting}]。"""
     out = []
-    for key, slot in _slots.items():
-        slot.max_concurrent = _get_channel_max(key)
-        out.append({
-            "channel_key": key,
-            "in_flight": slot.in_flight,
-            "max_concurrent": slot.max_concurrent,
-            "waiting": len(slot.waiters),
-            "unlimited": slot.is_unlimited(),
-        })
+    with channel_state.mutation_lock, _slots_guard:
+        for key, slot in _slots.items():
+            if key not in _retired_keys:
+                slot.max_concurrent = _get_channel_max(key)
+            out.append({
+                "channel_key": key,
+                "in_flight": slot.in_flight,
+                "max_concurrent": slot.max_concurrent,
+                "waiting": len(slot.waiters),
+                "unlimited": slot.is_unlimited(),
+            })
     out.sort(key=lambda x: x["channel_key"])
     return out
 
 
 def totals() -> dict:
     """汇总：{in_flight, waiting, tracked_channels}。"""
-    in_flight = sum(s.in_flight for s in _slots.values())
-    waiting = sum(len(s.waiters) for s in _slots.values())
-    return {
-        "in_flight": in_flight,
-        "waiting": waiting,
-        "tracked_channels": len(_slots),
-    }
+    with channel_state.mutation_lock, _slots_guard:
+        return {
+            "in_flight": sum(s.in_flight for s in _slots.values()),
+            "waiting": sum(len(s.waiters) for s in _slots.values()),
+            "tracked_channels": len(_slots),
+        }
 
 
 def forget_channel(ch_key: str) -> None:
     """渠道删除 / 改名时清理。必须确保 in_flight=0、waiters 空，否则忽略。"""
-    slot = _slots.get(ch_key)
-    if slot is None:
-        return
-    if slot.in_flight > 0 or slot.waiters:
-        # 还有在途请求或排队方 → 不清，等它们自行完成
-        return
-    _slots.pop(ch_key, None)
+    with channel_state.mutation_lock, _slots_guard:
+        slot = _slots.get(ch_key)
+        if slot is None:
+            return
+        if slot.in_flight > 0 or slot.waiters:
+            return
+        _slots.pop(ch_key, None)
 
 
-def rename_channel(old_key: str, new_key: str) -> None:
-    """渠道改名：把 slot 搬到新 key 下（保留 in_flight / waiters）。"""
+def capture_rename_limit(ch_key: str) -> int:
+    """Capture the old generation's limit before config publishes its rename."""
+    with channel_state.mutation_lock, _slots_guard:
+        slot = _slots.get(ch_key)
+        return slot.max_concurrent if slot is not None else _get_channel_max(ch_key)
+
+
+def retire_channel(ch_key: str, *, frozen_max: int | None = None,
+                   deleted_target: str | None = None) -> None:
+    """Let one removed/renamed generation drain without leaking its slot."""
+    with channel_state.mutation_lock, _slots_guard:
+        _retired_keys.add(ch_key)
+        if deleted_target is not None:
+            channel_state.retire_deleted(deleted_target)
+            _deleted_retire_targets[ch_key] = deleted_target
+        slot = _slots.get(ch_key)
+        if frozen_max is None:
+            frozen_max = slot.max_concurrent if slot is not None else _get_channel_max(ch_key)
+        _retired_limits[ch_key] = int(frozen_max)
+        if slot is not None:
+            slot.max_concurrent = int(frozen_max)
+            _cleanup_retired_slot(ch_key, slot)
+        elif deleted_target is not None:
+            # There is no tracked slot, but a request may still be between
+            # registry selection and acquire, or concurrency may be disabled.
+            # Drop slot bookkeeping while retaining the deleted generation's
+            # process-lifetime tombstone.
+            _deleted_retire_targets.pop(ch_key, None)
+            _retired_keys.discard(ch_key)
+            _retired_limits.pop(ch_key, None)
+
+
+def rename_channel(old_key: str, new_key: str, *, frozen_max: int | None = None) -> None:
+    """Retire the old slot in place; new requests get a separate new slot.
+
+    Existing requests and waiters still release/wake by ``old_key``. The old
+    slot is removed by the final release after it drains. Destination state is
+    never overwritten.
+    """
     if old_key == new_key:
         return
-    slot = _slots.pop(old_key, None)
-    if slot is None:
-        return
-    slot.key = new_key
-    slot.max_concurrent = _get_channel_max(new_key)
-    _slots[new_key] = slot
+    retire_channel(old_key, frozen_max=frozen_max)

--- a/src/concurrency.py
+++ b/src/concurrency.py
@@ -102,15 +102,34 @@ def _enabled() -> bool:
     return bool(cc_cfg.get("enabled", True))
 
 
+def _is_deleted_generation_locked(ch_key: str) -> bool:
+    """Whether a successful delete retired this exact/aliased generation.
+
+    Rename-only generations may continue draining in place.  A delete is
+    different: requests that have not acquired capacity yet must not start an
+    upstream call with credentials removed from config.
+    """
+    deleted_target = _deleted_retire_targets.get(ch_key)
+    if deleted_target is not None:
+        return True
+    resolved = channel_state.resolve(ch_key)
+    return (
+        channel_state.is_deleted(ch_key)
+        or channel_state.is_deleted(resolved)
+    )
+
+
 async def try_acquire(ch_key: str) -> bool:
     """非阻塞尝试占一个位置。成功 in_flight+=1，返回 True；满了返回 False。
 
     禁用并发限制或渠道不限（max=0）时永远返回 True。
     """
-    if not _enabled():
-        return True
     async with _slots_lock:
         with channel_state.mutation_lock, _slots_guard:
+            if _is_deleted_generation_locked(ch_key):
+                return False
+            if not _enabled():
+                return True
             slot = _get_or_create_slot_locked(ch_key)
             if slot.is_unlimited():
                 slot.in_flight += 1
@@ -181,10 +200,12 @@ def _cleanup_retired_slot(ch_key: str, slot: ChannelSlot) -> None:
 
 async def _acquire_or_register_waiter(
     ch_key: str,
-) -> tuple[ChannelSlot, asyncio.Future | None, bool]:
+) -> tuple[ChannelSlot | None, asyncio.Future | None, bool]:
     """Atomically acquire available capacity or append one waiter."""
     async with _slots_lock:
         with channel_state.mutation_lock, _slots_guard:
+            if _is_deleted_generation_locked(ch_key):
+                return None, None, False
             slot = _get_or_create_slot_locked(ch_key)
             if slot.is_unlimited() or slot.in_flight < slot.max_concurrent:
                 slot.in_flight += 1
@@ -234,8 +255,14 @@ async def acquire_from_candidates(
                 for previous_slot, previous_fut in futures:
                     _drop_waiter(previous_slot, previous_fut)
                 return (ch_key, payload)
+            if slot is None:
+                # Deleted after scheduler selection but before acquire.
+                continue
             assert fut is not None
             futures.append((slot, fut))
+
+        if not futures:
+            return None
 
         # 同时等 _release_event 作为兜底唤醒源（覆盖 slot 被重建等极端情况）
         _release_event.clear()
@@ -287,6 +314,23 @@ def _drop_waiter(slot: ChannelSlot, fut: asyncio.Future) -> None:
                 fut.cancel()
             except Exception:
                 pass
+
+
+def _cancel_waiter_threadsafe(fut: asyncio.Future) -> None:
+    """Cancel a waiter on its owning loop (delete may run in a TG thread)."""
+    if fut.done():
+        return
+    try:
+        loop = fut.get_loop()
+        if loop.is_running():
+            loop.call_soon_threadsafe(fut.cancel)
+        else:
+            fut.cancel()
+    except Exception:
+        try:
+            fut.cancel()
+        except Exception:
+            pass
 
 
 def is_saturated(ch_key: str) -> bool:
@@ -362,6 +406,17 @@ def retire_channel(ch_key: str, *, frozen_max: int | None = None,
         _retired_limits[ch_key] = int(frozen_max)
         if slot is not None:
             slot.max_concurrent = int(frozen_max)
+            if deleted_target is not None:
+                # A rename may drain queued waiters; a delete may not. Wake
+                # every pre-acquire waiter so it rechecks the generation and
+                # fails or selects another candidate without using old creds.
+                for fut in slot.waiters:
+                    _cancel_waiter_threadsafe(fut)
+                slot.waiters.clear()
+                try:
+                    _release_event.set()
+                except Exception:
+                    pass
             _cleanup_retired_slot(ch_key, slot)
         elif deleted_target is not None:
             # There is no tracked slot, but a request may still be between

--- a/src/config.py
+++ b/src/config.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import tempfile
 import threading
+from contextlib import contextmanager
 from typing import Any
 
 COMPACT_RESCUE_DEFAULT_DIRECT_PROMPT = (
@@ -84,7 +85,8 @@ COMPACT_RESCUE_DEFAULT_REDUCE_PROMPT = (
 )
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-# DATA_DIR 是所有运行时持久化文件的根目录（config.json / state.db / logs/ / .anthropic_proxy_ids.json）。
+# DATA_DIR 是所有运行时持久化文件的根目录（config.json / state.db /
+# openai_response_store.db / logs/ / .anthropic_proxy_ids.json）。
 # 优先使用环境变量 ANTHROPIC_PROXY_DATA_DIR（容器内通常是 /app/data），不设则回退到 BASE_DIR，
 # 保持现有源码安装方式（systemd 直跑）行为完全不变。
 DATA_DIR = os.environ.get("ANTHROPIC_PROXY_DATA_DIR") or BASE_DIR
@@ -534,8 +536,16 @@ DEFAULT_CONFIG: dict[str, Any] = {
         # previous_response_id 本地 store（跨变体 chat↔responses 必需，同协议可选）
         "store": {
             "enabled": True,
+            # 独立于 stateDbPath，relative path 以 DATA_DIR 为根；改后需重启。
+            "dbPath": "openai_response_store.db",
             "ttlMinutes": 60,
             "cleanupIntervalSeconds": 300,
+            # 每批同时受行数和 JSON payload 字节数限制，批间释放 Store 锁；
+            # 每轮再受批次数与时间预算限制，既能追赶积压也不长期阻塞 save。
+            "cleanupBatchSize": 100,
+            "cleanupBatchBytes": 8 * 1024 * 1024,
+            "cleanupMaxBatches": 100,
+            "cleanupTimeBudgetSeconds": 10,
         },
         # reasoning 跨协议桥接："passthrough" = 通过非官方字段 reasoning_content 双向映射；"drop" = 丢弃
         "reasoningBridge": "passthrough",
@@ -564,6 +574,7 @@ _mtime: float = 0.0
 # 必须是可重入锁 (RLock)：同一线程内的加载/保存辅助函数可能再次访问配置。
 # reload callbacks 始终在锁外执行，避免 callback 跨模块重入造成死锁。
 _lock = threading.RLock()
+_update_lifecycle_lock = threading.RLock()
 _reload_callbacks: list = []
 
 
@@ -789,6 +800,13 @@ def save() -> None:
         _mtime = _current_mtime()
 
 
+@contextmanager
+def serialized_updates():
+    """Keep a multi-step config/state lifecycle ahead of other config writes."""
+    with _update_lifecycle_lock:
+        yield
+
+
 def update(mutator, *, skip_if_unchanged: bool = False) -> dict:
     """以 mutator(cfg) 的方式原子修改 cfg 并持久化。
 
@@ -800,19 +818,20 @@ def update(mutator, *, skip_if_unchanged: bool = False) -> dict:
     也消除其它跨模块 callback 链可能产生的死锁。
     """
     global _cache, _mtime
-    with _lock:
-        if _cache is None:
-            _ensure_loaded()
-        candidate = copy.deepcopy(_cache)
-        mutator(candidate)
-        if skip_if_unchanged and candidate == _cache:
-            return _cache
-        _write_atomic(candidate)
-        _mtime = _current_mtime()
-        _cache = candidate
-        snapshot = candidate
-    _fire_reload_callbacks(snapshot)
-    return snapshot
+    with _update_lifecycle_lock:
+        with _lock:
+            if _cache is None:
+                _ensure_loaded()
+            candidate = copy.deepcopy(_cache)
+            mutator(candidate)
+            if skip_if_unchanged and candidate == _cache:
+                return _cache
+            _write_atomic(candidate)
+            _mtime = _current_mtime()
+            _cache = candidate
+            snapshot = candidate
+        _fire_reload_callbacks(snapshot)
+        return snapshot
 
 
 def on_reload(cb) -> None:

--- a/src/cooldown.py
+++ b/src/cooldown.py
@@ -13,12 +13,12 @@ import time
 from types import SimpleNamespace
 from typing import Optional
 
-from . import config, notifier, quota_errors, state_db
+from . import channel_state, config, notifier, quota_errors, state_db
 
 
 _INF = -1  # state.db 中用 -1 表示永久
 
-_lock = threading.Lock()
+_lock = channel_state.mutation_lock
 _entries: dict[tuple[str, str], dict] = {}  # (channel_key, model) -> state
 _initialized = False
 
@@ -111,7 +111,9 @@ def get_state(channel_key: str, model: str) -> Optional[dict]:
 
 def is_blocked(channel_key: str, model: str) -> bool:
     """(channel, model) 是否处于冷却中（永久或未过期的 cooldown_until）。"""
-    state = get_state(channel_key, model)
+    with _lock:
+        channel_key = channel_state.resolve(channel_key)
+        state = get_state(channel_key, model)
     if not state:
         return False
     cd = state.get("cooldown_until")
@@ -154,7 +156,6 @@ def record_error(channel_key: str, model: str, message: str | None = None,
     若本次推进让该 (channel, model) **首次进入永久冷却**，触发"channel_permanent"事件通知。
     """
     windows = _windows()
-    grace = _grace_count(channel_key)
     ladder_min_interval = _ladder_min_interval_ms()
     permanent_min_age = _permanent_min_age_ms()
     explicit_cooldown = cooldown_until
@@ -162,6 +163,10 @@ def record_error(channel_key: str, model: str, message: str | None = None,
     now = _now_ms()
 
     with _lock:
+        channel_key = channel_state.resolve(channel_key)
+        if channel_state.is_deleted(channel_key):
+            return {}
+        grace = _grace_count(channel_key)
         existing = _entries.get((channel_key, model))
         state = dict(existing) if existing is not None else {
             "error_count": 0,
@@ -229,7 +234,8 @@ def record_error(channel_key: str, model: str, message: str | None = None,
         # Persist before publishing the copied state, while holding the same
         # lock used by clear(). This makes record and clear linearisable and a
         # failed save cannot create a memory-only cooldown.
-        state_db.error_save(channel_key, model, new_count, cooldown_until, message)
+        with state_db.optional_write_timeout():
+            state_db.error_save(channel_key, model, new_count, cooldown_until, message)
         _entries[(channel_key, model)] = state
         result = dict(state)
 
@@ -255,7 +261,8 @@ def _was_actively_blocked(state: dict, now: int) -> bool:
 
 
 def clear(channel_key: str, model: Optional[str] = None, *,
-          notify_recovered: bool = True) -> None:
+          notify_recovered: bool = True,
+          resolve_alias: bool = True) -> None:
     """清除冷却。model=None 清该 channel 下所有模型。
 
     对每个清除前真的在冷却的条目，默认触发 ``channel_recovered`` 事件。
@@ -265,6 +272,8 @@ def clear(channel_key: str, model: Optional[str] = None, *,
     now = _now_ms()
     recovered: list[tuple[str, str, bool]] = []   # (ck, model, was_permanent)
     with _lock:
+        if resolve_alias:
+            channel_key = channel_state.resolve(channel_key)
         if model is None:
             keys = [k for k in _entries if k[0] == channel_key]
         else:
@@ -276,7 +285,8 @@ def clear(channel_key: str, model: Optional[str] = None, *,
                 recovered.append((k[0], k[1], was_perm))
         # Persistent deletion is the commit point. If it fails, leave every
         # in-memory entry intact so current-process and restart behavior agree.
-        state_db.error_delete(channel_key, model)
+        with state_db.optional_write_timeout():
+            state_db.error_delete(channel_key, model)
         for k in keys:
             _entries.pop(k, None)
 
@@ -293,19 +303,22 @@ def clear(channel_key: str, model: Optional[str] = None, *,
 
 def clear_all() -> None:
     with _lock:
-        state_db.error_delete(None, None)
+        with state_db.optional_write_timeout():
+            state_db.error_delete(None, None)
         _entries.clear()
 
 
-def rename_channel(old_key: str, new_key: str) -> None:
+def rename_channel(old_key: str, new_key: str, *, persist: bool = True) -> None:
     if old_key == new_key:
         return
     with _lock:
+        if persist:
+            with state_db.optional_write_timeout():
+                state_db.error_rename_channel(old_key, new_key)
         old_items = [(k, v) for k, v in _entries.items() if k[0] == old_key]
         for (_, model), state in old_items:
             _entries.pop((old_key, model), None)
             _entries[(new_key, model)] = state
-    state_db.error_rename_channel(old_key, new_key)
 
 
 def active_entries(now_ms: Optional[int] = None) -> list[dict]:

--- a/src/failover.py
+++ b/src/failover.py
@@ -123,6 +123,7 @@ from .transports import policy as transport_policy
 _CODEX_SNAPSHOT_WRITE_INTERVAL_S = 30.0
 _codex_snapshot_last: dict[str, float] = {}
 _codex_snapshot_lock = threading.Lock()
+_codex_snapshot_inflight: set[str] = set()
 
 
 def _maybe_record_codex_snapshot(ch: Channel, resp: Any) -> None:
@@ -134,21 +135,39 @@ def _maybe_record_codex_snapshot(ch: Channel, resp: Any) -> None:
             return
         account_key = getattr(ch, "account_key", None) or ch.email
         email = ch.email
+
+        # Auto-disable is based on this response, not on whether the auxiliary
+        # SQLite snapshot can be persisted. A BUSY/FULL/READONLY cache must
+        # never leave an explicitly over-limit account enabled.
+        _maybe_auto_disable_by_codex_snapshot(account_key, email, snap)
+
         # throttle bucket 用 account_key 作 key；OpenAI 同一邮箱可能有多个
-        # workspace，不能按 email 合并。
+        # workspace，不能按 email 合并。只在成功写入后推进 last；inflight
+        # 防止多个并发响应同时穿透，但写失败会立刻允许下一次重试。
         now = time.time()
         with _codex_snapshot_lock:
             last = _codex_snapshot_last.get(account_key, 0.0)
-            if now - last < _CODEX_SNAPSHOT_WRITE_INTERVAL_S:
+            if (
+                now - last < _CODEX_SNAPSHOT_WRITE_INTERVAL_S
+                or account_key in _codex_snapshot_inflight
+            ):
                 return
-            _codex_snapshot_last[account_key] = now
-        normalized = openai_provider.normalize_codex_snapshot(snap)
-        state_db.quota_save_openai_snapshot(account_key, snap, normalized, email=email)
-
-        # 🚨 响应头超限自动禁用（2026-04-20 新增）
-        # Codex 无 surpassed-threshold，但有 primary/secondary used percent；
-        # 判断任一 ≥ disableThresholdPercent 则触发（与 quota_monitor_once 语义一致）
-        _maybe_auto_disable_by_codex_snapshot(account_key, email, snap)
+            _codex_snapshot_inflight.add(account_key)
+        try:
+            normalized = openai_provider.normalize_codex_snapshot(snap)
+            state_db.quota_save_openai_snapshot(
+                account_key, snap, normalized, email=email,
+            )
+        except BaseException:
+            # Do not advance the throttle bucket: a following response should
+            # retry the cache write instead of waiting 30 seconds.
+            raise
+        else:
+            with _codex_snapshot_lock:
+                _codex_snapshot_last[account_key] = time.time()
+        finally:
+            with _codex_snapshot_lock:
+                _codex_snapshot_inflight.discard(account_key)
     except Exception as exc:
         print(f"[failover] codex snapshot record failed for {getattr(ch, 'email', '?')}: {exc}")
 
@@ -166,6 +185,7 @@ def _maybe_record_codex_snapshot(ch: Channel, resp: Any) -> None:
 _ANTHROPIC_SNAPSHOT_WRITE_INTERVAL_S = 30.0
 _anthropic_snapshot_last: dict[str, float] = {}
 _anthropic_snapshot_lock = threading.Lock()
+_anthropic_snapshot_inflight: set[str] = set()
 
 
 def _maybe_record_anthropic_snapshot(ch: Channel, resp: httpx.Response) -> None:
@@ -181,21 +201,32 @@ def _maybe_record_anthropic_snapshot(ch: Channel, resp: httpx.Response) -> None:
             return
         account_key = getattr(ch, "account_key", None) or ch.email
         email = ch.email
-        now = time.time()
-        with _anthropic_snapshot_lock:
-            last = _anthropic_snapshot_last.get(account_key, 0.0)
-            if now - last < _ANTHROPIC_SNAPSHOT_WRITE_INTERVAL_S:
-                return
-            _anthropic_snapshot_last[account_key] = now
-        state_db.quota_patch_passive(account_key, patch, email=email)
 
-        # 🚨 响应头超限自动禁用（2026-04-20 新增）
-        # 5h/7d 任一超限且账号当前未被禁用 → 立即置为 quota disabled
-        # 这比 quota_monitor_loop 的轮询快得多（下一次请求前就禁用，不用等 30min）
+        # Keep realtime disable independent from the best-effort quota cache.
         _maybe_auto_disable_by_headers(
             account_key, ch.email, dict(resp.headers),
             provider="claude",
         )
+
+        now = time.time()
+        with _anthropic_snapshot_lock:
+            last = _anthropic_snapshot_last.get(account_key, 0.0)
+            if (
+                now - last < _ANTHROPIC_SNAPSHOT_WRITE_INTERVAL_S
+                or account_key in _anthropic_snapshot_inflight
+            ):
+                return
+            _anthropic_snapshot_inflight.add(account_key)
+        try:
+            state_db.quota_patch_passive(account_key, patch, email=email)
+        except BaseException:
+            raise
+        else:
+            with _anthropic_snapshot_lock:
+                _anthropic_snapshot_last[account_key] = time.time()
+        finally:
+            with _anthropic_snapshot_lock:
+                _anthropic_snapshot_inflight.discard(account_key)
     except Exception as exc:
         print(f"[failover] anthropic snapshot record failed for "
               f"{getattr(ch, 'email', '?')}: {exc}")
@@ -214,6 +245,8 @@ def forget_anthropic_snapshot(account_key_or_email: str) -> None:
     with _anthropic_snapshot_lock:
         _anthropic_snapshot_last.pop(email, None)
         _anthropic_snapshot_last.pop(key, None)
+        _anthropic_snapshot_inflight.discard(email)
+        _anthropic_snapshot_inflight.discard(key)
 
 
 # ─── 响应头超限自动禁用（2026-04-20 新增） ───────────────────────
@@ -380,6 +413,8 @@ def forget_codex_snapshot(account_key_or_email: str) -> None:
     with _codex_snapshot_lock:
         _codex_snapshot_last.pop(email, None)
         _codex_snapshot_last.pop(key, None)
+        _codex_snapshot_inflight.discard(email)
+        _codex_snapshot_inflight.discard(key)
 
 
 def _toolkit_for(ch: Channel) -> dict:

--- a/src/failover.py
+++ b/src/failover.py
@@ -491,10 +491,10 @@ def _maybe_save_native_responses_store(
             output_items=output_items,
         )
     except Exception as exc:
-        traceback.print_exc()
+        should_log = True
         try:
             ek = notifier.escape_html
-            notifier.throttled_notify_event_sync(
+            should_log = notifier.throttled_notify_event_sync(
                 "openai_store_save_failed",
                 f"openai_store_save_failed:{api_key_name}",
                 f"❌ {notifier.provider_custom_emoji_html('openai')} <b>OpenAI Store 写入失败</b>（native Responses）\n"
@@ -506,6 +506,8 @@ def _maybe_save_native_responses_store(
             )
         except Exception:
             pass
+        if should_log:
+            traceback.print_exc()
 
 
 def _make_stream_translator(translator_ctx: Optional[dict]):

--- a/src/load_balancing.py
+++ b/src/load_balancing.py
@@ -220,17 +220,26 @@ def sync_channel_removed(channel_key: str) -> bool:
     changed = {"v": False}
 
     def _mutate(c: dict) -> None:
-        lb = c.setdefault("loadBalancing", {})
-        po = lb.setdefault("priorityOrders", {})
-        for fam in FAMILIES:
-            arr = list(po.get(fam) or [])
-            new = [x for x in arr if x != channel_key]
-            if new != arr:
-                po[fam] = new
-                changed["v"] = True
+        changed["v"] = mutate_channels_removed(c, {channel_key})
 
     config.update(_mutate)
     return changed["v"]
+
+
+def mutate_channels_removed(cfg: dict, channel_keys: set[str]) -> bool:
+    """Pure config mutation for atomically removing priority-order entries."""
+    if not channel_keys:
+        return False
+    changed = False
+    lb = cfg.setdefault("loadBalancing", {})
+    po = lb.setdefault("priorityOrders", {})
+    for fam in FAMILIES:
+        arr = list(po.get(fam) or [])
+        new = [key for key in arr if key not in channel_keys]
+        if new != arr:
+            po[fam] = new
+            changed = True
+    return changed
 
 
 def sync_channel_renamed(old_key: str, new_key: str, family: str) -> bool:
@@ -248,27 +257,35 @@ def sync_channel_renamed(old_key: str, new_key: str, family: str) -> bool:
     changed = {"v": False}
 
     def _mutate(c: dict) -> None:
-        lb = c.setdefault("loadBalancing", {})
-        po = lb.setdefault("priorityOrders", {})
-        for fam in FAMILIES:
-            arr = list(po.get(fam) or [])
-            new_arr: list[str] = []
-            seen: set[str] = set()
-            for key in arr:
-                if fam == family:
-                    k = new_key if key == old_key else key
-                elif key in (old_key, new_key):
-                    continue
-                else:
-                    k = key
-                if k not in seen:
-                    new_arr.append(k)
-                    seen.add(k)
-            if fam == family and new_key not in seen:
-                new_arr.append(new_key)
-            if new_arr != arr:
-                po[fam] = new_arr
-                changed["v"] = True
+        changed["v"] = mutate_channel_renamed(c, old_key, new_key, family)
 
     config.update(_mutate)
     return changed["v"]
+
+
+def mutate_channel_renamed(cfg: dict, old_key: str, new_key: str,
+                           family: str) -> bool:
+    """Pure config mutation used when a caller must publish rename atomically."""
+    lb = cfg.setdefault("loadBalancing", {})
+    po = lb.setdefault("priorityOrders", {})
+    changed = False
+    for fam in FAMILIES:
+        arr = list(po.get(fam) or [])
+        new_arr: list[str] = []
+        seen: set[str] = set()
+        for key in arr:
+            if fam == family:
+                k = new_key if key == old_key else key
+            elif key in (old_key, new_key):
+                continue
+            else:
+                k = key
+            if k not in seen:
+                new_arr.append(k)
+                seen.add(k)
+        if fam == family and new_key not in seen:
+            new_arr.append(new_key)
+        if new_arr != arr:
+            po[fam] = new_arr
+            changed = True
+    return changed

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -253,14 +253,16 @@ async def throttled_notify_event(event_key: str, alert_key: str, text: str,
 
 def throttled_notify_event_sync(event_key: str, alert_key: str, text: str,
                                 *, cooldown_seconds: int = _THROTTLE_DEFAULT_SEC,
-                                reply_markup: Optional[dict] = None) -> None:
+                                reply_markup: Optional[dict] = None) -> bool:
     """同 throttled_notify_event，但可从同步上下文调用。
 
     用在那些没法 await 的场景（如 sync 翻译器收尾、sync 的 Store save 回调）。
+    返回是否实际进入发送队列，供同步调用方避免重复日志。
     """
     if not _throttle_should_emit(alert_key, cooldown_seconds):
-        return
+        return False
     notify_event(event_key, text, reply_markup=reply_markup)
+    return True
 
 
 def wait_drain(timeout: float = 5.0) -> bool:

--- a/src/oauth_manager.py
+++ b/src/oauth_manager.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import copy
 import hashlib
 import json
 import math
@@ -341,7 +342,53 @@ def _remaining_str(iso_or_none: str | None) -> str:
     return f"{h}h {m}m" if h > 0 else f"{m}m"
 
 
+def _rename_priority_orders_in_config(cfg: dict, old_channel_key: str,
+                                      new_channel_key: str, family: str) -> None:
+    """Rename one priority key inside the caller's atomic config mutation."""
+    lb = cfg.setdefault("loadBalancing", {})
+    orders = lb.setdefault("priorityOrders", {})
+    for current_family in ("anthropic", "openai"):
+        result: list[str] = []
+        seen: set[str] = set()
+        for key in list(orders.get(current_family) or []):
+            if current_family == family and key == old_channel_key:
+                key = new_channel_key
+            elif key in (old_channel_key, new_channel_key) and current_family != family:
+                continue
+            if key not in seen:
+                result.append(key)
+                seen.add(key)
+        orders[current_family] = result
+
+
+def _rename_runtime_oauth_identity(old_account_key: str, new_account_key: str, *,
+                                   config_mutator, rollback_mutator,
+                                   email: str | None = None) -> None:
+    """Atomically coordinate config publication with all mirrored state."""
+    if not old_account_key or not new_account_key or old_account_key == new_account_key:
+        config.update(config_mutator)
+        return
+    from . import channel_state
+
+    old_channel_key = f"oauth:{old_account_key}"
+    new_channel_key = f"oauth:{new_account_key}"
+    channel_state.rename_with_config(
+        old_channel_key=old_channel_key,
+        new_channel_key=new_channel_key,
+        old_account_key=old_account_key,
+        new_account_key=new_account_key,
+        email=email,
+        config_mutator=config_mutator,
+        rollback_mutator=rollback_mutator,
+    )
+
+
 def _save_token_fields(account_key: str, new: dict) -> None:
+    with config.serialized_updates():
+        _save_token_fields_serialized(account_key, new)
+
+
+def _save_token_fields_serialized(account_key: str, new: dict) -> None:
     """把刷新后的 token 字段写回 config.oauthAccounts（按 account_key 精确匹配）。
 
     若刷新返回了新的 OpenAI workspace/account id，则需要把相关运行时状态和
@@ -354,30 +401,34 @@ def _save_token_fields(account_key: str, new: dict) -> None:
     canonical = _resolve_existing_account_key(account_key)
     target_key = canonical or account_key
     old_acc = get_account(target_key)
+    old_acc_snapshot = copy.deepcopy(old_acc) if old_acc is not None else None
+    old_priority_orders = copy.deepcopy(
+        config.get().get("loadBalancing", {}).get("priorityOrders", {})
+    )
     target_email = account_key_to_email(target_key)
     old_key = _canonical_key(old_acc) if old_acc else (canonical or account_key)
     new_key = old_key
+    rename_family = "anthropic"
     if old_acc:
         preview = dict(old_acc)
         preview.update(new)
         new_key = _canonical_key(preview)
         target_email = str(preview.get("email") or target_email)
+        rename_family = (
+            "openai" if _is_openai_family_provider(provider_of(preview))
+            else "anthropic"
+        )
 
-    if old_key and new_key and old_key != new_key:
-        try:
-            state_db.rename_oauth_identity(old_key, new_key, email=target_email)
-        except Exception as exc:
-            print(f"[oauth] state rename failed {old_key} -> {new_key}: {exc}")
-        try:
-            _prov = provider_of(old_acc or old_key)
-            load_balancing.sync_channel_renamed(
-                f"oauth:{old_key}", f"oauth:{new_key}",
-                "openai" if _is_openai_family_provider(_prov) else "anthropic",
-            )
-        except Exception as exc:
-            print(f"[oauth] priority rename failed {old_key} -> {new_key}: {exc}")
+    if old_key != new_key:
+        from . import channel_state
+        channel_state.assert_reusable(f"oauth:{new_key}")
+        for account in config.get().get("oauthAccounts", []):
+            candidate = _canonical_key(account)
+            if candidate == new_key and candidate != old_key:
+                raise ValueError(f"OAuth account identity already exists: {new_key}")
 
     def mutate(cfg):
+        updated = False
         for acc in cfg.get("oauthAccounts", []):
             if old_acc is not None:
                 if _canonical_key(acc) != old_key:
@@ -392,8 +443,34 @@ def _save_token_fields(account_key: str, new: dict) -> None:
                 acc["disabled_reason"] = None
                 acc["disabled_until"] = None
                 acc["enabled"] = True
+            updated = True
             break
-    config.update(mutate)
+        if updated and old_key != new_key:
+            _rename_priority_orders_in_config(
+                cfg, f"oauth:{old_key}", f"oauth:{new_key}", rename_family,
+            )
+
+    def rollback(cfg):
+        if old_acc_snapshot is not None:
+            accounts = cfg.get("oauthAccounts", [])
+            for index, acc in enumerate(accounts):
+                if _canonical_key(acc) == new_key:
+                    accounts[index] = copy.deepcopy(old_acc_snapshot)
+                    break
+        cfg.setdefault("loadBalancing", {})["priorityOrders"] = copy.deepcopy(
+            old_priority_orders
+        )
+
+    if old_key and new_key and old_key != new_key:
+        _rename_runtime_oauth_identity(
+            old_key,
+            new_key,
+            email=target_email,
+            config_mutator=mutate,
+            rollback_mutator=rollback,
+        )
+    else:
+        config.update(mutate)
 
 
 def _post_refresh_candidate(url: str, refresh_token: str, *, scope: str | None) -> dict:
@@ -1812,6 +1889,12 @@ def _openai_metadata_patch(entry: dict) -> dict:
 
 
 def add_account(entry: dict) -> None:
+    """Serialize target resolution, snapshots, config publication, and state rename."""
+    with config.serialized_updates():
+        _add_account_serialized(entry)
+
+
+def _add_account_serialized(entry: dict) -> None:
     """entry 需至少含 email / access_token / refresh_token。
 
     支持可选字段：
@@ -1901,11 +1984,17 @@ def add_account(entry: dict) -> None:
             break
     rename_old_key = _canonical_key(existing_target) if existing_target else ""
     rename_new_key = normalized_key if rename_old_key and rename_old_key != normalized_key else ""
+    from . import channel_state
+    if existing_target is None or rename_new_key:
+        channel_state.assert_reusable(f"oauth:{normalized_key}")
     if rename_new_key:
-        try:
-            state_db.rename_oauth_identity(rename_old_key, rename_new_key, email=email)
-        except Exception as exc:
-            print(f"[oauth] pre-rename state failed {rename_old_key} -> {rename_new_key}: {exc}")
+        for account in config.get().get("oauthAccounts", []):
+            if account is not existing_target and _canonical_key(account) == normalized_key:
+                raise ValueError(f"OAuth account identity already exists: {normalized_key}")
+    existing_snapshot = copy.deepcopy(existing_target) if existing_target else None
+    old_priority_orders = copy.deepcopy(
+        config.get().get("loadBalancing", {}).get("priorityOrders", {})
+    )
 
     def mutate(cfg):
         accounts = cfg.setdefault("oauthAccounts", [])
@@ -1941,28 +2030,38 @@ def add_account(entry: dict) -> None:
             if keep_max is not None and "maxConcurrent" not in entry:
                 target["maxConcurrent"] = keep_max
             if rename_new_key:
-                lb = cfg.setdefault("loadBalancing", {})
-                po = lb.setdefault("priorityOrders", {})
                 fam = "openai" if _is_openai_family_provider(provider) else "anthropic"
-                for f in ("anthropic", "openai"):
-                    arr = list(po.get(f) or [])
-                    new_arr: list[str] = []
-                    seen: set[str] = set()
-                    for key in arr:
-                        if f == fam and key == f"oauth:{rename_old_key}":
-                            key = f"oauth:{rename_new_key}"
-                        elif key in (f"oauth:{rename_old_key}", f"oauth:{rename_new_key}"):
-                            if f != fam:
-                                continue
-                        if key not in seen:
-                            new_arr.append(key)
-                            seen.add(key)
-                    po[f] = new_arr
+                _rename_priority_orders_in_config(
+                    cfg,
+                    f"oauth:{rename_old_key}",
+                    f"oauth:{rename_new_key}",
+                    fam,
+                )
             return
         accounts.append(normalized)
         added["v"] = True
 
-    config.update(mutate)
+    def rollback(cfg):
+        if existing_snapshot is not None:
+            accounts = cfg.get("oauthAccounts", [])
+            for index, account in enumerate(accounts):
+                if _canonical_key(account) == rename_new_key:
+                    accounts[index] = copy.deepcopy(existing_snapshot)
+                    break
+        cfg.setdefault("loadBalancing", {})["priorityOrders"] = copy.deepcopy(
+            old_priority_orders
+        )
+
+    if rename_new_key:
+        _rename_runtime_oauth_identity(
+            rename_old_key,
+            rename_new_key,
+            email=email,
+            config_mutator=mutate,
+            rollback_mutator=rollback,
+        )
+    else:
+        config.update(mutate)
     if added["v"]:
         load_balancing.sync_channel_added(
             f"oauth:{normalized_key}",
@@ -1971,53 +2070,108 @@ def add_account(entry: dict) -> None:
 
 
 def delete_account(account_key: str) -> None:
+    with config.serialized_updates():
+        _delete_account_serialized(account_key)
+
+
+def _delete_account_serialized(account_key: str) -> None:
     """按 account_key 精确删除一个账号 + 级联清理。
 
     兼容：若入参是裸 email（老 API），按 email 删除（可能删掉多条同邮箱的老数据）。
     """
-    canonical = _resolve_existing_account_key(account_key)
+    configured_keys = {
+        _canonical_key(account) for account in config.get().get("oauthAccounts", [])
+    }
+    if account_key not in configured_keys:
+        from . import channel_state
+        raw_channel = f"oauth:{account_key}"
+        resolved_channel = channel_state.resolve(raw_channel)
+        if resolved_channel != raw_channel:
+            account_key = resolved_channel[len("oauth:"):]
+    try:
+        canonical = _resolve_existing_account_key(account_key)
+    except AmbiguousOAuthAccountKey:
+        # Legacy bare-email deletion intentionally removes every provider entry
+        # sharing that email; ambiguity is only unsafe for single-account reads.
+        if ":" in account_key:
+            raise
+        canonical = None
     has_prov = ":" in account_key
     target_provider, target_identity = _split_ak(account_key)
 
+    def matches(account: dict) -> bool:
+        if canonical:
+            return _canonical_key(account) == canonical
+        if account.get("email") != target_identity:
+            return False
+        if not has_prov:
+            return True
+        return _acc_provider(account) == target_provider
+
+    cleanup_keys = [
+        _canonical_key(account)
+        for account in config.get().get("oauthAccounts", [])
+        if matches(account)
+    ]
+    if not cleanup_keys:
+        return
+    channel_keys = {f"oauth:{key}" for key in cleanup_keys}
+
     def mutate(cfg):
         accounts = cfg.get("oauthAccounts", [])
-        def _keep(a):
-            if canonical:
-                return _canonical_key(a) != canonical
-            if a.get("email") != target_identity:
-                return True
-            if not has_prov:
-                return False  # 老 API：按 email 删除（同邮箱可能多条，统一删）
-            return _acc_provider(a) != target_provider
-        cfg["oauthAccounts"] = [a for a in accounts if _keep(a)]
-    config.update(mutate)
+        cfg["oauthAccounts"] = [account for account in accounts if not matches(account)]
+        load_balancing.mutate_channels_removed(cfg, channel_keys)
 
-    # state.db 级联清理
-    cleanup_key = canonical or account_key
-    ch_key = f"oauth:{cleanup_key}"
-    load_balancing.sync_channel_removed(ch_key)
-    state_db.perf_delete(ch_key)
-    # cooldown 与亲和都必须走各自的内存 + state.db 双清接口；否则同一
-    # account key 在当前进程内重新添加后可能继承只存在于内存的冻结状态。
-    from . import cooldown as _cooldown
-    _cooldown.clear(ch_key, notify_recovered=False)
-    from . import affinity as _affinity
-    _affinity.delete_by_channel(ch_key)
-    try:
-        _affinity.client_delete_by_channel(ch_key)
-    except Exception:
-        pass
-    state_db.quota_delete(cleanup_key)
+    # Remove config + priority entries atomically, then keep every removed
+    # generation tombstoned until restart. Late in-flight responses must not
+    # recreate scorer/cooldown/affinity/quota rows after the cleanup commit.
+    from . import affinity as _affinity, channel_state, concurrency
+    from . import cooldown as _cooldown, scorer as _scorer
+    with channel_state.mutation_lock:
+        retirement_plan = {
+            channel_key: sorted(channel_state.alias_sources(channel_key)) + [channel_key]
+            for channel_key in channel_keys
+        }
+        frozen_limits = {
+            generation_key: concurrency.capture_rename_limit(generation_key)
+            for generation_keys in retirement_plan.values()
+            for generation_key in generation_keys
+        }
+        for channel_key in channel_keys:
+            channel_state.retire_deleted(channel_key)
+        try:
+            config.update(mutate)
+        except BaseException:
+            for channel_key in channel_keys:
+                channel_state.restore_deleted(channel_key)
+            raise
+        for channel_key, generation_keys in retirement_plan.items():
+            for generation_key in generation_keys:
+                concurrency.retire_channel(
+                    generation_key,
+                    frozen_max=frozen_limits[generation_key],
+                    deleted_target=channel_key,
+                )
 
-    # failover 的响应头 snapshot 节流桶（Codex + Anthropic 都清）
-    try:
-        from . import failover
-        failover.forget_codex_snapshot(cleanup_key)
-        failover.forget_anthropic_snapshot(cleanup_key)
-    except Exception:
-        pass
-    # OpenAI probe 节流桶（fetch_usage 统一路径后新增）
-    forget_openai_probe(cleanup_key)
+        for cleanup_key in cleanup_keys:
+            ch_key = f"oauth:{cleanup_key}"
+            _scorer.clear_stats(ch_key)
+            _cooldown.clear(
+                ch_key, notify_recovered=False, resolve_alias=False,
+            )
+            _affinity.delete_by_channel(ch_key)
+            _affinity.client_delete_by_channel(ch_key)
+            state_db.quota_delete(cleanup_key)
+
+            # failover 的响应头 snapshot 节流桶（Codex + Anthropic 都清）
+            try:
+                from . import failover
+                failover.forget_codex_snapshot(cleanup_key)
+                failover.forget_anthropic_snapshot(cleanup_key)
+            except Exception:
+                pass
+            # OpenAI probe 节流桶（fetch_usage 统一路径后新增）
+            forget_openai_probe(cleanup_key)
 
 
 _EXPECTED_REASON_UNSET = object()

--- a/src/oauth_manager.py
+++ b/src/oauth_manager.py
@@ -383,12 +383,22 @@ def _rename_runtime_oauth_identity(old_account_key: str, new_account_key: str, *
     )
 
 
-def _save_token_fields(account_key: str, new: dict) -> None:
-    with config.serialized_updates():
-        _save_token_fields_serialized(account_key, new)
+def _save_token_fields(account_key: str, new: dict) -> bool:
+    """Persist one refresh result only if its exact account generation survives.
+
+    A refresh may finish after the account was renamed or deleted.  The
+    process-lifetime channel generation map is authoritative here: a rename
+    may forward the result to its exact destination, while a deleted or
+    otherwise missing generation must drop it.  Never fall back to matching a
+    bare email, because Claude and OpenAI accounts may legitimately share one.
+    """
+    from . import channel_state
+
+    with config.serialized_updates(), channel_state.mutation_lock:
+        return _save_token_fields_serialized(account_key, new)
 
 
-def _save_token_fields_serialized(account_key: str, new: dict) -> None:
+def _save_token_fields_serialized(account_key: str, new: dict) -> bool:
     """把刷新后的 token 字段写回 config.oauthAccounts（按 account_key 精确匹配）。
 
     若刷新返回了新的 OpenAI workspace/account id，则需要把相关运行时状态和
@@ -398,15 +408,50 @@ def _save_token_fields_serialized(account_key: str, new: dict) -> None:
     若该账号此前因 `auth_error` 被自动禁用，刷新成功视为身份恢复：
     同时清掉 disabled_reason / disabled_until 并把 enabled 重新置 True。
     """
-    canonical = _resolve_existing_account_key(account_key)
-    target_key = canonical or account_key
-    old_acc = get_account(target_key)
+    from . import channel_state
+
+    # Production callers always pass a canonical key.  Keep the unambiguous
+    # legacy bare-email helper behavior for tests/admin paths, but resolve it
+    # before entering the generation check and never use email for mutation.
+    source_account_key = account_key
+    if ":" not in source_account_key:
+        try:
+            source_account_key = _resolve_existing_account_key(source_account_key) or ""
+        except AmbiguousOAuthAccountKey:
+            return False
+        if not source_account_key:
+            return False
+
+    source_channel_key = f"oauth:{source_account_key}"
+    target_channel_key = channel_state.resolve(source_channel_key)
+    if (
+        channel_state.is_deleted(source_channel_key)
+        or channel_state.is_deleted(target_channel_key)
+        or not target_channel_key.startswith("oauth:")
+    ):
+        return False
+    target_key = target_channel_key[len("oauth:"):]
+
+    old_acc = next(
+        (
+            account for account in config.get().get("oauthAccounts", [])
+            if _canonical_key(account) == target_key
+        ),
+        None,
+    )
+    if old_acc is None:
+        return False
+
+    source_provider, _source_identity = _split_ak(source_account_key)
+    if _acc_provider(old_acc) != _normalize_provider(source_provider):
+        return False
+
     old_acc_snapshot = copy.deepcopy(old_acc) if old_acc is not None else None
     old_priority_orders = copy.deepcopy(
         config.get().get("loadBalancing", {}).get("priorityOrders", {})
     )
-    target_email = account_key_to_email(target_key)
-    old_key = _canonical_key(old_acc) if old_acc else (canonical or account_key)
+    target_email = str(old_acc.get("email") or account_key_to_email(target_key))
+    old_key = _canonical_key(old_acc)
     new_key = old_key
     rename_family = "anthropic"
     if old_acc:
@@ -430,13 +475,7 @@ def _save_token_fields_serialized(account_key: str, new: dict) -> None:
     def mutate(cfg):
         updated = False
         for acc in cfg.get("oauthAccounts", []):
-            if old_acc is not None:
-                if _canonical_key(acc) != old_key:
-                    continue
-            elif canonical:
-                if _canonical_key(acc) != canonical:
-                    continue
-            elif acc.get("email") != target_email:
+            if _canonical_key(acc) != old_key:
                 continue
             acc.update(new)
             if acc.get("disabled_reason") == "auth_error":
@@ -471,6 +510,7 @@ def _save_token_fields_serialized(account_key: str, new: dict) -> None:
         )
     else:
         config.update(mutate)
+    return True
 
 
 def _post_refresh_candidate(url: str, refresh_token: str, *, scope: str | None) -> dict:
@@ -713,7 +753,11 @@ def _refresh_sync_locked(account_key: str, force: bool) -> str:
             except Exception as exc:
                 print(f"[oauth] claude refresh: profile fetch failed for {email}: {exc}")
 
-        _save_token_fields(account_key, new_fields)
+        if not _save_token_fields(account_key, new_fields):
+            print(
+                f"[oauth] discarded refresh result for retired generation: "
+                f"{account_key}"
+            )
         return new_fields["access_token"]
 
 

--- a/src/openai/store.py
+++ b/src/openai/store.py
@@ -41,6 +41,11 @@ class ResponseForbidden(Exception):
     pass
 
 
+class ResponseIdConflict(Exception):
+    """Another API key already owns this upstream response id."""
+    pass
+
+
 # ─── DTO ─────────────────────────────────────────────────────────
 
 
@@ -70,6 +75,9 @@ _logger = logging.getLogger(__name__)
 _cleanup_warning_lock = threading.Lock()
 _last_cleanup_warning_at = 0.0
 _CLEANUP_WARNING_INTERVAL_SECONDS = 3600.0
+_PRIVATE_DIR_MODE = 0o700
+_PRIVATE_FILE_MODE = 0o600
+_JOURNAL_SIZE_LIMIT_BYTES = 64 * 1024 * 1024
 
 
 def _paths_same_file(left: str, right: str) -> bool:
@@ -80,6 +88,68 @@ def _paths_same_file(left: str, right: str) -> bool:
         return os.path.samefile(left, right)
     except OSError:
         return False
+
+
+def _validate_private_path(path: str, *, directory: bool) -> os.stat_result:
+    """Fail closed on symlinks, foreign owners, or unsafe access."""
+    try:
+        info = os.lstat(path)
+    except FileNotFoundError:
+        raise
+    expected_type = stat.S_ISDIR if directory else stat.S_ISREG
+    if not expected_type(info.st_mode):
+        kind = "directory" if directory else "regular file"
+        raise RuntimeError(f"OpenAI Store path is not a {kind}: {path}")
+    if info.st_uid != os.geteuid():
+        raise RuntimeError(
+            f"OpenAI Store path must be owned by uid {os.geteuid()}: {path}"
+        )
+    mode = stat.S_IMODE(info.st_mode)
+    if directory:
+        # Source installs default DATA_DIR to the repository root, which is
+        # commonly 0755.  That remains safe for 0600 DB files as long as
+        # another uid cannot replace directory entries.  New/container data
+        # directories are still created/fixed to 0700.
+        if mode & 0o022:
+            raise RuntimeError(
+                "OpenAI Store directory must not be group/world writable "
+                f"(recommended mode 0700): {path}"
+            )
+    elif mode & 0o077:
+        raise RuntimeError(
+            f"OpenAI Store path must be private (mode 0600): {path}"
+        )
+    return info
+
+
+def _prepare_private_db_path(path: str) -> None:
+    """Create a private DB inode without relying on the process umask."""
+    parent = os.path.dirname(path) or "."
+    os.makedirs(parent, mode=_PRIVATE_DIR_MODE, exist_ok=True)
+    _validate_private_path(parent, directory=True)
+
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(path, flags, _PRIVATE_FILE_MODE)
+    except FileExistsError:
+        _validate_private_path(path, directory=False)
+    else:
+        os.close(fd)
+        _validate_private_path(path, directory=False)
+
+
+def _validate_private_store_files() -> None:
+    if not _db_path:
+        return
+    _validate_private_path(_db_path, directory=False)
+    for suffix in ("-wal", "-shm"):
+        sidecar = f"{_db_path}{suffix}"
+        try:
+            _validate_private_path(sidecar, directory=False)
+        except FileNotFoundError:
+            pass
 
 
 def _legacy_regular_file_exists(path: str) -> bool:
@@ -103,14 +173,17 @@ def _absolute_data_path(value: str) -> str:
     if os.path.isabs(value):
         return os.path.abspath(value)
     data_root = os.path.realpath(config.DATA_DIR)
-    resolved = os.path.realpath(os.path.join(data_root, value))
+    candidate = os.path.abspath(os.path.join(data_root, value))
+    resolved = os.path.realpath(candidate)
     try:
         inside_data_dir = os.path.commonpath((data_root, resolved)) == data_root
     except ValueError:
         inside_data_dir = False
     if not inside_data_dir:
         raise RuntimeError("relative openai.store.dbPath must stay within DATA_DIR")
-    return resolved
+    # Preserve the lexical final path so _prepare_private_db_path can reject a
+    # symlink inode instead of silently opening its realpath target.
+    return candidate
 
 
 def _resolve_legacy_db_path() -> str:
@@ -179,11 +252,21 @@ def _get_conn() -> sqlite3.Connection:
         _close_local_connection("conn")
         conn = None
     if conn is None:
+        # Check existing sidecars before SQLite can read, replace, or delete
+        # them.  The owner-only-writable parent makes the post-check stable
+        # against another uid racing a replacement.
+        _validate_private_store_files()
         conn = sqlite3.connect(_db_path, timeout=10)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute("PRAGMA synchronous=NORMAL")
-        conn.execute("PRAGMA busy_timeout=5000")
+        try:
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=NORMAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.execute(f"PRAGMA journal_size_limit={_JOURNAL_SIZE_LIMIT_BYTES}")
+            _validate_private_store_files()
+        except BaseException:
+            conn.close()
+            raise
         _local.conn = conn
         _local.conn_path = _db_path
     return conn
@@ -255,12 +338,13 @@ def init() -> None:
         _close_local_connection("legacy_conn")
     _db_path = resolved
     _legacy_db_path = legacy
-    os.makedirs(os.path.dirname(_db_path) or ".", exist_ok=True)
+    _prepare_private_db_path(_db_path)
     conn = _get_conn()
     with _write_lock:
         try:
             conn.executescript(_SCHEMA)
             conn.commit()
+            _validate_private_store_files()
         except BaseException:
             _rollback_failed_write(conn)
             raise
@@ -320,11 +404,31 @@ def save(response_id: str, parent_id: Optional[str], *,
     conn = _get_conn()
     with _write_lock:
         try:
-            conn.execute(
-                """INSERT OR REPLACE INTO openai_response_store
+            local_owner = conn.execute(
+                "SELECT api_key_name FROM openai_response_store WHERE response_id=?",
+                (response_id,),
+            ).fetchone()
+            if local_owner is None:
+                legacy = _legacy_lookup(response_id)
+                if (
+                    legacy is not None
+                    and legacy["api_key_name"] != (api_key_name or "")
+                ):
+                    raise ResponseIdConflict(response_id)
+            cur = conn.execute(
+                """INSERT INTO openai_response_store
                    (response_id, parent_id, api_key_name, model, channel_key,
                     created_at, expires_at, input_items, output_items)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(response_id) DO UPDATE SET
+                     parent_id=excluded.parent_id,
+                     model=excluded.model,
+                     channel_key=excluded.channel_key,
+                     created_at=excluded.created_at,
+                     expires_at=excluded.expires_at,
+                     input_items=excluded.input_items,
+                     output_items=excluded.output_items
+                   WHERE openai_response_store.api_key_name=excluded.api_key_name""",
                 (
                     response_id, parent_id, api_key_name or "", model or "",
                     channel_key or "", now, expires_at,
@@ -332,6 +436,8 @@ def save(response_id: str, parent_id: Optional[str], *,
                     json.dumps(output_items, ensure_ascii=False),
                 ),
             )
+            if cur.rowcount != 1:
+                raise ResponseIdConflict(response_id)
             conn.commit()
         except BaseException:
             _rollback_failed_write(conn)

--- a/src/openai/store.py
+++ b/src/openai/store.py
@@ -1,29 +1,26 @@
 """`previous_response_id` 本地 Store。
 
-挂在既有 `state.db` 上的一张独立表（`openai_response_store`），与 anthropic 侧
-表名隔离。Responses API 是有状态的：客户端可以用 `previous_response_id`
-续接历史；当上游是 openai-chat（无状态）时，proxy 必须本地展开历史并翻成
-chat messages 送给上游。
+新记录写入独立 SQLite，避免大 history 的写入和清理阻塞 ``state.db`` 中的
+评分、冷却与亲和状态。升级时不在线搬迁旧大表；新库 miss 后只读查询旧
+``state.db.openai_response_store``，让旧 response 链在原 TTL 内继续可用。
 
-模块级单例：
-  - `init()` 启动时调一次；失败则抛 RuntimeError
-  - `save(...)` / `lookup(...)` / `expand_history(...)` 接口
-  - `cleanup_expired()` / `cleanup_loop()` 后台清理
-
-并发：独立的 thread-local sqlite 连接 + 模块级 RLock 序列化写；SQLite WAL
-模式已处理跨进程（单进程）/跨线程的读写隔离。
+连接采用 thread-local，进程内写入由模块级 RLock 串行化，读取使用 WAL。
+过期清理采用有界批次，每批独立提交并在批次间让出写锁。
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
+from pathlib import Path
 import sqlite3
+import stat
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Optional
 
 from .. import config
 
@@ -67,28 +64,166 @@ _local = threading.local()
 _write_lock = threading.RLock()
 _initialized = False
 _db_path: Optional[str] = None
+_legacy_db_path: Optional[str] = None
+_DEFAULT_DB_NAME = "openai_response_store.db"
+_logger = logging.getLogger(__name__)
+_cleanup_warning_lock = threading.Lock()
+_last_cleanup_warning_at = 0.0
+_CLEANUP_WARNING_INTERVAL_SECONDS = 3600.0
+
+
+def _paths_same_file(left: str, right: str) -> bool:
+    """Compare paths by resolution and, when possible, by inode."""
+    if os.path.realpath(left) == os.path.realpath(right):
+        return True
+    try:
+        return os.path.samefile(left, right)
+    except OSError:
+        return False
+
+
+def _legacy_regular_file_exists(path: str) -> bool:
+    """Return False only for a definite ENOENT legacy database.
+
+    Permission, mount and wrong-file-type failures must remain observable so
+    they cannot be rewritten as previous_response_id 404 responses.
+    """
+    try:
+        info = os.stat(path)
+    except FileNotFoundError:
+        return False
+    if not stat.S_ISREG(info.st_mode):
+        raise sqlite3.OperationalError(
+            f"legacy response store path is not a regular file: {path}"
+        )
+    return True
+
+
+def _absolute_data_path(value: str) -> str:
+    if os.path.isabs(value):
+        return os.path.abspath(value)
+    data_root = os.path.realpath(config.DATA_DIR)
+    resolved = os.path.realpath(os.path.join(data_root, value))
+    try:
+        inside_data_dir = os.path.commonpath((data_root, resolved)) == data_root
+    except ValueError:
+        inside_data_dir = False
+    if not inside_data_dir:
+        raise RuntimeError("relative openai.store.dbPath must stay within DATA_DIR")
+    return resolved
+
+
+def _resolve_legacy_db_path() -> str:
+    # Preserve the existing stateDbPath resolution semantics for compatibility;
+    # only the new Store path gets the stricter DATA_DIR containment check.
+    value = str(config.get().get("stateDbPath", "state.db"))
+    if os.path.isabs(value):
+        return os.path.abspath(value)
+    return os.path.abspath(os.path.join(config.DATA_DIR, value))
 
 
 def _resolve_db_path() -> str:
-    """与 state_db 共用同一数据库文件。"""
+    """Resolve ``openai.store.dbPath`` relative to DATA_DIR.
+
+    An omitted path always gets a database distinct from ``stateDbPath``.  An
+    explicitly identical path is rejected: silently accepting it would bring
+    back the lock coupling this store exists to remove and would write the
+    legacy database during an upgrade.
+    """
     cfg = config.get()
-    rel = cfg.get("stateDbPath", "state.db")
-    if os.path.isabs(rel):
-        return rel
-    return os.path.join(config.DATA_DIR, rel)
+    store_cfg = (((cfg.get("openai") or {}).get("store")) or {})
+    configured = store_cfg.get("dbPath")
+    path = _absolute_data_path(str(configured or _DEFAULT_DB_NAME))
+    legacy = _resolve_legacy_db_path()
+    if _paths_same_file(path, legacy):
+        # config.get() deep-merges defaults, so the default value can be
+        # present even when the user never wrote this key.
+        if configured and str(configured) != _DEFAULT_DB_NAME:
+            raise RuntimeError("openai.store.dbPath must differ from stateDbPath")
+        # Defensive for unusual stateDbPath values matching the default.
+        path = _absolute_data_path("openai_response_store.v2.db")
+        if _paths_same_file(path, legacy):
+            raise RuntimeError("openai.store.dbPath fallback still aliases stateDbPath")
+    return path
+
+
+def _close_local_connection(name: str) -> None:
+    conn = getattr(_local, name, None)
+    if conn is not None:
+        try:
+            conn.close()
+        except sqlite3.Error:
+            pass
+    setattr(_local, name, None)
+    setattr(_local, f"{name}_path", None)
+
+
+def _rollback_failed_write(conn: sqlite3.Connection) -> None:
+    try:
+        conn.rollback()
+    except Exception:
+        try:
+            conn.close()
+        except Exception:
+            pass
+        if getattr(_local, "conn", None) is conn:
+            _local.conn = None
+            _local.conn_path = None
 
 
 def _get_conn() -> sqlite3.Connection:
-    if getattr(_local, "conn", None) is None:
-        if _db_path is None:
-            raise RuntimeError("openai.store.init() not called")
+    if _db_path is None:
+        raise RuntimeError("openai.store.init() not called")
+    conn = getattr(_local, "conn", None)
+    if conn is not None and getattr(_local, "conn_path", None) != _db_path:
+        _close_local_connection("conn")
+        conn = None
+    if conn is None:
         conn = sqlite3.connect(_db_path, timeout=10)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA synchronous=NORMAL")
         conn.execute("PRAGMA busy_timeout=5000")
         _local.conn = conn
-    return _local.conn
+        _local.conn_path = _db_path
+    return conn
+
+
+def _get_legacy_conn() -> Optional[sqlite3.Connection]:
+    """Open legacy state.db read-only, without creating a missing file."""
+    path = _legacy_db_path
+    if not path or (_db_path and _paths_same_file(path, _db_path)):
+        _close_local_connection("legacy_conn")
+        return None
+    if not _legacy_regular_file_exists(path):
+        _close_local_connection("legacy_conn")
+        return None
+    conn = getattr(_local, "legacy_conn", None)
+    if conn is not None and getattr(_local, "legacy_conn_path", None) != path:
+        _close_local_connection("legacy_conn")
+        conn = None
+    if conn is None:
+        try:
+            uri = f"{Path(path).resolve().as_uri()}?mode=ro"
+            conn = sqlite3.connect(uri, uri=True, timeout=1)
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA query_only=ON")
+            conn.execute("PRAGMA busy_timeout=1000")
+        except sqlite3.Error:
+            if conn is not None:
+                try:
+                    conn.close()
+                except sqlite3.Error:
+                    pass
+            # A file removed between the existence check and connect is a
+            # clean legacy miss. Permission/I/O/corruption failures must stay
+            # observable instead of being rewritten as response-id 404.
+            if not _legacy_regular_file_exists(path):
+                return None
+            raise
+        _local.legacy_conn = conn
+        _local.legacy_conn_path = path
+    return conn
 
 
 _SCHEMA = """
@@ -109,20 +244,30 @@ CREATE INDEX IF NOT EXISTS idx_resp_store_key     ON openai_response_store(api_k
 
 
 def init() -> None:
-    global _initialized, _db_path
-    if _initialized:
+    global _initialized, _db_path, _legacy_db_path
+    resolved = _resolve_db_path()
+    legacy = _resolve_legacy_db_path()
+    if _initialized and _db_path == resolved and _legacy_db_path == legacy:
         return
-    _db_path = _resolve_db_path()
+    if _db_path != resolved:
+        _close_local_connection("conn")
+    if _legacy_db_path != legacy:
+        _close_local_connection("legacy_conn")
+    _db_path = resolved
+    _legacy_db_path = legacy
     os.makedirs(os.path.dirname(_db_path) or ".", exist_ok=True)
     conn = _get_conn()
     with _write_lock:
-        conn.executescript(_SCHEMA)
-        conn.commit()
+        try:
+            conn.executescript(_SCHEMA)
+            conn.commit()
+        except BaseException:
+            _rollback_failed_write(conn)
+            raise
+    was_initialized = _initialized
     _initialized = True
-    print(f"[openai_store] Using {_db_path}")
-
-
-# ─── 配置访问 ────────────────────────────────────────────────────
+    if not was_initialized:
+        print(f"[openai_store] Using {_db_path} (legacy fallback: {_legacy_db_path})")
 
 
 def _store_cfg() -> dict:
@@ -142,6 +287,25 @@ def _cleanup_interval_seconds() -> int:
     return int(_store_cfg().get("cleanupIntervalSeconds", 300))
 
 
+def _cleanup_batch_size() -> int:
+    return max(1, min(int(_store_cfg().get("cleanupBatchSize", 100)), 1_000))
+
+
+def _cleanup_batch_bytes() -> int:
+    return max(
+        1,
+        min(int(_store_cfg().get("cleanupBatchBytes", 8 * 1024 * 1024)), 1024 * 1024 * 1024),
+    )
+
+
+def _cleanup_max_batches() -> int:
+    return max(1, min(int(_store_cfg().get("cleanupMaxBatches", 100)), 1_000))
+
+
+def _cleanup_time_budget_seconds() -> float:
+    return max(0.01, min(float(_store_cfg().get("cleanupTimeBudgetSeconds", 10)), 60.0))
+
+
 # ─── CRUD ────────────────────────────────────────────────────────
 
 
@@ -150,38 +314,48 @@ def save(response_id: str, parent_id: Optional[str], *,
          input_items: list, output_items: list,
          ttl_seconds: Optional[int] = None) -> None:
     if not _initialized:
-        # Store 未初始化时静默跳过，避免阻塞请求主路径
         return
     now = time.time()
-    ttl = ttl_seconds if ttl_seconds is not None else _ttl_seconds()
-    expires_at = now + ttl
+    expires_at = now + (ttl_seconds if ttl_seconds is not None else _ttl_seconds())
     conn = _get_conn()
     with _write_lock:
-        conn.execute(
-            """INSERT OR REPLACE INTO openai_response_store
-               (response_id, parent_id, api_key_name, model, channel_key,
-                created_at, expires_at, input_items, output_items)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (
-                response_id, parent_id, api_key_name or "", model or "",
-                channel_key or "", now, expires_at,
-                json.dumps(input_items, ensure_ascii=False),
-                json.dumps(output_items, ensure_ascii=False),
-            ),
-        )
-        conn.commit()
+        try:
+            conn.execute(
+                """INSERT OR REPLACE INTO openai_response_store
+                   (response_id, parent_id, api_key_name, model, channel_key,
+                    created_at, expires_at, input_items, output_items)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    response_id, parent_id, api_key_name or "", model or "",
+                    channel_key or "", now, expires_at,
+                    json.dumps(input_items, ensure_ascii=False),
+                    json.dumps(output_items, ensure_ascii=False),
+                ),
+            )
+            conn.commit()
+        except BaseException:
+            _rollback_failed_write(conn)
+            raise
 
 
-def lookup(response_id: str, *, api_key_name: str) -> StoredResponse:
-    if not _initialized:
-        raise ResponseNotFound(response_id)
-    conn = _get_conn()
-    row = conn.execute(
-        "SELECT * FROM openai_response_store WHERE response_id=?",
-        (response_id,),
-    ).fetchone()
-    if row is None:
-        raise ResponseNotFound(response_id)
+def _legacy_lookup(response_id: str) -> Optional[sqlite3.Row]:
+    conn = _get_legacy_conn()
+    if conn is None:
+        return None
+    try:
+        return conn.execute(
+            "SELECT * FROM openai_response_store WHERE response_id=?",
+            (response_id,),
+        ).fetchone()
+    except sqlite3.OperationalError as exc:
+        # A pre-store state.db legitimately has no such table. Other SQLite
+        # failures are service errors, not proof that the response id is absent.
+        if "no such table: openai_response_store" in str(exc).lower():
+            return None
+        raise
+
+
+def _row_to_response(row: sqlite3.Row, response_id: str, api_key_name: str) -> StoredResponse:
     if row["api_key_name"] != (api_key_name or ""):
         raise ResponseForbidden(response_id)
     if row["expires_at"] is not None and float(row["expires_at"]) < time.time():
@@ -189,7 +363,7 @@ def lookup(response_id: str, *, api_key_name: str) -> StoredResponse:
     try:
         input_items = json.loads(row["input_items"]) if row["input_items"] else []
         output_items = json.loads(row["output_items"]) if row["output_items"] else []
-    except Exception:
+    except (TypeError, ValueError, json.JSONDecodeError):
         input_items = []
         output_items = []
     return StoredResponse(
@@ -205,22 +379,31 @@ def lookup(response_id: str, *, api_key_name: str) -> StoredResponse:
     )
 
 
+def lookup(response_id: str, *, api_key_name: str) -> StoredResponse:
+    if not _initialized:
+        raise ResponseNotFound(response_id)
+    row = _get_conn().execute(
+        "SELECT * FROM openai_response_store WHERE response_id=?",
+        (response_id,),
+    ).fetchone()
+    if row is None:
+        row = _legacy_lookup(response_id)
+    if row is None:
+        raise ResponseNotFound(response_id)
+    return _row_to_response(row, response_id, api_key_name)
+
+
 def expand_history(response_id: str, *, api_key_name: str,
                    max_depth: int = 50) -> list[dict]:
-    """沿 parent_id 链向上展开，返回 items 列表（老→新；`input_items + output_items` 连接）。
-
-    链循环（防御性）或深度超 `max_depth` 时截断，返回已收集的部分。
-    """
+    """沿 parent_id 展开为老→新 items；遇到循环或超过 max_depth 时截断。"""
     chain: list[StoredResponse] = []
     seen: set[str] = set()
     cur: Optional[str] = response_id
-    depth = 0
-    while cur and cur not in seen and depth < max_depth:
+    while cur and cur not in seen and len(chain) < max_depth:
         seen.add(cur)
         rec = lookup(cur, api_key_name=api_key_name)
         chain.append(rec)
         cur = rec.parent_id
-        depth += 1
     chain.reverse()
     items: list[dict] = []
     for rec in chain:
@@ -229,22 +412,84 @@ def expand_history(response_id: str, *, api_key_name: str,
     return items
 
 
-def cleanup_expired(now: Optional[float] = None) -> int:
-    """清理过期记录，返回清理数量。"""
+def cleanup_expired(now: Optional[float] = None, *,
+                    batch_size: Optional[int] = None,
+                    max_batches: Optional[int] = None,
+                    batch_bytes: Optional[int] = None,
+                    time_budget_seconds: Optional[float] = None) -> int:
+    """Delete expired rows in short byte-bounded transactions.
+
+    Row and time limits let a backlog catch up without holding the Store write
+    lock for an entire cleanup run. A single oversized row is still deleted by
+    itself so it cannot permanently block progress.
+    """
     if not _initialized:
         return 0
+    cutoff = now if now is not None else time.time()
+    size = (
+        _cleanup_batch_size()
+        if batch_size is None else max(1, min(int(batch_size), 1_000))
+    )
+    batches = (
+        _cleanup_max_batches()
+        if max_batches is None else max(1, min(int(max_batches), 1_000))
+    )
+    byte_limit = (
+        _cleanup_batch_bytes()
+        if batch_bytes is None else max(1, min(int(batch_bytes), 1024 * 1024 * 1024))
+    )
+    time_budget = (
+        _cleanup_time_budget_seconds()
+        if time_budget_seconds is None
+        else max(0.01, min(float(time_budget_seconds), 60.0))
+    )
+    started = time.monotonic()
+    total = 0
     conn = _get_conn()
-    with _write_lock:
-        cur = conn.execute(
-            "DELETE FROM openai_response_store WHERE expires_at < ?",
-            (now if now is not None else time.time(),),
-        )
-        conn.commit()
-        return cur.rowcount or 0
+    for _ in range(batches):
+        with _write_lock:
+            try:
+                rows = conn.execute(
+                    """SELECT response_id,
+                              length(CAST(input_items AS BLOB))
+                              + length(CAST(output_items AS BLOB)) AS payload_bytes
+                       FROM openai_response_store
+                       WHERE expires_at < ? ORDER BY expires_at LIMIT ?""",
+                    (cutoff, size),
+                ).fetchall()
+                if not rows:
+                    conn.commit()
+                    break
+                selected: list[tuple[str]] = []
+                selected_bytes = 0
+                for row in rows:
+                    row_bytes = max(0, int(row["payload_bytes"] or 0))
+                    if selected and selected_bytes + row_bytes > byte_limit:
+                        break
+                    selected.append((str(row["response_id"]),))
+                    selected_bytes += row_bytes
+                cur = conn.executemany(
+                    "DELETE FROM openai_response_store WHERE response_id=?",
+                    selected,
+                )
+                deleted = max(0, cur.rowcount or 0)
+                conn.commit()
+            except BaseException:
+                _rollback_failed_write(conn)
+                raise
+        total += deleted
+        if deleted == 0:
+            break
+        # Let response-save threads acquire the Store lock between batches.
+        time.sleep(0)
+        if time.monotonic() - started >= time_budget:
+            break
+    return total
 
 
 async def cleanup_loop() -> None:
-    """后台循环：每 `cleanupIntervalSeconds` 跑一次 cleanup_expired。"""
+    """每隔 cleanupIntervalSeconds 在后台清理一轮过期记录。"""
+    global _last_cleanup_warning_at
     while True:
         try:
             interval = _cleanup_interval_seconds()
@@ -256,17 +501,34 @@ async def cleanup_loop() -> None:
             if cleared:
                 print(f"[openai_store] cleaned {cleared} expired entries")
         except Exception as exc:
-            print(f"[openai_store] cleanup failed: {exc}")
+            now = time.monotonic()
+            with _cleanup_warning_lock:
+                should_warn = (
+                    not _last_cleanup_warning_at
+                    or now - _last_cleanup_warning_at >= _CLEANUP_WARNING_INTERVAL_SECONDS
+                )
+                if should_warn:
+                    _last_cleanup_warning_at = now
+            if should_warn:
+                _logger.warning("openai Store cleanup failed: %s", exc, exc_info=True)
 
 
 # ─── 测试辅助 ────────────────────────────────────────────────────
 
 
-def _reset_for_test() -> None:
-    """仅测试用：清空表（保留 schema）。"""
-    if not _initialized:
+def _reset_for_test(*, reinitialize: bool = False) -> None:
+    """仅清新库；reinitialize=True 时关闭 thread-local 连接并重置初始化状态。"""
+    global _initialized, _db_path, _legacy_db_path, _last_cleanup_warning_at
+    _last_cleanup_warning_at = 0.0
+    if _initialized and not reinitialize:
+        conn = _get_conn()
+        with _write_lock:
+            conn.execute("DELETE FROM openai_response_store")
+            conn.commit()
         return
-    conn = _get_conn()
-    with _write_lock:
-        conn.execute("DELETE FROM openai_response_store")
-        conn.commit()
+    _close_local_connection("conn")
+    _close_local_connection("legacy_conn")
+    if reinitialize:
+        _initialized = False
+        _db_path = None
+        _legacy_db_path = None

--- a/src/openai/transform/responses_to_chat.py
+++ b/src/openai/transform/responses_to_chat.py
@@ -16,10 +16,12 @@ from __future__ import annotations
 
 import copy
 import json
+import sqlite3
 import time
 import uuid
 from typing import Any, Optional
 
+from ...sqlite_errors import is_availability_error
 from . import guard
 
 
@@ -216,6 +218,14 @@ def _resolve_input(body: dict, *, api_key_name: str = "") -> list:
                 f"previous_response_id '{prev_id}' does not belong to this API key",
                 param="previous_response_id",
             )
+        except sqlite3.Error as exc:
+            if not is_availability_error(exc):
+                raise
+            raise _guard.GuardError(
+                503, "server_error",
+                "previous_response_id store is temporarily unavailable",
+                param="previous_response_id",
+            ) from exc
 
     cur = body.get("input")
     if isinstance(cur, str):
@@ -709,21 +719,26 @@ def translate_response(chat: dict, *, model: str,
                     output_items=output_items,
                 )
         except Exception as exc:
-            import traceback as _tb
-            _tb.print_exc()
             from ... import notifier as _notifier
             ek = _notifier.escape_html
-            _notifier.throttled_notify_event_sync(
-                "openai_store_save_failed",
-                f"openai_store_save_failed:{api_key_name}",
-                f"❌ {_notifier.provider_custom_emoji_html('openai')} <b>OpenAI Store 写入失败</b>（非流式）\n"
-                f"API Key: <code>{ek(api_key_name)}</code>\n"
-                f"模型: <code>{ek(model)}</code> · 渠道: <code>{ek(channel_key or '?')}</code>\n"
-                f"resp_id: <code>{ek(resp_id)}</code>\n"
-                f"原因: <code>{ek(str(exc))[:300]}</code>\n"
-                "⚠ 下一次带该 previous_response_id 的请求会 404；"
-                "请检查 state.db 读写权限与磁盘空间。",
-            )
+            should_log = True
+            try:
+                should_log = _notifier.throttled_notify_event_sync(
+                    "openai_store_save_failed",
+                    f"openai_store_save_failed:{api_key_name}",
+                    f"❌ {_notifier.provider_custom_emoji_html('openai')} <b>OpenAI Store 写入失败</b>（非流式）\n"
+                    f"API Key: <code>{ek(api_key_name)}</code>\n"
+                    f"模型: <code>{ek(model)}</code> · 渠道: <code>{ek(channel_key or '?')}</code>\n"
+                    f"resp_id: <code>{ek(resp_id)}</code>\n"
+                    f"原因: <code>{ek(str(exc))[:300]}</code>\n"
+                    "⚠ 下一次带该 previous_response_id 的请求会 404；"
+                    "请检查 openai.store.dbPath 配置、对应文件权限与磁盘空间。",
+                )
+            except Exception:
+                pass
+            if should_log:
+                import traceback as _tb
+                _tb.print_exc()
 
     return resp
 

--- a/src/openai/transform/stream_c2r.py
+++ b/src/openai/transform/stream_c2r.py
@@ -835,22 +835,27 @@ class StreamTranslator:
         except Exception as exc:
             # 与非流式 translate_response 的处理一致：失败不中断已发完的流，
             # 但走节流告警让运维能看到（详见 responses_to_chat.translate_response）。
-            import traceback as _tb
-            _tb.print_exc()
             from ... import notifier as _notifier
             ek = _notifier.escape_html
-            _notifier.throttled_notify_event_sync(
-                "openai_store_save_failed",
-                f"openai_store_save_failed:{self._store_api_key_name}",
-                f"❌ {_notifier.provider_custom_emoji_html('openai')} <b>OpenAI Store 写入失败</b>（流式）\n"
-                f"API Key: <code>{ek(self._store_api_key_name)}</code>\n"
-                f"模型: <code>{ek(self.state.model)}</code> · "
-                f"渠道: <code>{ek(self._store_channel_key or '?')}</code>\n"
-                f"resp_id: <code>{ek(self.state.resp_id)}</code>\n"
-                f"原因: <code>{ek(str(exc))[:300]}</code>\n"
-                "⚠ 下一次带该 previous_response_id 的请求会 404；"
-                "请检查 state.db 读写权限与磁盘空间。",
-            )
+            should_log = True
+            try:
+                should_log = _notifier.throttled_notify_event_sync(
+                    "openai_store_save_failed",
+                    f"openai_store_save_failed:{self._store_api_key_name}",
+                    f"❌ {_notifier.provider_custom_emoji_html('openai')} <b>OpenAI Store 写入失败</b>（流式）\n"
+                    f"API Key: <code>{ek(self._store_api_key_name)}</code>\n"
+                    f"模型: <code>{ek(self.state.model)}</code> · "
+                    f"渠道: <code>{ek(self._store_channel_key or '?')}</code>\n"
+                    f"resp_id: <code>{ek(self.state.resp_id)}</code>\n"
+                    f"原因: <code>{ek(str(exc))[:300]}</code>\n"
+                    "⚠ 下一次带该 previous_response_id 的请求会 404；"
+                    "请检查 openai.store.dbPath 配置、对应文件权限与磁盘空间。",
+                )
+            except Exception:
+                pass
+            if should_log:
+                import traceback as _tb
+                _tb.print_exc()
 
     def _response_skeleton(self, *, status: str) -> dict:
         # 02-bug-findings #13: spec Response required 14 字段

--- a/src/protocols/finalize.py
+++ b/src/protocols/finalize.py
@@ -8,14 +8,43 @@ affinity, or close transports.  Callers keep the ordering and I/O details.
 
 from __future__ import annotations
 
+import logging
+import sqlite3
+import threading
+import time
 from dataclasses import dataclass
 from typing import Literal
 
+from ..sqlite_errors import is_availability_error
 from .runtime import should_cooldown, should_record_failure
 
 
 TerminalKind = Literal["success", "error", "client_cancelled"]
 FailurePolicy = Literal["runtime", "post_commit_stream", "cooldown_only"]
+_logger = logging.getLogger(__name__)
+_warning_lock = threading.Lock()
+_last_warning_at: dict[str, float] = {}
+_WARNING_INTERVAL_SECONDS = 60.0
+
+
+def _warn_availability_failure(name: str, exc: sqlite3.Error) -> None:
+    now = time.monotonic()
+    with _warning_lock:
+        last = _last_warning_at.get(name, 0.0)
+        if last and now - last < _WARNING_INTERVAL_SECONDS:
+            return
+        _last_warning_at[name] = now
+    _logger.warning("finalize health effect %s failed; response preserved: %s", name, exc)
+
+
+def _run_health_effect(name: str, effect) -> None:
+    """Keep SQLite health persistence failures off the primary response path."""
+    try:
+        effect()
+    except sqlite3.Error as exc:
+        if not is_availability_error(exc):
+            raise
+        _warn_availability_failure(name, exc)
 
 
 @dataclass(frozen=True)
@@ -100,15 +129,18 @@ def apply_success_health_effects(
 ) -> None:
     """Apply success scorer/cooldown effects for a precomputed plan."""
     if plan.record_success:
-        scorer.record_success(
-            channel_key,
-            model,
-            connect_ms=connect_ms,
-            first_byte_ms=first_byte_ms,
-            total_ms=total_ms,
+        _run_health_effect(
+            "record_success",
+            lambda: scorer.record_success(
+                channel_key,
+                model,
+                connect_ms=connect_ms,
+                first_byte_ms=first_byte_ms,
+                total_ms=total_ms,
+            ),
         )
     if plan.clear_cooldown:
-        cooldown.clear(channel_key, model)
+        _run_health_effect("clear_cooldown", lambda: cooldown.clear(channel_key, model))
 
 
 def apply_error_health_effects(
@@ -123,6 +155,12 @@ def apply_error_health_effects(
 ) -> None:
     """Apply error scorer/cooldown effects for a precomputed plan."""
     if plan.record_cooldown_error:
-        cooldown.record_error(channel_key, model, error_detail)
+        _run_health_effect(
+            "record_cooldown_error",
+            lambda: cooldown.record_error(channel_key, model, error_detail),
+        )
     if plan.record_failure:
-        scorer.record_failure(channel_key, model, connect_ms=connect_ms)
+        _run_health_effect(
+            "record_failure",
+            lambda: scorer.record_failure(channel_key, model, connect_ms=connect_ms),
+        )

--- a/src/scorer.py
+++ b/src/scorer.py
@@ -18,17 +18,27 @@
 
 from __future__ import annotations
 
+import logging
 import random
+import sqlite3
 import threading
 import time
 from typing import Optional
 
-from . import config, state_db
+from . import channel_state, config, state_db
+from .sqlite_errors import is_availability_error
 
 
 _lock = threading.Lock()
+# Keep one score mutation's memory snapshot and persistence ordered with
+# channel-key renames.  Reads still use only _lock and remain cheap.
+_mutation_lock = channel_state.mutation_lock
 _stats: dict[tuple[str, str], dict] = {}
 _initialized = False
+_logger = logging.getLogger(__name__)
+_persist_warning_lock = threading.Lock()
+_last_persist_warning_at = 0.0
+_PERSIST_WARNING_INTERVAL_SECONDS = 60.0
 
 # Old rows aggregated the superseded physical-connect meaning.  A deployment
 # must explicitly activate this version after reviewing production state.db;
@@ -146,11 +156,35 @@ def get_score(channel_key: str, model: str) -> float:
     return calculate_score(_get(channel_key, model))
 
 
+def _persist_best_effort(channel_key: str, model: str, snapshot: dict) -> None:
+    """Persist scoring without allowing SQLite failures onto the response path."""
+    global _last_persist_warning_at
+    try:
+        with state_db.optional_write_timeout():
+            state_db.perf_save(channel_key, model, snapshot)
+    except sqlite3.Error as exc:
+        if not is_availability_error(exc):
+            raise
+        now = time.monotonic()
+        should_warn = False
+        with _persist_warning_lock:
+            if (
+                _last_persist_warning_at == 0.0
+                or now - _last_persist_warning_at >= _PERSIST_WARNING_INTERVAL_SECONDS
+            ):
+                _last_persist_warning_at = now
+                should_warn = True
+        if should_warn:
+            _logger.warning(
+                "scorer SQLite persistence failed; keeping in-memory score: %s", exc,
+            )
+
+
 # ─── 记录成功 / 失败 ─────────────────────────────────────────────
 
-def record_success(channel_key: str, model: str,
-                   connect_ms: Optional[float], first_byte_ms: Optional[float],
-                   total_ms: Optional[float]) -> None:
+def _record_success(channel_key: str, model: str,
+                    connect_ms: Optional[float], first_byte_ms: Optional[float],
+                    total_ms: Optional[float]) -> None:
     params = _params()
     window = params["recentWindow"]
     alpha = params["emaAlpha"]
@@ -203,10 +237,20 @@ def record_success(channel_key: str, model: str,
 
         snapshot = dict(stats)
 
-    state_db.perf_save(channel_key, model, snapshot)
+    _persist_best_effort(channel_key, model, snapshot)
 
 
-def record_failure(channel_key: str, model: str, connect_ms: Optional[float]) -> None:
+def record_success(channel_key: str, model: str,
+                   connect_ms: Optional[float], first_byte_ms: Optional[float],
+                   total_ms: Optional[float]) -> None:
+    with _mutation_lock:
+        channel_key = channel_state.resolve(channel_key)
+        if channel_state.is_deleted(channel_key):
+            return
+        _record_success(channel_key, model, connect_ms, first_byte_ms, total_ms)
+
+
+def _record_failure(channel_key: str, model: str, connect_ms: Optional[float]) -> None:
     params = _params()
     window = params["recentWindow"]
     alpha = params["emaAlpha"]
@@ -241,7 +285,15 @@ def record_failure(channel_key: str, model: str, connect_ms: Optional[float]) ->
 
         snapshot = dict(stats)
 
-    state_db.perf_save(channel_key, model, snapshot)
+    _persist_best_effort(channel_key, model, snapshot)
+
+
+def record_failure(channel_key: str, model: str, connect_ms: Optional[float]) -> None:
+    with _mutation_lock:
+        channel_key = channel_state.resolve(channel_key)
+        if channel_state.is_deleted(channel_key):
+            return
+        _record_failure(channel_key, model, connect_ms)
 
 
 # ─── 排序 + 探索 ────────────────────────────────────────────────
@@ -329,26 +381,35 @@ def timing_semantics_migration(*, apply: bool = False) -> dict:
 
 
 def clear_stats(channel_key: Optional[str] = None, model: Optional[str] = None) -> None:
-    with _lock:
-        if channel_key and model:
-            _stats.pop((channel_key, model), None)
-        elif channel_key:
-            for k in [k for k in _stats if k[0] == channel_key]:
-                _stats.pop(k, None)
-        else:
-            _stats.clear()
-    state_db.perf_delete(channel_key, model)
+    with _mutation_lock:
+        state_db.perf_delete(channel_key, model)
+        with _lock:
+            if channel_key and model:
+                _stats.pop((channel_key, model), None)
+            elif channel_key:
+                for k in [k for k in _stats if k[0] == channel_key]:
+                    _stats.pop(k, None)
+            else:
+                _stats.clear()
 
 
-def rename_channel(old_key: str, new_key: str) -> None:
+def rename_channel(old_key: str, new_key: str, *, persist: bool = True) -> None:
     if old_key == new_key:
         return
-    with _lock:
-        items = [(k, v) for k, v in _stats.items() if k[0] == old_key]
-        for (_, m), v in items:
-            _stats.pop((old_key, m), None)
-            _stats[(new_key, m)] = v
-    state_db.perf_rename_channel(old_key, new_key)
+    with _mutation_lock:
+        if persist:
+            with state_db.optional_write_timeout():
+                state_db.perf_rename_channel(old_key, new_key)
+        with _lock:
+            items = [(k, v) for k, v in _stats.items() if k[0] == old_key]
+            for (_, m), v in items:
+                _stats.pop((old_key, m), None)
+                current = _stats.get((new_key, m))
+                if (
+                    current is None
+                    or int(v.get("last_updated", 0)) > int(current.get("last_updated", 0))
+                ):
+                    _stats[(new_key, m)] = v
 
 
 def snapshot() -> list[dict]:
@@ -372,3 +433,9 @@ def snapshot() -> list[dict]:
                 "score": round(score),
             })
     return out
+
+
+def channel_keys() -> set[str]:
+    """Return raw in-memory keys without requiring complete display stats."""
+    with _lock:
+        return {channel_key for channel_key, _model in _stats}

--- a/src/sqlite_errors.py
+++ b/src/sqlite_errors.py
@@ -1,0 +1,47 @@
+"""SQLite error classification shared by optional persistence side effects."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+_AVAILABILITY_PRIMARY_CODES = {
+    sqlite3.SQLITE_BUSY,
+    sqlite3.SQLITE_LOCKED,
+    sqlite3.SQLITE_NOMEM,
+    sqlite3.SQLITE_READONLY,
+    sqlite3.SQLITE_IOERR,
+    sqlite3.SQLITE_FULL,
+    sqlite3.SQLITE_CANTOPEN,
+    sqlite3.SQLITE_PROTOCOL,
+}
+_AVAILABILITY_MESSAGES = (
+    "database is locked",
+    "database table is locked",
+    "disk i/o error",
+    "database or disk is full",
+    "attempt to write a readonly database",
+    "unable to open database file",
+    "out of memory",
+)
+
+
+def is_availability_error(exc: BaseException) -> bool:
+    """Return whether a SQLite failure is environmental and safe to degrade.
+
+    Programming/schema/data-contract failures must remain visible. Only
+    lock/resource/I/O availability failures may skip an optional persistence
+    side effect while preserving the primary model response. Extended SQLite
+    result codes are reduced to their primary code.
+    """
+    if not isinstance(exc, sqlite3.Error):
+        return False
+    if isinstance(exc, (sqlite3.ProgrammingError, sqlite3.IntegrityError,
+                        sqlite3.DataError, sqlite3.NotSupportedError,
+                        sqlite3.InterfaceError)):
+        return False
+    code = getattr(exc, "sqlite_errorcode", None)
+    if isinstance(code, int):
+        return (code & 0xFF) in _AVAILABILITY_PRIMARY_CODES
+    message = str(exc).lower()
+    return any(fragment in message for fragment in _AVAILABILITY_MESSAGES)

--- a/src/state_db.py
+++ b/src/state_db.py
@@ -9,6 +9,7 @@ import os
 import sqlite3
 import threading
 import time
+from contextlib import contextmanager
 from typing import Any, Iterable
 
 from . import config
@@ -144,10 +145,14 @@ def init() -> None:
     os.makedirs(os.path.dirname(_db_path) or ".", exist_ok=True)
     conn = _get_conn()
     with _write_lock:
-        conn.executescript(_schema_sql())
-        _migrate_affinity_prompt_cache_key_col(conn)
-        _migrate_oauth_quota_cache_openai_cols(conn)
-        conn.commit()
+        try:
+            conn.executescript(_schema_sql())
+            _migrate_affinity_prompt_cache_key_col(conn)
+            _migrate_oauth_quota_cache_openai_cols(conn)
+            conn.commit()
+        except BaseException:
+            _rollback_failed_write(conn)
+            raise
     if not _initialized:
         print(f"[state_db] Using {_db_path}")
     _initialized = True
@@ -180,12 +185,12 @@ def schema_meta_get(key: str) -> str | None:
 
 
 def schema_meta_set(key: str, value: str) -> None:
-    with _write_lock:
-        _get_conn().execute(
+    def write(conn):
+        conn.execute(
             "INSERT OR REPLACE INTO schema_meta (key, value) VALUES (?, ?)",
             (key, value),
         )
-        _get_conn().commit()
+    _commit_write(write)
 
 
 # ================================================================
@@ -280,19 +285,7 @@ def run_composite_key_migration(email_to_key: dict[str, str]) -> dict:
                 new_ck = f"oauth:{ak}"
                 if old_ck == new_ck:
                     continue
-                r1 = conn.execute(
-                    "UPDATE performance_stats SET channel_key=? WHERE channel_key=?",
-                    (new_ck, old_ck),
-                )
-                r2 = conn.execute(
-                    "UPDATE channel_errors SET channel_key=? WHERE channel_key=?",
-                    (new_ck, old_ck),
-                )
-                r3 = conn.execute(
-                    "UPDATE cache_affinities SET channel_key=? WHERE channel_key=?",
-                    (new_ck, old_ck),
-                )
-                ch_migrated += r1.rowcount + r2.rowcount + r3.rowcount
+                ch_migrated += _rename_channel_key_no_commit(conn, old_ck, new_ck)
             stats["migrated_channel_rows"] = ch_migrated
 
             conn.execute(
@@ -376,136 +369,129 @@ def _rename_performance_stats_channel_key_no_commit(
     return updated_conflicts + deleted_conflicts + renamed
 
 def _rename_channel_key_no_commit(conn: sqlite3.Connection, old_key: str, new_key: str) -> int:
+    """Rename all persisted channel mirrors inside the caller's transaction.
+
+    Startup migrations call this directly; runtime renames call it through
+    ``rename_runtime_channel_state`` and publish memory under channel_state's
+    shared lifecycle lock.
+    """
     if old_key == new_key:
         return 0
     count = 0
     # performance_stats 有 PRIMARY KEY(channel_key, model)，需先合并再改名。
     count += _rename_performance_stats_channel_key_no_commit(conn, old_key, new_key)
-    # 其他表没有同样的复合唯一键冲突，直接改名即可。
-    for table in ("channel_errors", "cache_affinities", "client_affinities"):
+    # channel_errors 同样有 PRIMARY KEY(channel_key, model)。运行时 cooldown
+    # 的既有语义是 old key 获胜；迁移路径保持一致，先删除冲突的新 key 行。
+    cur = conn.execute(
+        """
+        DELETE FROM channel_errors
+        WHERE channel_key = ?
+          AND model IN (
+            SELECT model FROM channel_errors WHERE channel_key = ?
+          )
+        """,
+        (new_key, old_key),
+    )
+    count += int(cur.rowcount or 0)
+    cur = conn.execute(
+        "UPDATE channel_errors SET channel_key=? WHERE channel_key=?",
+        (new_key, old_key),
+    )
+    count += int(cur.rowcount or 0)
+
+    # affinity 表的主键是 fingerprint/client_key，channel_key 本身不唯一。
+    for table in ("cache_affinities", "client_affinities"):
         try:
             cur = conn.execute(
                 f"UPDATE {table} SET channel_key=? WHERE channel_key=?",
                 (new_key, old_key),
             )
             count += int(cur.rowcount or 0)
-        except sqlite3.OperationalError:
-            # Older DBs may not have client_affinities yet.
-            pass
+        except sqlite3.OperationalError as exc:
+            # Older DBs may not have client_affinities yet.  Other I/O/schema
+            # failures must abort the migration instead of becoming a miss.
+            if "no such table" not in str(exc).lower():
+                raise
     return count
 
 
-def quota_rename_account_key(old_key: str, new_key: str, *, email: str | None = None) -> int:
-    """Rename oauth_quota_cache primary key without changing quota contents."""
+def _quota_rename_account_key_no_commit(conn: sqlite3.Connection,
+                                        old_key: str, new_key: str, *,
+                                        email: str | None = None) -> int:
     if not old_key or not new_key or old_key == new_key:
         return 0
     if email is None:
         email = new_key.split(":", 1)[1] if ":" in new_key else new_key
-    with _write_lock:
-        conn = _get_conn()
-        old = conn.execute(
-            "SELECT * FROM oauth_quota_cache WHERE account_key=?",
-            (old_key,),
-        ).fetchone()
-        if old is None:
-            return 0
-        new = conn.execute(
-            "SELECT * FROM oauth_quota_cache WHERE account_key=?",
-            (new_key,),
-        ).fetchone()
-        if new is not None:
-            conn.execute("DELETE FROM oauth_quota_cache WHERE account_key=?", (old_key,))
-            conn.commit()
-            return 0
-        cols = [r["name"] for r in conn.execute("PRAGMA table_info(oauth_quota_cache)")]
-        insert_cols = cols
-        placeholders = ",".join(["?"] * len(insert_cols))
-        values = [
-            new_key if c == "account_key"
-            else email if c == "email"
-            else old[c]
-            for c in insert_cols
-        ]
-        conn.execute(
-            f"INSERT INTO oauth_quota_cache ({','.join(insert_cols)}) VALUES ({placeholders})",
-            values,
-        )
+    old = conn.execute(
+        "SELECT * FROM oauth_quota_cache WHERE account_key=?",
+        (old_key,),
+    ).fetchone()
+    if old is None:
+        return 0
+    new = conn.execute(
+        "SELECT * FROM oauth_quota_cache WHERE account_key=?",
+        (new_key,),
+    ).fetchone()
+    if new is not None:
+        old_ts = max(int(old["fetched_at"] or 0), int(old["last_passive_update_at"] or 0))
+        new_ts = max(int(new["fetched_at"] or 0), int(new["last_passive_update_at"] or 0))
+        if old_ts > new_ts:
+            cols = [r["name"] for r in conn.execute("PRAGMA table_info(oauth_quota_cache)")]
+            values = [
+                new_key if c == "account_key"
+                else email if c == "email"
+                else old[c]
+                for c in cols
+            ]
+            assignments = ",".join([f"{c}=?" for c in cols])
+            conn.execute(
+                f"UPDATE oauth_quota_cache SET {assignments} WHERE account_key=?",
+                values + [new_key],
+            )
         conn.execute("DELETE FROM oauth_quota_cache WHERE account_key=?", (old_key,))
-        conn.commit()
-        return 1
+        return 0
+    cols = [r["name"] for r in conn.execute("PRAGMA table_info(oauth_quota_cache)")]
+    placeholders = ",".join(["?"] * len(cols))
+    values = [
+        new_key if c == "account_key"
+        else email if c == "email"
+        else old[c]
+        for c in cols
+    ]
+    conn.execute(
+        f"INSERT INTO oauth_quota_cache ({','.join(cols)}) VALUES ({placeholders})",
+        values,
+    )
+    conn.execute("DELETE FROM oauth_quota_cache WHERE account_key=?", (old_key,))
+    return 1
 
 
-def rename_oauth_identity(old_account_key: str, new_account_key: str, *,
-                          email: str | None = None) -> dict:
-    """Rename state rows from one OAuth logical identity to another."""
-    stats = {"quota_rows": 0, "channel_rows": 0}
-    if not old_account_key or not new_account_key or old_account_key == new_account_key:
-        return stats
-    with _write_lock:
-        conn = _get_conn()
-        conn.execute("BEGIN IMMEDIATE")
-        try:
-            old_ck = f"oauth:{old_account_key}"
-            new_ck = f"oauth:{new_account_key}"
-            stats["channel_rows"] = _rename_channel_key_no_commit(conn, old_ck, new_ck)
+def quota_rename_account_key(old_key: str, new_key: str, *, email: str | None = None) -> int:
+    """Rename oauth_quota_cache primary key without changing quota contents."""
+    return _commit_write(
+        lambda conn: _quota_rename_account_key_no_commit(
+            conn, old_key, new_key, email=email,
+        )
+    )
 
-            old = conn.execute(
-                "SELECT * FROM oauth_quota_cache WHERE account_key=?",
-                (old_account_key,),
-            ).fetchone()
-            if old is not None:
-                new = conn.execute(
-                    "SELECT * FROM oauth_quota_cache WHERE account_key=?",
-                    (new_account_key,),
-                ).fetchone()
-                if new is not None:
-                    old_ts = max(int(old["fetched_at"] or 0), int(old["last_passive_update_at"] or 0))
-                    new_ts = max(int(new["fetched_at"] or 0), int(new["last_passive_update_at"] or 0))
-                    if old_ts > new_ts:
-                        cols = [r["name"] for r in conn.execute("PRAGMA table_info(oauth_quota_cache)")]
-                        values = [
-                            new_account_key if c == "account_key"
-                            else email if c == "email" and email is not None
-                            else old[c]
-                            for c in cols
-                        ]
-                        assignments = ",".join([f"{c}=?" for c in cols])
-                        conn.execute(
-                            f"UPDATE oauth_quota_cache SET {assignments} WHERE account_key=?",
-                            values + [new_account_key],
-                        )
-                    conn.execute(
-                        "DELETE FROM oauth_quota_cache WHERE account_key=?",
-                        (old_account_key,),
-                    )
-                else:
-                    if email is None:
-                        email = old["email"]
-                    cols = [r["name"] for r in conn.execute("PRAGMA table_info(oauth_quota_cache)")]
-                    placeholders = ",".join(["?"] * len(cols))
-                    values = [
-                        new_account_key if c == "account_key"
-                        else email if c == "email"
-                        else old[c]
-                        for c in cols
-                    ]
-                    conn.execute(
-                        f"INSERT INTO oauth_quota_cache ({','.join(cols)}) VALUES ({placeholders})",
-                        values,
-                    )
-                    conn.execute(
-                        "DELETE FROM oauth_quota_cache WHERE account_key=?",
-                        (old_account_key,),
-                    )
-                    stats["quota_rows"] = 1
-            conn.execute("COMMIT")
-        except Exception:
-            try:
-                conn.execute("ROLLBACK")
-            except Exception:
-                pass
-            raise
-    return stats
+
+def rename_runtime_channel_state(old_channel_key: str, new_channel_key: str, *,
+                                 old_account_key: str | None = None,
+                                 new_account_key: str | None = None,
+                                 email: str | None = None) -> int:
+    """Atomically rename every persisted mirror for one live channel."""
+    if old_channel_key == new_channel_key:
+        return 0
+
+    def write(conn: sqlite3.Connection) -> int:
+        changed = _rename_channel_key_no_commit(conn, old_channel_key, new_channel_key)
+        if old_account_key and new_account_key and old_account_key != new_account_key:
+            changed += _quota_rename_account_key_no_commit(
+                conn, old_account_key, new_account_key, email=email,
+            )
+        return changed
+
+    return _commit_write(write)
 
 
 OPENAI_WORKSPACE_KEY_VERSION = "1"
@@ -703,6 +689,52 @@ def _rollback_failed_write(conn: sqlite3.Connection) -> None:
                 _local.conn = None
 
 
+def _commit_write(effect):
+    """Run one state mutation with rollback-safe transaction handling."""
+    with _write_lock:
+        conn = _get_conn()
+        try:
+            result = effect(conn)
+            conn.commit()
+            return result
+        except BaseException:
+            _rollback_failed_write(conn)
+            raise
+
+
+@contextmanager
+def optional_write_timeout(timeout_ms: int = 100):
+    """Temporarily bound an auxiliary state write's SQLite lock wait.
+
+    The global write lock keeps the connection-local PRAGMA change from
+    leaking into another state mutation. Nested state writers are safe because
+    ``_write_lock`` is re-entrant.
+    """
+    bounded = max(1, min(int(timeout_ms), 5_000))
+    if _db_path is None:
+        # Preserve the original initialization error at the actual write site;
+        # this context manager itself must not become a new prerequisite.
+        yield
+        return
+    with _write_lock:
+        conn = _get_conn()
+        row = conn.execute("PRAGMA busy_timeout").fetchone()
+        previous = int(row[0] if row is not None else 5_000)
+        conn.execute(f"PRAGMA busy_timeout={bounded}")
+        try:
+            yield
+        finally:
+            if getattr(_local, "conn", None) is conn:
+                try:
+                    conn.execute(f"PRAGMA busy_timeout={previous}")
+                except sqlite3.Error:
+                    try:
+                        conn.close()
+                    except sqlite3.Error:
+                        pass
+                    _local.conn = None
+
+
 def checkpoint() -> None:
     conn = _get_conn()
     try:
@@ -718,8 +750,8 @@ def now_ms() -> int:
 # ─── network_check_status ───────────────────────────────────────
 
 def network_check_save(row: dict[str, Any]) -> None:
-    with _write_lock:
-        _get_conn().execute(
+    def write(conn):
+        conn.execute(
             """INSERT OR REPLACE INTO network_check_status
                (key, label, category, ok, detail, latency_ms, checked_at)
                VALUES (?,?,?,?,?,?,?)""",
@@ -733,7 +765,7 @@ def network_check_save(row: dict[str, Any]) -> None:
                 int(row.get("checked_at") or now_ms()),
             ),
         )
-        _get_conn().commit()
+    _commit_write(write)
 
 
 def network_check_load(key: str) -> dict | None:
@@ -751,19 +783,20 @@ def network_check_load_all() -> list[dict]:
 
 
 def network_check_delete(key: str) -> None:
-    with _write_lock:
-        _get_conn().execute("DELETE FROM network_check_status WHERE key=?", (key,))
-        _get_conn().commit()
+    _commit_write(
+        lambda conn: conn.execute(
+            "DELETE FROM network_check_status WHERE key=?", (key,),
+        )
+    )
 
 
 def network_check_delete_stale(live_keys: set[str]) -> None:
-    with _write_lock:
-        conn = _get_conn()
+    def write(conn):
         rows = conn.execute("SELECT key FROM network_check_status").fetchall()
         for r in rows:
             if r["key"] not in live_keys:
                 conn.execute("DELETE FROM network_check_status WHERE key=?", (r["key"],))
-        conn.commit()
+    _commit_write(write)
 
 
 # ─── xAI Imagine video job bindings ───────────────────────────────
@@ -841,25 +874,30 @@ def xai_video_job_cleanup(now: int | None = None) -> int:
 
 def perf_save(channel_key: str, model: str, stats: dict[str, Any]) -> None:
     with _write_lock:
-        _get_conn().execute(
-            """INSERT OR REPLACE INTO performance_stats
-               (channel_key, model, total_requests, success_count,
-                recent_requests, recent_success_count,
-                avg_connect_ms, avg_first_byte_ms, avg_total_ms, last_updated)
-               VALUES (?,?,?,?,?,?,?,?,?,?)""",
-            (
-                channel_key, model,
-                int(stats.get("total_requests", 0)),
-                int(stats.get("success_count", 0)),
-                int(stats.get("recent_requests", 0)),
-                int(stats.get("recent_success_count", 0)),
-                float(stats.get("avg_connect_ms", 0.0)),
-                float(stats.get("avg_first_byte_ms", 0.0)),
-                float(stats.get("avg_total_ms", 0.0)),
-                int(stats.get("last_updated", now_ms())),
-            ),
-        )
-        _get_conn().commit()
+        conn = _get_conn()
+        try:
+            conn.execute(
+                """INSERT OR REPLACE INTO performance_stats
+                   (channel_key, model, total_requests, success_count,
+                    recent_requests, recent_success_count,
+                    avg_connect_ms, avg_first_byte_ms, avg_total_ms, last_updated)
+                   VALUES (?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    channel_key, model,
+                    int(stats.get("total_requests", 0)),
+                    int(stats.get("success_count", 0)),
+                    int(stats.get("recent_requests", 0)),
+                    int(stats.get("recent_success_count", 0)),
+                    float(stats.get("avg_connect_ms", 0.0)),
+                    float(stats.get("avg_first_byte_ms", 0.0)),
+                    float(stats.get("avg_total_ms", 0.0)),
+                    int(stats.get("last_updated", now_ms())),
+                ),
+            )
+            conn.commit()
+        except sqlite3.Error:
+            _rollback_failed_write(conn)
+            raise
 
 
 def perf_load(channel_key: str, model: str) -> dict | None:
@@ -876,34 +914,28 @@ def perf_load_all() -> list[dict]:
 
 
 def perf_delete(channel_key: str | None = None, model: str | None = None) -> None:
-    with _write_lock:
+    def write(conn):
         if channel_key and model:
-            _get_conn().execute(
+            conn.execute(
                 "DELETE FROM performance_stats WHERE channel_key=? AND model=?",
                 (channel_key, model),
             )
         elif channel_key:
-            _get_conn().execute(
+            conn.execute(
                 "DELETE FROM performance_stats WHERE channel_key=?",
                 (channel_key,),
             )
         else:
-            _get_conn().execute("DELETE FROM performance_stats")
-        _get_conn().commit()
+            conn.execute("DELETE FROM performance_stats")
+    _commit_write(write)
 
 
 def perf_rename_channel(old_key: str, new_key: str) -> None:
     if old_key == new_key:
         return
-    with _write_lock:
-        conn = _get_conn()
-        # 先删新 key 下的所有行（避免主键冲突），再把 old 的改名
-        conn.execute("DELETE FROM performance_stats WHERE channel_key=?", (new_key,))
-        conn.execute(
-            "UPDATE performance_stats SET channel_key=? WHERE channel_key=?",
-            (new_key, old_key),
-        )
-        conn.commit()
+    def write(conn):
+        _rename_performance_stats_channel_key_no_commit(conn, old_key, new_key)
+    _commit_write(write)
 
 
 # ─── channel_errors ───────────────────────────────────────────────
@@ -964,14 +996,24 @@ def error_delete(channel_key: str | None = None, model: str | None = None) -> No
 def error_rename_channel(old_key: str, new_key: str) -> None:
     if old_key == new_key:
         return
-    with _write_lock:
-        conn = _get_conn()
-        conn.execute("DELETE FROM channel_errors WHERE channel_key=?", (new_key,))
+    def write(conn):
+        # Only conflicting models are replaced by old-key state.  Models that
+        # exist solely on the destination identity must survive the merge.
+        conn.execute(
+            """
+            DELETE FROM channel_errors
+            WHERE channel_key=?
+              AND model IN (
+                SELECT model FROM channel_errors WHERE channel_key=?
+              )
+            """,
+            (new_key, old_key),
+        )
         conn.execute(
             "UPDATE channel_errors SET channel_key=? WHERE channel_key=?",
             (new_key, old_key),
         )
-        conn.commit()
+    _commit_write(write)
 
 
 # ─── cache_affinities ─────────────────────────────────────────────
@@ -982,40 +1024,44 @@ def affinity_upsert(fingerprint: str, channel_key: str, model: str,
     ts = last_used if last_used is not None else now_ms()
     with _write_lock:
         conn = _get_conn()
-        # 先尝试更新；若未命中则插入。prompt_cache_key=None 表示不改
-        # 既有值，避免非 OpenAI 协议/老调用路径清空 OpenAI 会话缓存绑定。
-        if prompt_cache_key is not None:
-            cur = conn.execute(
-                """UPDATE cache_affinities
-                   SET channel_key=?, model=?, last_used=?, prompt_cache_key=?
-                   WHERE fingerprint=?""",
-                (channel_key, model, ts, prompt_cache_key, fingerprint),
-            )
-        else:
-            cur = conn.execute(
-                """UPDATE cache_affinities
-                   SET channel_key=?, model=?, last_used=?
-                   WHERE fingerprint=?""",
-                (channel_key, model, ts, fingerprint),
-            )
-        if cur.rowcount == 0:
-            conn.execute(
-                """INSERT INTO cache_affinities
-                   (fingerprint, channel_key, model, last_used, created_at, prompt_cache_key)
-                   VALUES (?,?,?,?,?,?)""",
-                (fingerprint, channel_key, model, ts, ts, prompt_cache_key),
-            )
-        conn.commit()
+        try:
+            # 先尝试更新；若未命中则插入。prompt_cache_key=None 表示不改
+            # 既有值，避免非 OpenAI 协议/老调用路径清空 OpenAI 会话缓存绑定。
+            if prompt_cache_key is not None:
+                cur = conn.execute(
+                    """UPDATE cache_affinities
+                       SET channel_key=?, model=?, last_used=?, prompt_cache_key=?
+                       WHERE fingerprint=?""",
+                    (channel_key, model, ts, prompt_cache_key, fingerprint),
+                )
+            else:
+                cur = conn.execute(
+                    """UPDATE cache_affinities
+                       SET channel_key=?, model=?, last_used=?
+                       WHERE fingerprint=?""",
+                    (channel_key, model, ts, fingerprint),
+                )
+            if cur.rowcount == 0:
+                conn.execute(
+                    """INSERT INTO cache_affinities
+                       (fingerprint, channel_key, model, last_used, created_at, prompt_cache_key)
+                       VALUES (?,?,?,?,?,?)""",
+                    (fingerprint, channel_key, model, ts, ts, prompt_cache_key),
+                )
+            conn.commit()
+        except sqlite3.Error:
+            _rollback_failed_write(conn)
+            raise
 
 
 def affinity_touch(fingerprint: str, last_used: int | None = None) -> None:
     ts = last_used if last_used is not None else now_ms()
-    with _write_lock:
-        _get_conn().execute(
+    def write(conn):
+        conn.execute(
             "UPDATE cache_affinities SET last_used=? WHERE fingerprint=?",
             (ts, fingerprint),
         )
-        _get_conn().commit()
+    _commit_write(write)
 
 
 def affinity_load(fingerprint: str) -> dict | None:
@@ -1032,62 +1078,62 @@ def affinity_load_all() -> list[dict]:
 
 
 def affinity_delete(fingerprint: str | None = None) -> None:
-    with _write_lock:
+    def write(conn):
         if fingerprint:
-            _get_conn().execute(
+            conn.execute(
                 "DELETE FROM cache_affinities WHERE fingerprint=?",
                 (fingerprint,),
             )
         else:
-            _get_conn().execute("DELETE FROM cache_affinities")
-        _get_conn().commit()
+            conn.execute("DELETE FROM cache_affinities")
+    _commit_write(write)
 
 
 def affinity_delete_by_channel(channel_key: str) -> None:
-    with _write_lock:
-        _get_conn().execute(
+    def write(conn):
+        conn.execute(
             "DELETE FROM cache_affinities WHERE channel_key=?",
             (channel_key,),
         )
-        _get_conn().commit()
+    _commit_write(write)
 
 
 def affinity_delete_stale_channels(live_keys: Iterable[str]) -> None:
     """删除不在 live_keys 中的所有渠道对应的亲和记录。"""
     live_set = set(live_keys)
-    with _write_lock:
-        rows = _get_conn().execute(
+    def write(conn):
+        rows = conn.execute(
             "SELECT DISTINCT channel_key FROM cache_affinities"
         ).fetchall()
         stale = [r["channel_key"] for r in rows if r["channel_key"] not in live_set]
         for k in stale:
-            _get_conn().execute(
+            conn.execute(
                 "DELETE FROM cache_affinities WHERE channel_key=?", (k,)
             )
-        _get_conn().commit()
+    _commit_write(write)
 
 
 def affinity_rename_channel(old_key: str, new_key: str) -> None:
     if old_key == new_key:
         return
-    with _write_lock:
-        _get_conn().execute(
+    def write(conn):
+        conn.execute(
             "UPDATE cache_affinities SET channel_key=? WHERE channel_key=?",
             (new_key, old_key),
         )
-        _get_conn().commit()
+    _commit_write(write)
 
 
-def affinity_cleanup(ttl_ms: int) -> int:
+def affinity_cleanup(ttl_ms: int, *, cutoff_ms: int | None = None) -> int:
     """清理 last_used 早于 now-ttl 的记录。返回清理条数。"""
-    cutoff = now_ms() - ttl_ms
-    with _write_lock:
-        cur = _get_conn().execute(
+    cutoff = cutoff_ms if cutoff_ms is not None else now_ms() - ttl_ms
+    def write(conn):
+        cur = conn.execute(
             "DELETE FROM cache_affinities WHERE last_used < ?",
             (cutoff,),
         )
-        _get_conn().commit()
         return cur.rowcount
+    return _commit_write(write)
 
 
 # ─── client_affinities ─────────────────────────────────────────────
@@ -1097,20 +1143,24 @@ def client_affinity_upsert(client_key: str, channel_key: str, model: str,
     ts = last_used if last_used is not None else now_ms()
     with _write_lock:
         conn = _get_conn()
-        cur = conn.execute(
-            """UPDATE client_affinities
-               SET channel_key=?, model=?, last_used=?
-               WHERE client_key=?""",
-            (channel_key, model, ts, client_key),
-        )
-        if cur.rowcount == 0:
-            conn.execute(
-                """INSERT INTO client_affinities
-                   (client_key, channel_key, model, last_used, created_at)
-                   VALUES (?,?,?,?,?)""",
-                (client_key, channel_key, model, ts, ts),
+        try:
+            cur = conn.execute(
+                """UPDATE client_affinities
+                   SET channel_key=?, model=?, last_used=?
+                   WHERE client_key=?""",
+                (channel_key, model, ts, client_key),
             )
-        conn.commit()
+            if cur.rowcount == 0:
+                conn.execute(
+                    """INSERT INTO client_affinities
+                       (client_key, channel_key, model, last_used, created_at)
+                       VALUES (?,?,?,?,?)""",
+                    (client_key, channel_key, model, ts, ts),
+                )
+            conn.commit()
+        except sqlite3.Error:
+            _rollback_failed_write(conn)
+            raise
 
 
 def client_affinity_load_all() -> list[dict]:
@@ -1119,63 +1169,106 @@ def client_affinity_load_all() -> list[dict]:
 
 
 def client_affinity_delete(client_key: str | None = None) -> None:
-    with _write_lock:
+    def write(conn):
         if client_key:
-            _get_conn().execute(
+            conn.execute(
                 "DELETE FROM client_affinities WHERE client_key=?",
                 (client_key,),
             )
         else:
-            _get_conn().execute("DELETE FROM client_affinities")
-        _get_conn().commit()
+            conn.execute("DELETE FROM client_affinities")
+    _commit_write(write)
 
 
 def client_affinity_delete_by_channel(channel_key: str) -> None:
-    with _write_lock:
-        _get_conn().execute(
+    def write(conn):
+        conn.execute(
             "DELETE FROM client_affinities WHERE channel_key=?",
             (channel_key,),
         )
-        _get_conn().commit()
+    _commit_write(write)
 
 
 def client_affinity_delete_stale_channels(live_keys: Iterable[str]) -> None:
     live_set = set(live_keys)
-    with _write_lock:
-        rows = _get_conn().execute(
+    def write(conn):
+        rows = conn.execute(
             "SELECT DISTINCT channel_key FROM client_affinities"
         ).fetchall()
         stale = [r["channel_key"] for r in rows if r["channel_key"] not in live_set]
         for k in stale:
-            _get_conn().execute(
+            conn.execute(
                 "DELETE FROM client_affinities WHERE channel_key=?", (k,)
             )
-        _get_conn().commit()
+    _commit_write(write)
 
 
 def client_affinity_rename_channel(old_key: str, new_key: str) -> None:
     if old_key == new_key:
         return
-    with _write_lock:
-        _get_conn().execute(
+    def write(conn):
+        conn.execute(
             "UPDATE client_affinities SET channel_key=? WHERE channel_key=?",
             (new_key, old_key),
         )
-        _get_conn().commit()
+    _commit_write(write)
 
 
-def client_affinity_cleanup(ttl_ms: int) -> int:
-    cutoff = now_ms() - ttl_ms
-    with _write_lock:
-        cur = _get_conn().execute(
+def client_affinity_cleanup(ttl_ms: int, *, cutoff_ms: int | None = None) -> int:
+    cutoff = cutoff_ms if cutoff_ms is not None else now_ms() - ttl_ms
+    def write(conn):
+        cur = conn.execute(
             "DELETE FROM client_affinities WHERE last_used < ?",
             (cutoff,),
         )
-        _get_conn().commit()
         return cur.rowcount
+    return _commit_write(write)
 
 
 # ─── oauth_quota_cache ────────────────────────────────────────────
+
+def _commit_quota_write(account_key: str, effect):
+    """Commit one quota-cache write against the current OAuth generation.
+
+    A request that started before an identity rename still carries the old
+    account key.  Resolve that generation while holding the shared lifecycle
+    lock so it updates the renamed row instead of recreating a stale one.  The
+    same lock makes the tombstone check atomic with deletion cleanup: once a
+    delete starts, no late quota write can slip in after its final DELETE.
+    """
+    from . import channel_state
+
+    with channel_state.mutation_lock:
+        source_channel_key = f"oauth:{account_key}"
+        target_channel_key = channel_state.resolve(source_channel_key)
+        if (
+            channel_state.is_deleted(source_channel_key)
+            or channel_state.is_deleted(target_channel_key)
+        ):
+            return None
+        prefix = "oauth:"
+        target_account_key = (
+            target_channel_key[len(prefix):]
+            if target_channel_key.startswith(prefix)
+            else account_key
+        )
+        with optional_write_timeout():
+            return _commit_write(
+                lambda conn: effect(conn, target_account_key)
+            )
+
+
+def _quota_display_email(account_key: str) -> str:
+    """Best-effort email fallback for canonical and legacy quota keys."""
+    if ":" not in account_key:
+        return account_key
+    provider, identity = account_key.split(":", 1)
+    # OpenAI canonical keys are provider:email:workspace. Historical xAI
+    # keys can also be provider:email:subject. The email is the first identity
+    # component; Claude remains provider:email.
+    if provider in {"openai", "xai"} and ":" in identity:
+        return identity.split(":", 1)[0]
+    return identity
 
 def quota_save(account_key: str, data: dict[str, Any],
                *, email: str | None = None) -> None:
@@ -1183,12 +1276,12 @@ def quota_save(account_key: str, data: dict[str, Any],
 
     若调用方未显式提供 email，则按 "provider:email" 拆出 email 作显示列兜底。
     """
-    if email is None:
-        email = account_key.split(":", 1)[1] if ":" in account_key else account_key
-    with _write_lock:
-        conn = _get_conn()
+    def write(conn, target_account_key: str):
+        target_email = email
+        if target_email is None:
+            target_email = _quota_display_email(target_account_key)
         values = (
-            email,
+            target_email,
             int(data.get("fetched_at", now_ms())),
             data.get("five_hour_util"),
             data.get("five_hour_reset"),
@@ -1207,7 +1300,7 @@ def quota_save(account_key: str, data: dict[str, Any],
         )
         row = conn.execute(
             "SELECT account_key FROM oauth_quota_cache WHERE account_key=?",
-            (account_key,),
+            (target_account_key,),
         ).fetchone()
         if row is None:
             conn.execute(
@@ -1221,7 +1314,7 @@ def quota_save(account_key: str, data: dict[str, Any],
                     extra_used, extra_limit, extra_util,
                     raw_data)
                    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-                (account_key,) + values,
+                (target_account_key,) + values,
             )
         else:
             conn.execute(
@@ -1235,9 +1328,9 @@ def quota_save(account_key: str, data: dict[str, Any],
                      extra_used=?, extra_limit=?, extra_util=?,
                      raw_data=?
                    WHERE account_key=?""",
-                values + (account_key,),
+                values + (target_account_key,),
             )
-        conn.commit()
+    _commit_quota_write(account_key, write)
 
 
 def quota_load(account_key_or_email: str) -> dict | None:
@@ -1274,9 +1367,9 @@ def quota_load_all() -> list[dict]:
 
 
 def quota_delete(account_key_or_email: str) -> None:
-    with _write_lock:
+    def write(conn):
         if ":" in account_key_or_email:
-            _get_conn().execute(
+            conn.execute(
                 "DELETE FROM oauth_quota_cache WHERE account_key=?",
                 (account_key_or_email,),
             )
@@ -1284,16 +1377,16 @@ def quota_delete(account_key_or_email: str) -> None:
             # early schema upgrades. Keep this as a best-effort cleanup only.
             prov, identity = account_key_or_email.split(":", 1)
             if prov == "openai":
-                _get_conn().execute(
+                conn.execute(
                     "DELETE FROM oauth_quota_cache WHERE account_key=?",
                     (identity,),
                 )
         else:
-            _get_conn().execute(
+            conn.execute(
                 "DELETE FROM oauth_quota_cache WHERE email=?",
                 (account_key_or_email,),
             )
-        _get_conn().commit()
+    _commit_write(write)
 
 
 def quota_patch_passive(account_key: str, patch: dict,
@@ -1317,20 +1410,20 @@ def quota_patch_passive(account_key: str, patch: dict,
     safe = {k: v for k, v in patch.items() if k in ALLOWED}
     if not safe:
         return
-    if email is None:
-        email = account_key.split(":", 1)[1] if ":" in account_key else account_key
     now_ms_val = now_ms()
 
-    with _write_lock:
-        conn = _get_conn()
+    def write(conn, target_account_key: str):
+        target_email = email
+        if target_email is None:
+            target_email = _quota_display_email(target_account_key)
         row = conn.execute(
             "SELECT account_key FROM oauth_quota_cache WHERE account_key=?",
-            (account_key,),
+            (target_account_key,),
         ).fetchone()
         if row is None:
             # 不存在 → INSERT 一条，只带白名单字段，其他 NULL
             cols = ["account_key", "email", "fetched_at", "last_passive_update_at"]
-            vals = [account_key, email, 0, now_ms_val]
+            vals = [target_account_key, target_email, 0, now_ms_val]
             for k, v in safe.items():
                 cols.append(k)
                 vals.append(v)
@@ -1343,12 +1436,12 @@ def quota_patch_passive(account_key: str, patch: dict,
             # 存在 → UPDATE 白名单字段 + last_passive_update_at
             set_parts = [f"{k}=?" for k in safe.keys()]
             set_parts.append("last_passive_update_at=?")
-            vals = list(safe.values()) + [now_ms_val, account_key]
+            vals = list(safe.values()) + [now_ms_val, target_account_key]
             conn.execute(
                 f"UPDATE oauth_quota_cache SET {', '.join(set_parts)} WHERE account_key=?",
                 vals,
             )
-        conn.commit()
+    _commit_quota_write(account_key, write)
 
 
 def quota_save_openai_snapshot(account_key: str, snap: dict,
@@ -1380,13 +1473,13 @@ def quota_save_openai_snapshot(account_key: str, snap: dict,
         ts = now + max(0, int(sec))
         return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts))
 
-    if email is None:
-        email = account_key.split(":", 1)[1] if ":" in account_key else account_key
     passive_ts = fetched_at
-    with _write_lock:
-        conn = _get_conn()
+    def write(conn, target_account_key: str):
+        target_email = email
+        if target_email is None:
+            target_email = _quota_display_email(target_account_key)
         values = (
-            email,
+            target_email,
             fetched_at,
             passive_ts,
             normalized.get("five_hour_util"),
@@ -1403,7 +1496,7 @@ def quota_save_openai_snapshot(account_key: str, snap: dict,
         )
         row = conn.execute(
             "SELECT account_key FROM oauth_quota_cache WHERE account_key=?",
-            (account_key,),
+            (target_account_key,),
         ).fetchone()
         if row is None:
             conn.execute(
@@ -1419,7 +1512,7 @@ def quota_save_openai_snapshot(account_key: str, snap: dict,
                     codex_primary_over_secondary_pct)
                    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                 (
-                    account_key,
+                    target_account_key,
                 ) + values[:7] + (
                     None, None,        # sonnet —— OpenAI 无此维度
                     None, None,        # opus   —— 同上
@@ -1437,6 +1530,6 @@ def quota_save_openai_snapshot(account_key: str, snap: dict,
                      codex_secondary_used_pct=?, codex_secondary_reset_sec=?, codex_secondary_window_min=?,
                      codex_primary_over_secondary_pct=?
                    WHERE account_key=?""",
-                values + (account_key,),
+                values + (target_account_key,),
             )
-        conn.commit()
+    _commit_quota_write(account_key, write)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -143,6 +143,27 @@ def _restore_telegram_ui_globals():
         ui._admin_ids = set(orig_admin_ids)
 
 
+@pytest.fixture(autouse=True)
+def _isolate_channel_generation_globals():
+    """Process-lifetime tombstones must not leak between independent tests."""
+    from src import channel_state, concurrency
+
+    def reset() -> None:
+        with channel_state.mutation_lock, concurrency._slots_guard:
+            channel_state._transition_keys.clear()
+            channel_state._aliases.clear()
+            channel_state._deleted_keys.clear()
+            concurrency._retired_keys.clear()
+            concurrency._retired_limits.clear()
+            concurrency._deleted_retire_targets.clear()
+
+    reset()
+    try:
+        yield
+    finally:
+        reset()
+
+
 async def _traced_httpx_mock_handle(self, request):
     """Make MockTransport emulate HTTPcore's authoritative upload trace.
 

--- a/src/tests/isolated_pytest.py
+++ b/src/tests/isolated_pytest.py
@@ -42,6 +42,7 @@ def main(argv: list[str]) -> int:
     image_path = (data_dir / "image_logs.db").resolve()
     for path in (data_dir, log_dir):
         path.mkdir(parents=True, exist_ok=True)
+        path.chmod(0o700)
     for path in (data_dir, log_dir, config_path, state_path, image_path):
         if not path.is_absolute() or not _under(path, root):
             raise SystemExit(f"isolation refused: unsafe path {path}")

--- a/src/tests/live_openai_probe.py
+++ b/src/tests/live_openai_probe.py
@@ -99,7 +99,12 @@ def _write_config(tmp_dir: str, protocol: str) -> None:
         "updateChecker": {"enabled": False},
         "timeouts": {"connect": 10, "firstByte": 60, "idle": 60, "total": 180},
         "openai": {
-            "store": {"enabled": True, "ttlMinutes": 60, "cleanupIntervalSeconds": 300},
+            "store": {
+                "enabled": True,
+                "dbPath": os.path.join(tmp_dir, "openai_response_store.db"),
+                "ttlMinutes": 60,
+                "cleanupIntervalSeconds": 300,
+            },
             "reasoningBridge": "passthrough",
             "translation": {"enabled": True, "rejectOnBuiltinTools": True,
                             "rejectOnMultiCandidate": True},

--- a/src/tests/test_concurrency.py
+++ b/src/tests/test_concurrency.py
@@ -20,6 +20,8 @@ from src.tests import _isolation
 _isolation.isolate()
 
 import asyncio
+import threading
+import time
 import os
 import sys
 
@@ -69,6 +71,8 @@ def _setup(m):
 def _reset_slots(concurrency):
     """清空全局 slot 状态，避免测试相互污染。"""
     concurrency._slots.clear()
+    concurrency._retired_keys.clear()
+    concurrency._retired_limits.clear()
     concurrency._release_event = __import__("asyncio").Event()
 
 
@@ -377,11 +381,19 @@ def test_rename_and_forget(m):
 
     async def run():
         await c.try_acquire("api:rn1")
+        await c.try_acquire("api:rn2")
         assert "api:rn1" in c._slots
+        destination = c._slots["api:rn2"]
         c.rename_channel("api:rn1", "api:rn2")
+        # Active old work keeps releasing by old key; destination state is not
+        # overwritten. The final old release drains and removes the retired slot.
+        assert c._slots["api:rn1"].in_flight == 1
+        assert c._slots["api:rn2"] is destination
+        assert destination.in_flight == 1
+        c.release("api:rn1")
         assert "api:rn1" not in c._slots
         assert c._slots["api:rn2"].in_flight == 1
-        # 释放 + forget
+        # 释放 + forget destination
         c.release("api:rn2")
         c.forget_channel("api:rn2")
         assert "api:rn2" not in c._slots
@@ -391,6 +403,170 @@ def test_rename_and_forget(m):
         assert "api:rn2" in c._slots
 
     asyncio.run(run())
+
+
+def test_rename_drains_old_waiter_and_unlimited_slot_without_touching_destination(m):
+    c = m["concurrency"]
+    cfg = m["config"]
+    reg = m["registry"]
+    _setup(m)
+    _reset_slots(c)
+    _set_cfg(cfg,
+             concurrency_cfg={"enabled": True, "defaultMaxConcurrent": 1},
+             channels=[{
+                 "name": "drain-old", "type": "api", "baseUrl": "http://x", "apiKey": "k",
+                 "protocol": "anthropic", "models": [{"real": "m", "alias": "m"}],
+                 "cc_mimicry": True, "enabled": True, "maxConcurrent": 1,
+             }, {
+                 "name": "drain-new", "type": "api", "baseUrl": "http://y", "apiKey": "k",
+                 "protocol": "anthropic", "models": [{"real": "m", "alias": "m"}],
+                 "cc_mimicry": True, "enabled": True, "maxConcurrent": 1,
+             }])
+    reg.rebuild_from_config()
+
+    async def run():
+        assert await c.try_acquire("api:drain-old")
+        assert await c.try_acquire("api:drain-new")
+        destination = c._slots["api:drain-new"]
+        waiter = asyncio.create_task(
+            c.acquire_from_candidates([("api:drain-old", "payload")], 2)
+        )
+        for _ in range(100):
+            if c._slots["api:drain-old"].waiters:
+                break
+            await asyncio.sleep(0.001)
+        assert c._slots["api:drain-old"].waiters
+
+        c.rename_channel("api:drain-old", "api:drain-new")
+        c.release("api:drain-old")
+        assert await waiter == ("api:drain-old", "payload")
+        assert c._slots["api:drain-new"] is destination
+        assert destination.in_flight == 1
+        c.release("api:drain-old")
+        assert "api:drain-old" not in c._slots
+        c.release("api:drain-new")
+
+        # Unlimited slots use an early release path and must drain too.
+        cfg.update(lambda x: x.setdefault("concurrency", {}).__setitem__("defaultMaxConcurrent", 0))
+        assert await c.try_acquire("api:unlimited-old")
+        c.rename_channel("api:unlimited-old", "api:unlimited-new")
+        c.release("api:unlimited-old")
+        assert "api:unlimited-old" not in c._slots
+
+        # A retired custom limit must not refresh to default unlimited after
+        # the old key disappears from registry; only one waiter may pass.
+        def freeze_cfg(x):
+            x.setdefault("concurrency", {})["defaultMaxConcurrent"] = 0
+            x["channels"] = [{
+                "name": "freeze-old", "type": "api", "baseUrl": "http://f", "apiKey": "***",
+                "protocol": "anthropic", "models": [{"real": "m", "alias": "m"}],
+                "cc_mimicry": True, "enabled": True, "maxConcurrent": 1,
+            }]
+        cfg.update(freeze_cfg)
+        reg.rebuild_from_config()
+        assert await c.try_acquire("api:freeze-old")
+        waiters = [
+            asyncio.create_task(
+                c.acquire_from_candidates([("api:freeze-old", index)], 2)
+            )
+            for index in (1, 2)
+        ]
+        for _ in range(100):
+            if len(c._slots["api:freeze-old"].waiters) == 2:
+                break
+            await asyncio.sleep(0.001)
+        assert len(c._slots["api:freeze-old"].waiters) == 2
+        c.rename_channel("api:freeze-old", "api:freeze-new")
+        c.release("api:freeze-old")
+        await asyncio.sleep(0.02)
+        assert sum(task.done() for task in waiters) == 1
+        assert c._slots["api:freeze-old"].max_concurrent == 1
+        first_done = next(task for task in waiters if task.done())
+        assert (await first_done)[0] == "api:freeze-old"
+        c.release("api:freeze-old")
+        second_pending = next(task for task in waiters if task is not first_done)
+        assert (await second_pending)[0] == "api:freeze-old"
+        c.release("api:freeze-old")
+        assert "api:freeze-old" not in c._slots
+
+        # Cancellation immediately after wake must not strand a retired slot.
+        cfg.update(lambda x: x.setdefault("concurrency", {}).__setitem__("defaultMaxConcurrent", 1))
+        assert await c.try_acquire("api:cancel-old")
+        cancelled_waiter = asyncio.create_task(
+            c.acquire_from_candidates([("api:cancel-old", "payload")], 2)
+        )
+        for _ in range(100):
+            if c._slots["api:cancel-old"].waiters:
+                break
+            await asyncio.sleep(0.001)
+        c.rename_channel("api:cancel-old", "api:cancel-new")
+        c.release("api:cancel-old")
+        cancelled_waiter.cancel()
+        try:
+            await cancelled_waiter
+        except asyncio.CancelledError:
+            pass
+        assert "api:cancel-old" not in c._slots
+
+    asyncio.run(run())
+
+
+def test_cross_thread_late_pre_acquire_cannot_detach_or_overwrite_frozen_limit(m):
+    c = m["concurrency"]
+    cfg = m["config"]
+    reg = m["registry"]
+    _setup(m); _reset_slots(c)
+    _set_cfg(cfg,
+             concurrency_cfg={"enabled": True, "defaultMaxConcurrent": 0},
+             channels=[{
+                 "name": "thread-old", "type": "api", "baseUrl": "http://x", "apiKey": "***",
+                 "protocol": "anthropic", "models": [{"real": "m", "alias": "m"}],
+                 "cc_mimicry": True, "enabled": True, "maxConcurrent": 1,
+             }])
+    reg.rebuild_from_config()
+    entered = threading.Event()
+    allow = threading.Event()
+    rename_done = threading.Event()
+    errors = []
+    real_get_max = c._get_channel_max
+
+    def paused_get_max(key):
+        if key == "api:thread-old":
+            entered.set(); assert allow.wait(5)
+        return real_get_max(key)
+
+    c._get_channel_max = paused_get_max
+
+    def acquire_worker():
+        try:
+            assert asyncio.run(c.try_acquire("api:thread-old"))
+        except BaseException as exc:
+            errors.append(exc)
+
+    def rename_worker():
+        try:
+            c.rename_channel("api:thread-old", "api:thread-new", frozen_max=1)
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            rename_done.set()
+
+    first = threading.Thread(target=acquire_worker)
+    second = threading.Thread(target=rename_worker)
+    try:
+        first.start(); assert entered.wait(5)
+        second.start(); time.sleep(0.05)
+        assert not rename_done.is_set()
+        allow.set(); first.join(5); second.join(5)
+    finally:
+        allow.set(); first.join(5); second.join(5)
+        c._get_channel_max = real_get_max
+
+    assert not errors
+    assert c._slots["api:thread-old"].max_concurrent == 1
+    assert c._slots["api:thread-old"].in_flight == 1
+    c.release("api:thread-old")
+    assert "api:thread-old" not in c._slots
 
 
 # ─── scheduler 分流 ────────────────────────────────────────────

--- a/src/tests/test_cooldown_registry_consistency.py
+++ b/src/tests/test_cooldown_registry_consistency.py
@@ -53,7 +53,8 @@ def test_registry_orphan_cleanup_uses_cooldown_commit_point(monkeypatch):
 
     cleared: list[tuple[str, str | None, bool]] = []
 
-    def clear(channel_key, model=None, *, notify_recovered=True):
+    def clear(channel_key, model=None, *, notify_recovered=True,
+              resolve_alias=True):
         cleared.append((channel_key, model, notify_recovered))
 
     monkeypatch.setattr(registry.cooldown, "clear", clear)

--- a/src/tests/test_protocol_fake_upstreams.py
+++ b/src/tests/test_protocol_fake_upstreams.py
@@ -23,6 +23,7 @@ _isolation.isolate()
 import asyncio
 import json
 import os
+import sqlite3
 import sys
 import time
 from datetime import datetime, timedelta, timezone
@@ -2824,6 +2825,127 @@ async def test_responses_client_to_anthropic_fake_upstream(m):
     assert out["output"][0]["content"][0]["text"] == "responses client pong"
     assert out["usage"]["input_tokens"] == 9
     assert out["usage"]["input_tokens_details"]["cached_tokens"] == 2
+
+
+async def test_non_stream_success_survives_locked_state_db_for_all_ingress(m, monkeypatch):
+    _setup(m)
+    _install_keys(m, _default_key())
+    router = MockRouter()
+    router.register("https://locked-chat.example", lambda req: _chat_response("anthropic ingress ok"))
+    router.register("https://locked-chat-other.example", lambda req: _chat_response("wrong anthropic route"))
+    router.register("https://locked-anth-chat.example", lambda req: _anthropic_response("chat ingress ok"))
+    router.register("https://locked-anth-chat-other.example", lambda req: _anthropic_response("wrong chat route"))
+    router.register("https://locked-anth-responses.example", lambda req: _anthropic_response("responses ingress ok"))
+    router.register("https://locked-anth-responses-other.example", lambda req: _anthropic_response("wrong responses route"))
+
+    fingerprints = {
+        "anthropic": "fp-anthropic-locked",
+        "chat": "fp-chat-locked",
+        "responses": "fp-responses-locked",
+    }
+    monkeypatch.setattr(
+        m["scheduler"].fingerprint, "fingerprint_query",
+        lambda *_args, **_kwargs: fingerprints["anthropic"],
+    )
+    monkeypatch.setattr(
+        m["openai_handler"].fingerprint, "fingerprint_query_chat",
+        lambda *_args, **_kwargs: fingerprints["chat"],
+    )
+    monkeypatch.setattr(
+        m["openai_handler"].fingerprint, "fingerprint_query_responses",
+        lambda *_args, **_kwargs: fingerprints["responses"],
+    )
+    monkeypatch.setattr(
+        m["failover"].fingerprint, "fingerprint_write", lambda *_args, **_kwargs: fingerprints["anthropic"],
+    )
+    monkeypatch.setattr(
+        m["failover"].fingerprint, "fingerprint_write_chat", lambda *_args, **_kwargs: fingerprints["chat"],
+    )
+    monkeypatch.setattr(
+        m["failover"].fingerprint, "fingerprint_write_responses", lambda *_args, **_kwargs: fingerprints["responses"],
+    )
+    m["affinity"]._entries.clear()
+    m["affinity"]._client_entries.clear()
+    m["affinity"].upsert(fingerprints["anthropic"], "api:locked-chat", "gpt-real")
+    m["affinity"].upsert(fingerprints["chat"], "api:locked-anth-chat", "claude-real")
+    m["affinity"].upsert(fingerprints["responses"], "api:locked-anth-responses", "claude-real")
+    before = m["affinity"].snapshot()
+
+    state_conn = m["state_db"]._get_conn()
+    original_busy_timeout = int(state_conn.execute("PRAGMA busy_timeout").fetchone()[0])
+    started = time.monotonic()
+    locker = sqlite3.connect(m["state_db"]._db_path, timeout=0.05)
+    locker.execute("BEGIN IMMEDIATE")
+    try:
+        _install_channels(m, [
+            _make_openai_channel(
+                "locked-chat-other", "https://locked-chat-other.example",
+                protocol="openai-chat", alias="sonnet", real="gpt-real",
+            ),
+            _make_openai_channel(
+                "locked-chat", "https://locked-chat.example",
+                protocol="openai-chat", alias="sonnet", real="gpt-real",
+            ),
+        ])
+        anth_body = {
+            "model": "sonnet", "stream": False, "max_tokens": 32,
+            "messages": [{"role": "user", "content": "ping"}],
+        }
+        anth_resp, anth_client, anth_route = await _call_anthropic_core(m, router, anth_body)
+        await anth_client.aclose()
+        assert anth_resp.status_code == 200
+        assert anth_route.affinity_hit is True
+        assert json.loads(anth_resp.body)["content"][0]["text"] == "anthropic ingress ok"
+
+        _install_channels(m, [
+            _make_anthropic_channel(
+                m, "locked-anth-chat-other", "https://locked-anth-chat-other.example",
+                alias="gpt-5", real="claude-real",
+            ),
+            _make_anthropic_channel(
+                m, "locked-anth-chat", "https://locked-anth-chat.example",
+                alias="gpt-5", real="claude-real",
+            ),
+        ])
+        chat_body = {
+            "model": "gpt-5", "stream": False,
+            "messages": [{"role": "user", "content": "ping"}],
+        }
+        chat_resp, chat_client = await _call_openai_handler(m, router, "chat", chat_body)
+        await chat_client.aclose()
+        assert chat_resp.status_code == 200
+        assert json.loads(chat_resp.body)["choices"][0]["message"]["content"] == "chat ingress ok"
+
+        _install_channels(m, [
+            _make_anthropic_channel(
+                m, "locked-anth-responses-other", "https://locked-anth-responses-other.example",
+                alias="gpt-5", real="claude-real",
+            ),
+            _make_anthropic_channel(
+                m, "locked-anth-responses", "https://locked-anth-responses.example",
+                alias="gpt-5", real="claude-real",
+            ),
+        ])
+        responses_body = {
+            "model": "gpt-5", "stream": False, "input": "ping",
+        }
+        responses_resp, responses_client = await _call_openai_handler(
+            m, router, "responses", responses_body,
+        )
+        await responses_client.aclose()
+        assert responses_resp.status_code == 200
+        assert json.loads(responses_resp.body)["output_text"] == "responses ingress ok"
+    finally:
+        locker.rollback()
+        locker.close()
+
+    assert time.monotonic() - started < 2.5
+    assert int(state_conn.execute("PRAGMA busy_timeout").fetchone()[0]) == original_busy_timeout
+
+    # Existing affinity hits take the bound route, but a locked state DB keeps
+    # the previous memory value rather than publishing process-only timestamps.
+    assert m["affinity"].snapshot() == before
+    assert m["affinity"].client_snapshot() == {}
 
 
 async def test_responses_native_state_passthrough_fake_upstream(m):

--- a/src/tests/test_protocol_finalize.py
+++ b/src/tests/test_protocol_finalize.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import sqlite3
+
+import pytest
+
 from src.protocols import finalize
 
 
@@ -132,6 +136,109 @@ def test_apply_success_health_effects_is_dependency_injected():
     assert cd.cleared == [("api:ch", "m")]
     assert sc.failures == []
     assert cd.errors == []
+
+
+def test_success_health_effects_isolate_sqlite_failures_and_continue(caplog):
+    class LockedScorer(_Scorer):
+        def record_success(self, *_args, **_kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+    cd = _Cooldown()
+    finalize._last_warning_at.clear()
+    caplog.set_level("WARNING")
+    finalize.apply_success_health_effects(
+        finalize.success_plan(),
+        scorer=LockedScorer(),
+        cooldown=cd,
+        channel_key="api:ch",
+        model="m",
+    )
+
+    assert cd.cleared == [("api:ch", "m")]
+    assert "response preserved" in caplog.text
+
+
+def test_health_effects_do_not_hide_programming_errors():
+    class BrokenScorer(_Scorer):
+        def record_success(self, *_args, **_kwargs):
+            raise ValueError("programming bug")
+
+    with pytest.raises(ValueError, match="programming bug"):
+        finalize.apply_success_health_effects(
+            finalize.success_plan(),
+            scorer=BrokenScorer(),
+            cooldown=_Cooldown(),
+            channel_key="api:ch",
+            model="m",
+        )
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        sqlite3.ProgrammingError("closed connection"),
+        sqlite3.IntegrityError("constraint failed"),
+        sqlite3.OperationalError("no such table: channel_errors"),
+    ],
+)
+def test_health_effects_do_not_hide_sqlite_programming_or_schema_errors(exc):
+    class BrokenScorer(_Scorer):
+        def record_success(self, *_args, **_kwargs):
+            raise exc
+
+    with pytest.raises(type(exc), match=str(exc)):
+        finalize.apply_success_health_effects(
+            finalize.success_plan(),
+            scorer=BrokenScorer(),
+            cooldown=_Cooldown(),
+            channel_key="api:ch",
+            model="m",
+        )
+
+
+def test_error_health_effects_isolate_sqlite_failures_and_continue(caplog):
+    class LockedCooldown(_Cooldown):
+        def record_error(self, *_args, **_kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+    sc = _Scorer()
+    finalize._last_warning_at.clear()
+    caplog.set_level("WARNING")
+    finalize.apply_error_health_effects(
+        finalize.error_plan("upstream_error", failure_policy="post_commit_stream"),
+        scorer=sc,
+        cooldown=LockedCooldown(),
+        channel_key="api:ch",
+        model="m",
+        error_detail="failed",
+        connect_ms=12,
+    )
+
+    assert sc.failures == [{
+        "channel_key": "api:ch",
+        "model": "m",
+        "connect_ms": 12,
+    }]
+    assert "response preserved" in caplog.text
+
+
+def test_health_effect_sqlite_warnings_are_rate_limited(caplog):
+    class LockedScorer(_Scorer):
+        def record_success(self, *_args, **_kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+    finalize._last_warning_at.clear()
+    caplog.set_level("WARNING")
+    for _ in range(3):
+        finalize.apply_success_health_effects(
+            finalize.success_plan(),
+            scorer=LockedScorer(),
+            cooldown=_Cooldown(),
+            channel_key="api:ch",
+            model="m",
+        )
+    warnings = [r for r in caplog.records if "response preserved" in r.message]
+    assert len(warnings) == 1
 
 
 def test_apply_error_health_effects_respects_plan_flags():

--- a/src/tests/test_sqlite_lock_root_fix.py
+++ b/src/tests/test_sqlite_lock_root_fix.py
@@ -1,0 +1,1902 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+import uuid
+
+import pytest
+
+from src import affinity, channel_state, config, scorer, state_db
+from src.openai import store
+
+
+LEGACY_SCHEMA = """
+CREATE TABLE openai_response_store (
+  response_id TEXT PRIMARY KEY,
+  parent_id TEXT,
+  api_key_name TEXT,
+  model TEXT,
+  channel_key TEXT,
+  created_at REAL NOT NULL,
+  expires_at REAL NOT NULL,
+  input_items TEXT NOT NULL,
+  output_items TEXT NOT NULL
+)
+"""
+
+
+@pytest.fixture
+def isolated_store(monkeypatch):
+    # Keep even this test-specific store below the fail-closed DATA_DIR created
+    # by isolated_pytest.py; a relative dbPath must never fall back to BASE_DIR.
+    root = Path(config.DATA_DIR) / f"sqlite-root-fix-{uuid.uuid4().hex}"
+    root.mkdir(parents=True)
+    cfg = {
+        "stateDbPath": "state.db",
+        "openai": {"store": {
+            "enabled": True,
+            "dbPath": "responses.db",
+            "ttlMinutes": 60,
+            "cleanupIntervalSeconds": 300,
+            "cleanupBatchSize": 100,
+            "cleanupBatchBytes": 8 * 1024 * 1024,
+            "cleanupMaxBatches": 100,
+            "cleanupTimeBudgetSeconds": 10,
+        }},
+    }
+    monkeypatch.setattr(config, "DATA_DIR", str(root))
+    monkeypatch.setattr(config, "get", lambda: cfg)
+    store._reset_for_test(reinitialize=True)
+    store.init()
+    try:
+        yield root, cfg
+    finally:
+        store._reset_for_test(reinitialize=True)
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def _save(response_id: str, parent_id: str | None = None) -> None:
+    store.save(
+        response_id, parent_id,
+        api_key_name="key-a", model="gpt-test", channel_key="api:test",
+        input_items=[{"id": response_id, "type": "message"}], output_items=[],
+    )
+
+
+def test_config_defaults_keep_history_out_of_state_db():
+    defaults = config.DEFAULT_CONFIG
+    store_defaults = defaults["openai"]["store"]
+    assert store_defaults["dbPath"] != defaults["stateDbPath"]
+    assert store_defaults["cleanupBatchSize"] == 100
+    assert store_defaults["cleanupBatchBytes"] == 8 * 1024 * 1024
+    assert store_defaults["cleanupMaxBatches"] == 100
+    assert store_defaults["cleanupTimeBudgetSeconds"] == 10
+
+
+def test_store_init_rolls_back_failed_schema_setup(monkeypatch, tmp_path):
+    class BrokenConnection:
+        def __init__(self):
+            self.rolled_back = False
+
+        def executescript(self, _sql):
+            raise sqlite3.OperationalError("schema is locked")
+
+        def rollback(self):
+            self.rolled_back = True
+
+    conn = BrokenConnection()
+    monkeypatch.setattr(store, "_resolve_db_path", lambda: str(tmp_path / "store.db"))
+    monkeypatch.setattr(
+        store, "_resolve_legacy_db_path", lambda: str(tmp_path / "state.db"),
+    )
+    monkeypatch.setattr(store, "_get_conn", lambda: conn)
+    monkeypatch.setattr(store, "_initialized", False)
+    monkeypatch.setattr(store, "_db_path", None)
+    monkeypatch.setattr(store, "_legacy_db_path", None)
+    with pytest.raises(sqlite3.OperationalError, match="schema is locked"):
+        store.init()
+    assert conn.rolled_back is True
+
+
+def test_default_store_path_is_data_relative_and_separate(isolated_store):
+    root, cfg = isolated_store
+    cfg["openai"]["store"].pop("dbPath")
+    store._reset_for_test(reinitialize=True)
+    store.init()
+
+    assert Path(store._db_path).parent == root
+    assert Path(store._db_path).name == "openai_response_store.db"
+    assert Path(store._db_path).resolve() != Path(store._legacy_db_path).resolve()
+
+    # Deep-merged defaults still look configured at runtime.  Even if an old
+    # stateDbPath happens to use the new default name, do not rejoin that DB.
+    cfg["openai"]["store"]["dbPath"] = "openai_response_store.db"
+    cfg["stateDbPath"] = "openai_response_store.db"
+    store._reset_for_test(reinitialize=True)
+    store.init()
+    assert Path(store._db_path).name == "openai_response_store.v2.db"
+    assert Path(store._db_path).resolve() != Path(store._legacy_db_path).resolve()
+
+
+def test_explicit_store_path_cannot_rejoin_state_db(isolated_store):
+    _root, cfg = isolated_store
+    cfg["openai"]["store"]["dbPath"] = "state.db"
+    store._reset_for_test(reinitialize=True)
+    with pytest.raises(RuntimeError, match="must differ"):
+        store.init()
+
+
+def test_hardlinked_store_path_cannot_rejoin_state_db(isolated_store):
+    root, cfg = isolated_store
+    state_path = root / "state.db"
+    explicit_path = root / "store-hardlink.db"
+    state_path.touch()
+    explicit_path.hardlink_to(state_path)
+    cfg["openai"]["store"]["dbPath"] = explicit_path.name
+    store._reset_for_test(reinitialize=True)
+    with pytest.raises(RuntimeError, match="must differ"):
+        store.init()
+
+
+def test_relative_store_path_cannot_escape_data_dir(isolated_store):
+    _root, cfg = isolated_store
+    cfg["openai"]["store"]["dbPath"] = "../escaped.db"
+    store._reset_for_test(reinitialize=True)
+    with pytest.raises(RuntimeError, match="must stay within DATA_DIR"):
+        store.init()
+
+
+def test_relative_store_path_cannot_escape_through_symlink(isolated_store):
+    root, cfg = isolated_store
+    outside = root.parent / f"outside-{uuid.uuid4().hex}"
+    outside.mkdir()
+    (root / "escape-link").symlink_to(outside, target_is_directory=True)
+    cfg["openai"]["store"]["dbPath"] = "escape-link/store.db"
+    store._reset_for_test(reinitialize=True)
+    try:
+        with pytest.raises(RuntimeError, match="must stay within DATA_DIR"):
+            store.init()
+    finally:
+        shutil.rmtree(outside, ignore_errors=True)
+
+
+def test_legacy_fallback_is_read_only_and_new_database_wins(isolated_store):
+    root, _cfg = isolated_store
+    legacy = root / "state.db"
+    now = time.time()
+    with sqlite3.connect(legacy) as conn:
+        conn.execute(LEGACY_SCHEMA)
+        conn.execute(
+            "INSERT INTO openai_response_store VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "legacy-id", None, "key-a", "old-model", "api:old", now,
+                now + 3600, json.dumps([{"source": "legacy"}]), "[]",
+            ),
+        )
+
+    legacy_row = store.lookup("legacy-id", api_key_name="key-a")
+    assert legacy_row.model == "old-model"
+    assert legacy_row.input_items == [{"source": "legacy"}]
+
+    # A newly persisted child may continue a legacy parent without migration.
+    _save("new-id", parent_id="legacy-id")
+    expanded = store.expand_history("new-id", api_key_name="key-a")
+    assert expanded == [{"source": "legacy"}, {"id": "new-id", "type": "message"}]
+
+    # Same id in the new DB must shadow legacy, and all new writes stay there.
+    _save("legacy-id")
+    assert store.lookup("legacy-id", api_key_name="key-a").model == "gpt-test"
+    with sqlite3.connect(legacy) as conn:
+        assert conn.execute(
+            "SELECT 1 FROM openai_response_store WHERE response_id='new-id'"
+        ).fetchone() is None
+    with sqlite3.connect(root / "responses.db") as conn:
+        assert conn.execute(
+            "SELECT 1 FROM openai_response_store WHERE response_id='new-id'"
+        ).fetchone() is not None
+
+
+def test_legacy_fallback_preserves_expired_and_forbidden_semantics(isolated_store):
+    root, _cfg = isolated_store
+    now = time.time()
+    with sqlite3.connect(root / "state.db") as conn:
+        conn.execute(LEGACY_SCHEMA)
+        conn.executemany(
+            "INSERT INTO openai_response_store VALUES (?, NULL, ?, 'old', '', ?, ?, '[]', '[]')",
+            [
+                ("legacy-expired", "key-a", now - 20, now - 10),
+                ("legacy-forbidden", "key-b", now, now + 3600),
+            ],
+        )
+    with pytest.raises(store.ResponseExpired):
+        store.lookup("legacy-expired", api_key_name="key-a")
+    with pytest.raises(store.ResponseForbidden):
+        store.lookup("legacy-forbidden", api_key_name="key-a")
+
+
+def test_expand_history_cycle_and_depth_are_bounded(isolated_store):
+    _save("chain-a")
+    _save("chain-b", parent_id="chain-a")
+    _save("chain-c", parent_id="chain-b")
+    conn = store._get_conn()
+    conn.execute(
+        "UPDATE openai_response_store SET parent_id='chain-c' WHERE response_id='chain-a'"
+    )
+    conn.commit()
+
+    bounded = store.expand_history("chain-c", api_key_name="key-a", max_depth=2)
+    assert [item["id"] for item in bounded] == ["chain-b", "chain-c"]
+    cyclic = store.expand_history("chain-c", api_key_name="key-a", max_depth=50)
+    assert [item["id"] for item in cyclic] == ["chain-a", "chain-b", "chain-c"]
+
+
+def test_legacy_missing_database_or_table_is_a_clean_miss(isolated_store):
+    root, _cfg = isolated_store
+    assert not (root / "state.db").exists()
+    with pytest.raises(store.ResponseNotFound):
+        store.lookup("missing", api_key_name="key-a")
+    # A state DB from a version predating this table is also a clean miss.
+    with sqlite3.connect(root / "state.db") as conn:
+        conn.execute("CREATE TABLE unrelated (id INTEGER)")
+    with pytest.raises(store.ResponseNotFound):
+        store.lookup("missing", api_key_name="key-a")
+
+
+def test_legacy_precheck_only_treats_enoent_as_miss(isolated_store, monkeypatch):
+    root, _cfg = isolated_store
+    legacy_path = root / "state.db"
+    legacy_path.mkdir()
+    with pytest.raises(sqlite3.OperationalError, match="not a regular file"):
+        store.lookup("legacy-directory", api_key_name="key-a")
+
+    legacy_path.rmdir()
+    real_stat = store.os.stat
+
+    def denied(path, *args, **kwargs):
+        if str(path) == str(legacy_path):
+            raise PermissionError(13, "permission denied", str(path))
+        return real_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(store.os, "stat", denied)
+    with pytest.raises(PermissionError, match="permission denied"):
+        store.lookup("legacy-denied", api_key_name="key-a")
+
+
+def test_legacy_sqlite_failure_is_not_rewritten_as_404(isolated_store, monkeypatch):
+    class LockedLegacy:
+        def execute(self, *_args, **_kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(store, "_get_legacy_conn", lambda: LockedLegacy())
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        store.lookup("legacy-busy", api_key_name="key-a")
+
+    from src.openai.transform import guard, responses_to_chat
+    with pytest.raises(guard.GuardError) as raised:
+        responses_to_chat.translate_request(
+            {
+                "model": "gpt-test",
+                "previous_response_id": "legacy-busy",
+                "input": "continue",
+            },
+            api_key_name="key-a",
+        )
+    assert raised.value.status == 503
+    assert raised.value.err_type == "server_error"
+
+
+def test_cleanup_expired_is_bounded_and_commits_each_batch(isolated_store):
+    for i in range(7):
+        _save(f"expired-{i}")
+    conn = store._get_conn()
+    conn.execute("UPDATE openai_response_store SET expires_at=?", (time.time() - 1,))
+    conn.commit()
+
+    assert store.cleanup_expired(batch_size=2, max_batches=2) == 4
+    assert conn.execute("SELECT count(*) FROM openai_response_store").fetchone()[0] == 3
+    assert store.cleanup_expired(batch_size=2, max_batches=10) == 3
+    assert conn.execute("SELECT count(*) FROM openai_response_store").fetchone()[0] == 0
+
+
+def test_cleanup_respects_payload_bytes_and_still_deletes_oversized_row(isolated_store):
+    payload = "x" * 2048
+    for i in range(3):
+        store.save(
+            f"large-{i}", None, api_key_name="key-a", model="gpt-test",
+            channel_key="api:test", input_items=[{"payload": payload}],
+            output_items=[], ttl_seconds=-1,
+        )
+    assert store.cleanup_expired(
+        batch_size=100, max_batches=2, batch_bytes=1024, time_budget_seconds=10,
+    ) == 2
+    assert store.cleanup_expired(
+        batch_size=100, max_batches=2, batch_bytes=1024, time_budget_seconds=10,
+    ) == 1
+
+
+def test_cleanup_releases_store_lock_between_batches(isolated_store, monkeypatch):
+    for i in range(3):
+        store.save(
+            f"yield-{i}", None, api_key_name="key-a", model="gpt-test",
+            channel_key="api:test", input_items=[], output_items=[], ttl_seconds=-1,
+        )
+    writer_errors: list[BaseException] = []
+    invoked = False
+
+    def yield_to_writer(_seconds: float) -> None:
+        nonlocal invoked
+        if invoked:
+            return
+        invoked = True
+
+        def writer() -> None:
+            try:
+                _save("save-during-cleanup")
+            except BaseException as exc:
+                writer_errors.append(exc)
+
+        thread = threading.Thread(target=writer)
+        thread.start()
+        thread.join(timeout=1)
+        assert not thread.is_alive(), "cleanup retained Store lock between batches"
+
+    monkeypatch.setattr(store.time, "sleep", yield_to_writer)
+    assert store.cleanup_expired(batch_size=1, max_batches=2) == 2
+    assert invoked is True
+    assert writer_errors == []
+    assert store.lookup("save-during-cleanup", api_key_name="key-a").response_id == "save-during-cleanup"
+
+
+def test_cleanup_default_catches_up_ten_thousand_small_rows(isolated_store):
+    conn = store._get_conn()
+    now = time.time()
+    payload = json.dumps([{"text": "x" * 128}])
+    conn.executemany(
+        """INSERT INTO openai_response_store
+           (response_id, parent_id, api_key_name, model, channel_key,
+            created_at, expires_at, input_items, output_items)
+           VALUES (?, NULL, 'key-a', 'gpt-test', 'api:test', ?, ?, ?, '[]')""",
+        [(f"bulk-{i}", now - 10, now - 1, payload) for i in range(10_000)],
+    )
+    conn.commit()
+
+    assert store.cleanup_expired() == 10_000
+    assert conn.execute("SELECT count(*) FROM openai_response_store").fetchone()[0] == 0
+
+
+def test_store_thread_local_connections_handle_concurrent_writes(isolated_store):
+    errors: list[BaseException] = []
+    workers = 6
+    writes_per_worker = 20
+    barrier = threading.Barrier(workers)
+
+    def worker(worker_id: int) -> None:
+        try:
+            barrier.wait()
+            for i in range(writes_per_worker):
+                response_id = f"thread-{worker_id}-{i}"
+                _save(response_id)
+                assert store.lookup(response_id, api_key_name="key-a").response_id == response_id
+        except BaseException as exc:  # collected and asserted in the test thread
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(workers)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not errors
+    assert all(not thread.is_alive() for thread in threads)
+    assert store._get_conn().execute(
+        "SELECT count(*) FROM openai_response_store"
+    ).fetchone()[0] == workers * writes_per_worker
+
+
+def test_state_db_write_lock_does_not_block_openai_store(isolated_store):
+    root, _cfg = isolated_store
+    legacy = sqlite3.connect(root / "state.db", timeout=0.1)
+    legacy.execute("CREATE TABLE state_only (id INTEGER)")
+    legacy.commit()
+    legacy.execute("BEGIN IMMEDIATE")
+    try:
+        # This used to target state.db and would block/fail behind the writer.
+        _save("independent-write")
+    finally:
+        legacy.rollback()
+        legacy.close()
+    assert store.lookup("independent-write", api_key_name="key-a").response_id == "independent-write"
+
+
+def test_cross_process_state_lock_does_not_block_openai_store(isolated_store):
+    root, _cfg = isolated_store
+    state_path = root / "state.db"
+    script = (
+        "import sqlite3, sys\n"
+        "conn = sqlite3.connect(sys.argv[1], timeout=1)\n"
+        "conn.execute('CREATE TABLE IF NOT EXISTS process_lock (id INTEGER)')\n"
+        "conn.commit()\n"
+        "conn.execute('BEGIN IMMEDIATE')\n"
+        "print('LOCKED', flush=True)\n"
+        "sys.stdin.readline()\n"
+        "conn.rollback()\n"
+        "conn.close()\n"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script, str(state_path)],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert proc.stdout is not None and proc.stdout.readline().strip() == "LOCKED"
+        started = time.monotonic()
+        _save("cross-process-independent")
+        assert time.monotonic() - started < 1.0
+    finally:
+        if proc.stdin is not None:
+            proc.stdin.write("release\n")
+            proc.stdin.flush()
+        proc.wait(timeout=5)
+    assert proc.returncode == 0, proc.stderr.read() if proc.stderr else ""
+
+
+def test_scorer_sqlite_failure_keeps_memory_and_is_rate_limited(monkeypatch, caplog):
+    scorer._stats.clear()
+    scorer._last_persist_warning_at = 0.0
+    calls = 0
+
+    def fail_sqlite(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(scorer.state_db, "perf_save", fail_sqlite)
+    caplog.set_level("WARNING")
+    scorer.record_success("api:locked", "model", 10, 20, 30)
+    scorer.record_failure("api:locked", "model", 15)
+
+    stats = scorer.get_stats("api:locked", "model")
+    assert calls == 2
+    assert stats is not None and stats["total_requests"] == 2
+    assert stats["success_count"] == 1
+    warnings = [r for r in caplog.records if "keeping in-memory score" in r.message]
+    assert len(warnings) == 1
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        sqlite3.ProgrammingError("closed connection"),
+        sqlite3.IntegrityError("constraint failed"),
+        sqlite3.OperationalError("no such table: performance_stats"),
+    ],
+)
+def test_scorer_does_not_swallow_sqlite_programming_or_schema_errors(monkeypatch, exc):
+    scorer._stats.clear()
+
+    def programmer_error(*_args, **_kwargs):
+        raise exc
+
+    monkeypatch.setattr(scorer.state_db, "perf_save", programmer_error)
+    with pytest.raises(type(exc), match=str(exc)):
+        scorer.record_success("api:bug", "model", 10, 20, 30)
+    # Memory is still updated before persistence is attempted.
+    assert scorer.get_stats("api:bug", "model")["total_requests"] == 1
+
+
+def test_affinity_concurrent_upserts_publish_in_commit_order(monkeypatch):
+    affinity._entries.clear()
+    persisted: dict[str, str] = {}
+    first_persisted = threading.Event()
+    release_first = threading.Event()
+
+    def persist(fingerprint, channel_key, model, **_kwargs):
+        persisted[fingerprint] = model
+        if model == "model-a":
+            first_persisted.set()
+            assert release_first.wait(timeout=2)
+
+    monkeypatch.setattr(affinity.state_db, "affinity_upsert", persist)
+    first = threading.Thread(
+        target=affinity.upsert, args=("fp-order", "api:a", "model-a"),
+    )
+    second = threading.Thread(
+        target=affinity.upsert, args=("fp-order", "api:b", "model-b"),
+    )
+    first.start()
+    assert first_persisted.wait(timeout=1)
+    second.start()
+    time.sleep(0.05)
+    release_first.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive() and not second.is_alive()
+    assert persisted["fp-order"] == "model-b"
+    assert affinity.snapshot()["fp-order"]["model"] == "model-b"
+
+
+def test_client_affinity_concurrent_upserts_publish_in_commit_order(monkeypatch):
+    affinity._client_entries.clear()
+    persisted: dict[str, str] = {}
+    first_persisted = threading.Event()
+    release_first = threading.Event()
+
+    def persist(client_key, channel_key, model, **_kwargs):
+        persisted[client_key] = model
+        if model == "model-a":
+            first_persisted.set()
+            assert release_first.wait(timeout=2)
+
+    monkeypatch.setattr(affinity.state_db, "client_affinity_upsert", persist)
+    first = threading.Thread(
+        target=affinity.client_upsert, args=("client-order", "api:a", "model-a"),
+    )
+    second = threading.Thread(
+        target=affinity.client_upsert, args=("client-order", "api:b", "model-b"),
+    )
+    first.start()
+    assert first_persisted.wait(timeout=1)
+    second.start()
+    time.sleep(0.05)
+    release_first.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive() and not second.is_alive()
+    assert persisted["client-order"] == "model-b"
+    assert affinity.client_snapshot()["client-order"]["model"] == "model-b"
+
+
+def test_scheduler_affinity_touch_survives_locked_state_db(monkeypatch):
+    from types import SimpleNamespace
+    from src import scheduler
+
+    affinity._entries.clear()
+    old_last_used = state_db.now_ms() - 1000
+    affinity._entries["fp-hit"] = {
+        "channel_key": "api:bound",
+        "model": "model",
+        "last_used": old_last_used,
+        "prompt_cache_key": None,
+    }
+
+    def locked(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(affinity.state_db, "affinity_touch", locked)
+    candidates = [
+        (SimpleNamespace(key="api:other"), "model"),
+        (SimpleNamespace(key="api:bound"), "model"),
+    ]
+    ordered, hit = scheduler._apply_affinity(candidates, "fp-hit", None)
+
+    assert hit is True
+    assert ordered[0][0].key == "api:bound"
+    assert affinity.snapshot()["fp-hit"]["last_used"] == old_last_used
+
+
+def test_affinity_availability_failure_skips_memory_update(monkeypatch):
+    affinity._entries.clear()
+    affinity._client_entries.clear()
+
+    def locked(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(affinity.state_db, "affinity_upsert", locked)
+    monkeypatch.setattr(affinity.state_db, "client_affinity_upsert", locked)
+    affinity.upsert("fp-locked", "api:test", "model")
+    affinity.client_upsert("client-locked", "api:test", "model")
+    assert affinity.get("fp-locked") is None
+    assert affinity.client_get("client-locked") is None
+
+
+def test_affinity_availability_failure_skips_touch_delete_and_rename(monkeypatch):
+    affinity._entries.clear()
+    affinity._client_entries.clear()
+    affinity._entries["fp"] = {
+        "channel_key": "api:old", "model": "model", "last_used": 1,
+        "prompt_cache_key": None,
+    }
+    affinity._client_entries["client"] = {
+        "channel_key": "api:old", "model": "model", "last_used": 1,
+    }
+
+    def locked(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    for name in (
+        "affinity_touch", "affinity_delete", "affinity_rename_channel",
+        "client_affinity_delete", "client_affinity_rename_channel",
+    ):
+        monkeypatch.setattr(affinity.state_db, name, locked)
+
+    affinity.touch("fp")
+    affinity.delete("fp")
+    affinity.rename_channel("api:old", "api:new")
+    affinity.client_delete("client")
+    affinity.client_rename_channel("api:old", "api:new")
+
+    assert affinity.snapshot()["fp"] == {
+        "channel_key": "api:old", "model": "model", "last_used": 1,
+        "prompt_cache_key": None,
+    }
+    assert affinity.client_snapshot()["client"] == {
+        "channel_key": "api:old", "model": "model", "last_used": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [sqlite3.ProgrammingError("closed connection"), sqlite3.IntegrityError("constraint failed")],
+)
+def test_affinity_does_not_swallow_programming_errors(monkeypatch, exc):
+    affinity._entries.clear()
+
+    def fail(*_args, **_kwargs):
+        raise exc
+
+    monkeypatch.setattr(affinity.state_db, "affinity_upsert", fail)
+    with pytest.raises(type(exc), match=str(exc)):
+        affinity.upsert("fp-bug", "api:test", "model")
+    assert affinity.get("fp-bug") is None
+
+
+@pytest.mark.parametrize(
+    "writer,args",
+    [
+        (state_db.affinity_upsert, ("fp", "api:test", "model")),
+        (state_db.affinity_touch, ("fp",)),
+        (state_db.affinity_delete, ("fp",)),
+        (state_db.affinity_cleanup, (1,)),
+        (state_db.client_affinity_upsert, ("client", "api:test", "model")),
+        (state_db.client_affinity_delete, ("client",)),
+        (state_db.client_affinity_cleanup, (1,)),
+    ],
+)
+def test_affinity_state_writes_roll_back_failed_transaction(monkeypatch, writer, args):
+    class LockedConnection:
+        def __init__(self):
+            self.rolled_back = False
+
+        def execute(self, sql, *_args, **_kwargs):
+            if str(sql).startswith("PRAGMA busy_timeout"):
+                return self
+            raise sqlite3.OperationalError("database is locked")
+
+        def fetchone(self):
+            return (5_000,)
+
+        def rollback(self):
+            self.rolled_back = True
+
+    conn = LockedConnection()
+    monkeypatch.setattr(state_db, "_get_conn", lambda: conn)
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        writer(*args)
+    assert conn.rolled_back is True
+
+
+def test_perf_save_rolls_back_failed_sqlite_write(monkeypatch):
+    class LockedConnection:
+        def __init__(self):
+            self.rolled_back = False
+
+        def execute(self, *_args, **_kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+        def rollback(self):
+            self.rolled_back = True
+
+    conn = LockedConnection()
+    monkeypatch.setattr(state_db, "_get_conn", lambda: conn)
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        state_db.perf_save("api:locked", "model", {})
+    assert conn.rolled_back is True
+
+
+@pytest.mark.parametrize(
+    "writer",
+    [
+        lambda: state_db.schema_meta_set("key", "value"),
+        lambda: state_db.network_check_save({"key": "network"}),
+        lambda: state_db.network_check_delete("network"),
+        lambda: state_db.network_check_delete_stale(set()),
+        lambda: state_db.quota_save("openai:account", {}),
+        lambda: state_db.quota_delete("openai:account"),
+        lambda: state_db.quota_patch_passive(
+            "claude:account", {"five_hour_util": 1},
+        ),
+        lambda: state_db.quota_save_openai_snapshot(
+            "openai:account",
+            {"fetched_at": 1},
+            {
+                "five_hour_util": 1,
+                "five_hour_reset_sec": 1,
+                "seven_day_util": 2,
+                "seven_day_reset_sec": 2,
+            },
+        ),
+    ],
+)
+def test_auxiliary_state_writes_roll_back_failed_transaction(monkeypatch, writer):
+    class LockedConnection:
+        def __init__(self):
+            self.rolled_back = False
+
+        def execute(self, sql, *_args, **_kwargs):
+            if str(sql).startswith("PRAGMA busy_timeout"):
+                return self
+            raise sqlite3.OperationalError("database is locked")
+
+        def fetchone(self):
+            return (5_000,)
+
+        def rollback(self):
+            self.rolled_back = True
+
+    conn = LockedConnection()
+    monkeypatch.setattr(state_db, "_get_conn", lambda: conn)
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        writer()
+    assert conn.rolled_back is True
+
+
+def test_state_db_init_rolls_back_failed_schema_setup(monkeypatch, tmp_path):
+    class BrokenConnection:
+        def __init__(self):
+            self.rolled_back = False
+
+        def executescript(self, _sql):
+            raise sqlite3.OperationalError("schema is locked")
+
+        def rollback(self):
+            self.rolled_back = True
+
+    conn = BrokenConnection()
+    monkeypatch.setattr(state_db, "_resolve_db_path", lambda: str(tmp_path / "state.db"))
+    monkeypatch.setattr(state_db, "_get_conn", lambda: conn)
+    monkeypatch.setattr(state_db, "_initialized", False)
+    with pytest.raises(sqlite3.OperationalError, match="schema is locked"):
+        state_db.init()
+    assert conn.rolled_back is True
+
+
+@pytest.mark.parametrize(
+    "writer",
+    [
+        lambda key: state_db.quota_save(key, {"fetched_at": 1}),
+        lambda key: state_db.quota_patch_passive(key, {"five_hour_util": 1}),
+        lambda key: state_db.quota_save_openai_snapshot(
+            key,
+            {"fetched_at": 1},
+            {
+                "five_hour_util": 1,
+                "five_hour_reset_sec": 1,
+                "seven_day_util": 2,
+                "seven_day_reset_sec": 2,
+            },
+        ),
+    ],
+)
+def test_quota_cache_response_path_writes_fail_fast_under_state_lock(writer):
+    state_db.init()
+    key = f"openai:quota-lock-{uuid.uuid4().hex}"
+    locker = sqlite3.connect(state_db._db_path, timeout=0.05)
+    locker.execute("BEGIN IMMEDIATE")
+    started = time.monotonic()
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            writer(key)
+    finally:
+        locker.rollback()
+        locker.close()
+    assert time.monotonic() - started < 1.0
+
+
+def test_late_quota_writes_after_rename_follow_current_account_generation():
+    state_db.init()
+    suffix = uuid.uuid4().hex
+    old_key = f"openai:old-{suffix}@example.test"
+    new_key = f"openai:new-{suffix}@example.test:workspace-{suffix}"
+    state_db.quota_save(old_key, {"fetched_at": 1, "five_hour_util": 1})
+    with channel_state.mutation_lock:
+        state_db.quota_rename_account_key(
+            old_key, new_key, email=f"new-{suffix}@example.test",
+        )
+        channel_state._install_alias(f"oauth:{old_key}", f"oauth:{new_key}")
+
+    # Simulate three responses that started before the identity rename.
+    state_db.quota_save(
+        old_key, {"fetched_at": 2, "five_hour_util": 11},
+    )
+    state_db.quota_patch_passive(old_key, {"seven_day_util": 22})
+    state_db.quota_save_openai_snapshot(
+        old_key,
+        {
+            "fetched_at": 3,
+            "primary_used_pct": 33,
+            "primary_reset_sec": 60,
+            "primary_window_min": 300,
+        },
+        {
+            "five_hour_util": 33,
+            "five_hour_reset_sec": 60,
+            "seven_day_util": 44,
+            "seven_day_reset_sec": 120,
+        },
+    )
+
+    matching = {
+        row["account_key"]: row
+        for row in state_db.quota_load_all()
+        if suffix in row["account_key"]
+    }
+    assert set(matching) == {new_key}
+    assert matching[new_key]["email"] == f"new-{suffix}@example.test"
+    assert matching[new_key]["codex_primary_used_pct"] == 33
+    assert matching[new_key]["five_hour_util"] == 33
+    assert matching[new_key]["seven_day_util"] == 44
+
+
+def test_runtime_oauth_identity_rename_keeps_all_db_and_memory_mirrors_aligned():
+    from src import cooldown, oauth_manager
+
+    state_db.init()
+    scorer.init()
+    cooldown.init()
+    affinity.init()
+    affinity.client_init()
+
+    suffix = uuid.uuid4().hex
+    old_account = f"openai:old-{suffix}"
+    new_account = f"openai:new-{suffix}"
+    old_channel = f"oauth:{old_account}"
+    new_channel = f"oauth:{new_account}"
+    model = "gate-model"
+    destination_model = "destination-only-model"
+
+    scorer.record_success(old_channel, model, 11, 22, 33)
+    scorer.record_failure(new_channel, destination_model, 99)
+    old_score = scorer.get_stats(old_channel, model)
+    destination_score = scorer.get_stats(new_channel, destination_model)
+    cooldown.record_error(
+        old_channel, model, "old wins", cooldown_until=state_db.now_ms() + 60_000,
+    )
+    cooldown.record_error(
+        new_channel, model, "new conflict", cooldown_until=state_db.now_ms() + 120_000,
+    )
+    cooldown.record_error(
+        new_channel, destination_model, "destination survives",
+        cooldown_until=state_db.now_ms() + 120_000,
+    )
+    old_cooldown = cooldown.get_state(old_channel, model)
+    destination_cooldown = cooldown.get_state(new_channel, destination_model)
+    affinity.upsert(f"fp-old-{suffix}", old_channel, model)
+    affinity.upsert(f"fp-new-{suffix}", new_channel, model)
+    affinity.client_upsert(f"client-old-{suffix}", old_channel, model)
+    affinity.client_upsert(f"client-new-{suffix}", new_channel, model)
+    state_db.quota_save(
+        old_account, {"fetched_at": 200, "raw_data": '{"source":"old"}'},
+        email=f"old-{suffix}@example.test",
+    )
+    state_db.quota_save(
+        new_account, {"fetched_at": 100, "raw_data": '{"source":"new"}'},
+        email=f"new-{suffix}@example.test",
+    )
+
+    oauth_manager._rename_runtime_oauth_identity(
+        old_account,
+        new_account,
+        email=f"new-{suffix}@example.test",
+        config_mutator=lambda cfg: None,
+        rollback_mutator=lambda cfg: None,
+    )
+
+    assert scorer.get_stats(old_channel, model) is None
+    assert scorer.get_stats(new_channel, model) == old_score
+    assert scorer.get_stats(new_channel, destination_model) == destination_score
+    assert cooldown.get_state(old_channel, model) is None
+    assert cooldown.get_state(new_channel, model) == old_cooldown
+    assert cooldown.get_state(new_channel, destination_model) == destination_cooldown
+    assert affinity.get(f"fp-old-{suffix}")["channel_key"] == new_channel
+    assert affinity.get(f"fp-new-{suffix}")["channel_key"] == new_channel
+    assert affinity.client_get(f"client-old-{suffix}")["channel_key"] == new_channel
+    assert affinity.client_get(f"client-new-{suffix}")["channel_key"] == new_channel
+    assert state_db.quota_load(old_account) is None
+    assert state_db.quota_load(new_account)["raw_data"] == '{"source":"old"}'
+
+    conn = sqlite3.connect(state_db._db_path)
+    try:
+        for table in ("performance_stats", "channel_errors", "cache_affinities", "client_affinities"):
+            assert conn.execute(
+                f"SELECT count(*) FROM {table} WHERE channel_key=?", (old_channel,),
+            ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT last_error_message FROM channel_errors WHERE channel_key=? AND model=?",
+            (new_channel, model),
+        ).fetchone()[0] == "old wins"
+    finally:
+        conn.close()
+
+    # A retry after all old rows have moved is a no-op, not a destructive
+    # delete of destination-only models.
+    oauth_manager._rename_runtime_oauth_identity(
+        old_account,
+        new_account,
+        email=f"new-{suffix}@example.test",
+        config_mutator=lambda cfg: None,
+        rollback_mutator=lambda cfg: None,
+    )
+    assert scorer.get_stats(new_channel, destination_model) == destination_score
+    assert cooldown.get_state(new_channel, destination_model) == destination_cooldown
+
+
+def test_migration_channel_rename_merges_channel_error_primary_key_conflicts():
+    state_db.init()
+    suffix = uuid.uuid4().hex
+    old_channel = f"oauth:old-{suffix}"
+    new_channel = f"oauth:new-{suffix}"
+    model = "gate-model"
+    state_db.error_save(old_channel, model, 7, -1, "old wins")
+    state_db.error_save(new_channel, model, 2, 123, "new conflict")
+
+    state_db._commit_write(
+        lambda conn: state_db._rename_channel_key_no_commit(
+            conn, old_channel, new_channel,
+        )
+    )
+
+    conn = sqlite3.connect(state_db._db_path)
+    try:
+        rows = conn.execute(
+            "SELECT channel_key, error_count, last_error_message FROM channel_errors "
+            "WHERE channel_key IN (?, ?) AND model=?",
+            (old_channel, new_channel, model),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows == [(new_channel, 7, "old wins")]
+
+
+def test_refresh_identity_and_priority_publish_in_one_reload_snapshot():
+    from src import cooldown, oauth_manager
+    from src.channel import registry
+
+    state_db.init()
+    scorer.init()
+    cooldown.init()
+    affinity.init()
+    affinity.client_init()
+    suffix = uuid.uuid4().hex
+    email = f"reload-{suffix}@example.test"
+    account = {
+        "email": email,
+        "provider": "openai",
+        "access_token": "test-access-token",
+        "refresh_token": "test-refresh-token",
+        "id_token": "h.p.s",
+        "chatgpt_account_id": f"acct-old-{suffix}",
+        "models": ["gpt-test"],
+        "enabled": True,
+    }
+    old_account = oauth_manager._canonical_key(account)
+    updated = dict(account)
+    updated["chatgpt_account_id"] = f"acct-new-{suffix}"
+    new_account = oauth_manager._canonical_key(updated)
+    assert old_account != new_account
+    old_channel = f"oauth:{old_account}"
+    new_channel = f"oauth:{new_account}"
+
+    def seed_config(cfg):
+        cfg["oauthAccounts"] = [dict(account)]
+        cfg.setdefault("loadBalancing", {}).setdefault("priorityOrders", {})["openai"] = [old_channel]
+
+    config.update(seed_config)
+    registry.rebuild_from_config()
+    scorer.record_success(old_channel, "gpt-test", 1, 2, 3)
+    cooldown.record_error(
+        old_channel, "gpt-test", "keep me",
+        cooldown_until=state_db.now_ms() + 60_000,
+    )
+    affinity.upsert(f"fp-reload-{suffix}", old_channel, "gpt-test")
+
+    snapshots: list[tuple[list[str], list[str]]] = []
+
+    def reload_callback(cfg):
+        snapshots.append((
+            [oauth_manager._canonical_key(a) for a in cfg.get("oauthAccounts", [])],
+            list(cfg.get("loadBalancing", {}).get("priorityOrders", {}).get("openai", [])),
+        ))
+        registry.rebuild_from_config()
+
+    config.on_reload(reload_callback)
+    try:
+        oauth_manager._save_token_fields(
+            old_account, {"chatgpt_account_id": f"acct-new-{suffix}"},
+        )
+    finally:
+        config._reload_callbacks.remove(reload_callback)
+
+    assert snapshots == [([new_account], [new_channel])]
+    assert registry.get_channel(new_channel) is not None
+    assert registry.get_channel(old_channel) is None
+    assert scorer.get_stats(new_channel, "gpt-test") is not None
+    assert cooldown.get_state(new_channel, "gpt-test") is not None
+    assert affinity.get(f"fp-reload-{suffix}")["channel_key"] == new_channel
+    with pytest.raises(ValueError, match="restart before reusing"):
+        oauth_manager.add_account(dict(account))
+
+    config.update(
+        lambda cfg: cfg.setdefault("oauthAccounts", []).append(dict(account))
+    )
+    registry.rebuild_from_config()
+    assert registry.get_channel(old_channel) is None
+    oauth_manager.delete_account(old_account)
+    assert cooldown.get_state(new_channel, "gpt-test") is not None
+    assert [
+        oauth_manager._canonical_key(item)
+        for item in config.get().get("oauthAccounts", [])
+    ] == [new_account]
+
+
+def test_api_channel_rename_preserves_state_with_real_reload_callback():
+    from src import cooldown
+    from src.channel import registry
+
+    state_db.init(); scorer.init(); cooldown.init(); affinity.init(); affinity.client_init()
+    suffix = uuid.uuid4().hex
+    old_name = f"old-{suffix}"
+    new_name = f"new-{suffix}"
+    old_key = f"api:{old_name}"
+    new_key = f"api:{new_name}"
+
+    def seed(cfg):
+        cfg["channels"] = [{
+            "name": old_name,
+            "type": "api",
+            "baseUrl": "http://127.0.0.1:9",
+            "apiKey": "***",
+            "protocol": "anthropic",
+            "models": [{"real": "model", "alias": "model"}],
+            "cc_mimicry": True,
+            "enabled": True,
+        }]
+        cfg.setdefault("loadBalancing", {})["initialized"] = True
+        cfg["loadBalancing"]["priorityOrders"] = {
+            "anthropic": [old_key], "openai": [],
+        }
+
+    config.update(seed)
+    registry.rebuild_from_config()
+    scorer.record_success(old_key, "model", 1, 2, 3)
+    cooldown.record_error(
+        old_key, "model", "keep", cooldown_until=state_db.now_ms() + 60_000,
+    )
+    affinity.upsert(f"fp-api-{suffix}", old_key, "model")
+    affinity.client_upsert(f"client-api-{suffix}", old_key, "model")
+    snapshots = []
+
+    def callback(cfg):
+        snapshots.append((
+            [entry.get("name") for entry in cfg.get("channels", [])],
+            list(cfg.get("loadBalancing", {}).get("priorityOrders", {}).get("anthropic", [])),
+        ))
+        registry.rebuild_from_config()
+
+    config.on_reload(callback)
+    try:
+        registry.update_api_channel(old_name, {"name": new_name})
+    finally:
+        config._reload_callbacks.remove(callback)
+
+    assert snapshots == [([new_name], [new_key])]
+    assert scorer.get_stats(old_key, "model") is None
+    assert scorer.get_stats(new_key, "model") is not None
+    assert cooldown.get_state(new_key, "model") is not None
+    assert affinity.get(f"fp-api-{suffix}")["channel_key"] == new_key
+    assert affinity.client_get(f"client-api-{suffix}")["channel_key"] == new_key
+
+    # A request that started on the old generation may finish after rename;
+    # every late state write must still land on the destination generation.
+    scorer.record_success(old_key, "model", 4, 5, 6)
+    cooldown.record_error(old_key, "late-model", "late")
+    affinity.upsert(f"fp-late-{suffix}", old_key, "model")
+    affinity.client_upsert(f"client-late-{suffix}", old_key, "model")
+    assert scorer.get_stats(new_key, "model")["total_requests"] == 2
+    assert cooldown.get_state(new_key, "late-model") is not None
+    assert affinity.get(f"fp-late-{suffix}")["channel_key"] == new_key
+    assert affinity.client_get(f"client-late-{suffix}")["channel_key"] == new_key
+
+    # Maintenance cleanup must use the raw stale key rather than resolving the
+    # request alias and accidentally clearing the live destination cooldown.
+    conn = sqlite3.connect(state_db._db_path)
+    try:
+        conn.execute(
+            """INSERT OR REPLACE INTO channel_errors
+               (channel_key, model, error_count, cooldown_until, last_error_message, last_error_at)
+               VALUES (?,?,?,?,?,?)""",
+            (old_key, "orphan", 1, state_db.now_ms() + 60_000, "orphan", state_db.now_ms()),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    registry._sync_state_db_with_channels()
+    assert cooldown.get_state(new_key, "late-model") is not None
+    conn = sqlite3.connect(state_db._db_path)
+    try:
+        assert conn.execute(
+            "SELECT count(*) FROM channel_errors WHERE channel_key=?", (old_key,),
+        ).fetchone()[0] == 0
+    finally:
+        conn.close()
+
+    with pytest.raises(ValueError, match="restart before reusing"):
+        registry.add_api_channel({
+            "name": old_name,
+            "baseUrl": "http://127.0.0.1:9",
+            "apiKey": "***",
+            "protocol": "anthropic",
+            "models": [{"real": "model", "alias": "model"}],
+        })
+
+    raw_old = {
+        "name": old_name, "type": "api", "baseUrl": "http://127.0.0.1:9",
+        "apiKey": "***", "protocol": "anthropic",
+        "models": [{"real": "model", "alias": "model"}],
+        "cc_mimicry": True, "enabled": True,
+    }
+    config.update(lambda cfg: cfg.setdefault("channels", []).append(raw_old))
+    registry.rebuild_from_config()
+    assert registry.get_channel(old_key) is None
+    assert registry.delete_api_channel(old_name)
+    assert cooldown.get_state(new_key, "late-model") is not None
+
+
+def test_oauth_rename_state_failure_rolls_config_back_without_losing_old_state(monkeypatch):
+    from src import cooldown, oauth_manager
+    from src.channel import registry
+
+    state_db.init(); scorer.init(); cooldown.init(); affinity.init(); affinity.client_init()
+    suffix = uuid.uuid4().hex
+    old_account = {
+        "email": f"rollback-{suffix}@example.test",
+        "provider": "openai",
+        "access_token": "***",
+        "refresh_token": "***",
+        "id_token": "***",
+        "chatgpt_account_id": f"old-{suffix}",
+        "models": ["model"],
+        "enabled": True,
+    }
+    old_key = oauth_manager._canonical_key(old_account)
+    updated = dict(old_account, chatgpt_account_id=f"new-{suffix}")
+    new_key = oauth_manager._canonical_key(updated)
+    old_channel = f"oauth:{old_key}"
+
+    def seed(cfg):
+        cfg["oauthAccounts"] = [dict(old_account)]
+        cfg.setdefault("loadBalancing", {})["priorityOrders"] = {
+            "anthropic": [], "openai": [old_channel],
+        }
+
+    config.update(seed)
+    registry.rebuild_from_config()
+    scorer.record_success(old_channel, "model", 1, 2, 3)
+    cooldown.record_error(
+        old_channel, "model", "keep", cooldown_until=state_db.now_ms() + 60_000,
+    )
+    affinity.upsert(f"fp-rollback-{suffix}", old_channel, "model")
+    snapshots = []
+
+    def callback(cfg):
+        snapshots.append([oauth_manager._canonical_key(a) for a in cfg.get("oauthAccounts", [])])
+        registry.rebuild_from_config()
+
+    config.on_reload(callback)
+    monkeypatch.setattr(
+        state_db,
+        "rename_runtime_channel_state",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            sqlite3.OperationalError("database is locked")
+        ),
+    )
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            oauth_manager._save_token_fields(
+                old_key, {"chatgpt_account_id": f"new-{suffix}"},
+            )
+    finally:
+        config._reload_callbacks.remove(callback)
+
+    assert snapshots == [[new_key], [old_key]]
+    assert [oauth_manager._canonical_key(a) for a in config.get()["oauthAccounts"]] == [old_key]
+    assert scorer.get_stats(old_channel, "model") is not None
+    assert cooldown.get_state(old_channel, "model") is not None
+    assert affinity.get(f"fp-rollback-{suffix}")["channel_key"] == old_channel
+
+
+def test_post_commit_publisher_failure_installs_alias_and_attempts_remaining_publishers(monkeypatch):
+    from src import channel_state, cooldown, oauth_manager
+
+    state_db.init(); scorer.init(); cooldown.init(); affinity.init(); affinity.client_init()
+    suffix = uuid.uuid4().hex
+    old_account = f"openai:publish-old-{suffix}"
+    new_account = f"openai:publish-new-{suffix}"
+    old_channel = f"oauth:{old_account}"
+    new_channel = f"oauth:{new_account}"
+    scorer.record_success(old_channel, "model", 1, 2, 3)
+    cooldown.record_error(
+        old_channel, "model", "keep", cooldown_until=state_db.now_ms() + 60_000,
+    )
+    affinity.upsert(f"fp-publish-{suffix}", old_channel, "model")
+    affinity.client_upsert(f"client-publish-{suffix}", old_channel, "model")
+    real_scorer_rename = scorer.rename_channel
+
+    def broken_scorer(*args, **kwargs):
+        raise RuntimeError("publisher bug")
+
+    monkeypatch.setattr(scorer, "rename_channel", broken_scorer)
+    with pytest.raises(ExceptionGroup, match="memory publication failed"):
+        oauth_manager._rename_runtime_oauth_identity(
+            old_account,
+            new_account,
+            email=f"publish-{suffix}@example.test",
+            config_mutator=lambda cfg: None,
+            rollback_mutator=lambda cfg: None,
+        )
+
+    assert channel_state.resolve(old_channel) == new_channel
+    assert cooldown.get_state(new_channel, "model") is not None
+    assert affinity.get(f"fp-publish-{suffix}")["channel_key"] == new_channel
+    assert affinity.client_get(f"client-publish-{suffix}")["channel_key"] == new_channel
+    monkeypatch.setattr(scorer, "rename_channel", real_scorer_rename)
+    scorer.record_success(old_channel, "late", 4, 5, 6)
+    assert scorer.get_stats(new_channel, "late") is not None
+    assert scorer.get_stats(old_channel, "late") is None
+
+
+def test_oauth_rename_config_write_failure_does_not_move_runtime_state(monkeypatch):
+    from src import oauth_manager
+
+    state_db.init(); scorer.init(); affinity.init(); affinity.client_init()
+    suffix = uuid.uuid4().hex
+    account = {
+        "email": f"write-fail-{suffix}@example.test",
+        "provider": "openai",
+        "access_token": "***",
+        "refresh_token": "***",
+        "chatgpt_account_id": f"old-{suffix}",
+        "models": ["model"],
+    }
+    old_key = oauth_manager._canonical_key(account)
+    old_channel = f"oauth:{old_key}"
+    config.update(lambda cfg: cfg.__setitem__("oauthAccounts", [dict(account)]))
+    scorer.record_success(old_channel, "model", 1, 2, 3)
+    affinity.upsert(f"fp-write-fail-{suffix}", old_channel, "model")
+    monkeypatch.setattr(
+        config, "_write_atomic",
+        lambda candidate: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    with pytest.raises(OSError, match="disk full"):
+        oauth_manager._save_token_fields(
+            old_key, {"chatgpt_account_id": f"new-{suffix}"},
+        )
+
+    assert [oauth_manager._canonical_key(a) for a in config.get()["oauthAccounts"]] == [old_key]
+    assert scorer.get_stats(old_channel, "model") is not None
+    assert affinity.get(f"fp-write-fail-{suffix}")["channel_key"] == old_channel
+
+
+def test_oauth_refresh_rejects_duplicate_destination_identity():
+    from src import oauth_manager
+
+    state_db.init(); scorer.init(); affinity.init(); affinity.client_init()
+    suffix = uuid.uuid4().hex
+    email = f"duplicate-{suffix}@example.test"
+    old_account = {
+        "email": email, "provider": "openai", "access_token": "***old",
+        "refresh_token": "***old", "chatgpt_account_id": f"old-{suffix}",
+        "models": ["model"],
+    }
+    destination = {
+        "email": email, "provider": "openai", "access_token": "***new",
+        "refresh_token": "***new", "chatgpt_account_id": f"new-{suffix}",
+        "models": ["model"],
+    }
+    old_key = oauth_manager._canonical_key(old_account)
+    destination_key = oauth_manager._canonical_key(destination)
+    config.update(
+        lambda cfg: cfg.__setitem__(
+            "oauthAccounts", [dict(old_account), dict(destination)],
+        )
+    )
+    scorer.record_success(f"oauth:{old_key}", "model", 1, 2, 3)
+
+    with pytest.raises(ValueError, match="identity already exists"):
+        oauth_manager._save_token_fields(
+            old_key, {"chatgpt_account_id": f"new-{suffix}"},
+        )
+
+    assert [
+        oauth_manager._canonical_key(account)
+        for account in config.get()["oauthAccounts"]
+    ] == [old_key, destination_key]
+    assert scorer.get_stats(f"oauth:{old_key}", "model") is not None
+
+
+def test_concurrent_reload_waits_until_oauth_state_rename_is_published(monkeypatch):
+    from src import oauth_manager
+    from src.channel import registry
+
+    state_db.init(); scorer.init(); affinity.init(); affinity.client_init()
+    suffix = uuid.uuid4().hex
+    account = {
+        "email": f"concurrent-{suffix}@example.test",
+        "provider": "openai",
+        "access_token": "***",
+        "refresh_token": "***",
+        "chatgpt_account_id": f"old-{suffix}",
+        "models": ["model"],
+    }
+    old_key = oauth_manager._canonical_key(account)
+    updated = dict(account, chatgpt_account_id=f"new-{suffix}")
+    new_key = oauth_manager._canonical_key(updated)
+    old_channel = f"oauth:{old_key}"
+    new_channel = f"oauth:{new_key}"
+    config.update(lambda cfg: cfg.__setitem__("oauthAccounts", [dict(account)]))
+    registry.rebuild_from_config()
+    scorer.record_success(old_channel, "model", 1, 2, 3)
+    affinity.upsert(f"fp-concurrent-{suffix}", old_channel, "model")
+
+    callback = lambda cfg: registry.rebuild_from_config()
+    config.on_reload(callback)
+    entered = threading.Event()
+    allow_commit = threading.Event()
+    second_done = threading.Event()
+    errors: list[BaseException] = []
+    real_rename = state_db.rename_runtime_channel_state
+
+    def paused_rename(*args, **kwargs):
+        entered.set()
+        assert allow_commit.wait(5)
+        return real_rename(*args, **kwargs)
+
+    monkeypatch.setattr(state_db, "rename_runtime_channel_state", paused_rename)
+
+    def refresh_worker():
+        try:
+            oauth_manager._save_token_fields(
+                old_key, {"chatgpt_account_id": f"new-{suffix}"},
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    def reload_worker():
+        try:
+            config.update(lambda cfg: cfg.__setitem__("concurrentReloadProbe", suffix))
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            second_done.set()
+
+    first = threading.Thread(target=refresh_worker)
+    second = threading.Thread(target=reload_worker)
+    try:
+        first.start()
+        assert entered.wait(5)
+        second.start()
+        # The second config lifecycle must wait until config and all mirrored
+        # state for the rename have published together.
+        time.sleep(0.05)
+        assert not second_done.is_set()
+        allow_commit.set()
+        first.join(5); second.join(5)
+    finally:
+        allow_commit.set()
+        first.join(5); second.join(5)
+        config._reload_callbacks.remove(callback)
+
+    assert not first.is_alive() and not second.is_alive()
+    assert not errors
+    assert scorer.get_stats(old_channel, "model") is None
+    assert scorer.get_stats(new_channel, "model") is not None
+    assert affinity.get(f"fp-concurrent-{suffix}")["channel_key"] == new_channel
+    assert registry.get_channel(new_channel) is not None
+
+
+def test_paused_old_registry_rebuild_cannot_overwrite_completed_rename(monkeypatch):
+    from src import cooldown
+    from src.channel import registry
+
+    state_db.init(); scorer.init(); cooldown.init(); affinity.init(); affinity.client_init()
+    suffix = uuid.uuid4().hex
+    old_name = f"cas-old-{suffix}"
+    new_name = f"cas-new-{suffix}"
+    old_key = f"api:{old_name}"
+    new_key = f"api:{new_name}"
+
+    def seed(cfg):
+        cfg["channels"] = [{
+            "name": old_name, "type": "api", "baseUrl": "http://127.0.0.1:9",
+            "apiKey": "***", "protocol": "anthropic",
+            "models": [{"real": "model", "alias": "model"}],
+            "cc_mimicry": True, "enabled": True,
+        }]
+
+    config.update(seed)
+    registry.rebuild_from_config()
+    scorer.record_success(old_key, "model", 1, 2, 3)
+    affinity.upsert(f"fp-cas-{suffix}", old_key, "model")
+    entered = threading.Event(); allow = threading.Event(); rename_done = threading.Event()
+    errors: list[BaseException] = []
+    real_cls = registry.ApiChannel
+
+    class PausingApiChannel(real_cls):
+        def __init__(self, entry):
+            entered.set()
+            assert allow.wait(5)
+            super().__init__(entry)
+
+    monkeypatch.setattr(registry, "ApiChannel", PausingApiChannel)
+
+    def old_rebuild():
+        try:
+            registry.rebuild_from_config()
+        except BaseException as exc:
+            errors.append(exc)
+
+    def rename():
+        try:
+            registry.update_api_channel(old_name, {"name": new_name})
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            rename_done.set()
+
+    first = threading.Thread(target=old_rebuild)
+    second = threading.Thread(target=rename)
+    first.start(); assert entered.wait(5)
+    second.start(); time.sleep(0.05)
+    assert not rename_done.is_set()
+    allow.set(); first.join(5); second.join(5)
+
+    assert not errors
+    assert registry.get_channel(old_key) is None
+    assert registry.get_channel(new_key) is not None
+    assert scorer.get_stats(new_key, "model") is not None
+    assert affinity.get(f"fp-cas-{suffix}")["channel_key"] == new_key
+
+
+def test_api_delete_holds_serialized_lifecycle_through_cascade(monkeypatch):
+    from src.channel import registry
+
+    state_db.init(); scorer.init(); affinity.init(); affinity.client_init()
+    suffix = uuid.uuid4().hex
+    name = f"delete-race-{suffix}"
+    key = f"api:{name}"
+    entry = {
+        "name": name, "type": "api", "baseUrl": "http://127.0.0.1:9",
+        "apiKey": "***", "protocol": "anthropic",
+        "models": [{"real": "model", "alias": "model"}],
+        "cc_mimicry": True, "enabled": True,
+    }
+    config.update(lambda cfg: cfg.__setitem__("channels", [dict(entry)]))
+    registry.rebuild_from_config(); scorer.record_success(key, "old", 1, 2, 3)
+    entered = threading.Event(); allow = threading.Event(); add_done = threading.Event()
+    results = []; errors: list[BaseException] = []
+    real_clear = scorer.clear_stats
+
+    def paused_clear(channel_key=None, model=None):
+        if channel_key == key:
+            entered.set(); assert allow.wait(5)
+        return real_clear(channel_key, model)
+
+    monkeypatch.setattr(scorer, "clear_stats", paused_clear)
+
+    def delete_worker():
+        try:
+            results.append(registry.delete_api_channel(name))
+        except BaseException as exc:
+            errors.append(exc)
+
+    def add_worker():
+        try:
+            registry.add_api_channel(dict(entry))
+            scorer.record_success(key, "new", 4, 5, 6)
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            add_done.set()
+
+    first = threading.Thread(target=delete_worker)
+    second = threading.Thread(target=add_worker)
+    first.start(); assert entered.wait(5)
+    second.start(); time.sleep(0.05)
+    assert not add_done.is_set()
+    allow.set(); first.join(5); second.join(5)
+
+    assert results == [True]
+    assert len(errors) == 1
+    assert isinstance(errors[0], ValueError)
+    assert "restart before reusing" in str(errors[0])
+    assert registry.get_channel(key) is None
+    assert scorer.get_stats(key, "old") is None
+    assert scorer.get_stats(key, "new") is None
+
+
+def test_registry_stale_cleanup_clears_scorer_and_cooldown_memory_and_db(monkeypatch):
+    from src import cooldown
+    from src.channel import registry
+
+    state_db.init()
+    scorer.init()
+    cooldown.init()
+    stale = f"api:stale-{uuid.uuid4().hex}"
+    scorer.record_success(stale, "model", 1, 2, 3)
+    cooldown.record_error(
+        stale, "model", "stale", cooldown_until=state_db.now_ms() + 60_000,
+    )
+    memory_only = f"api:memory-only-{uuid.uuid4().hex}"
+    real_perf_save = state_db.perf_save
+    monkeypatch.setattr(
+        state_db, "perf_save",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            sqlite3.OperationalError("database is locked")
+        ),
+    )
+    scorer.record_success(memory_only, "model", 1, 2, 3)
+    monkeypatch.setattr(state_db, "perf_save", real_perf_save)
+    partial = f"api:partial-memory-{uuid.uuid4().hex}"
+    with scorer._lock:
+        scorer._stats[(partial, "model")] = {"total_requests": 1}
+    assert scorer.get_stats(stale, "model") is not None
+    assert scorer.get_stats(memory_only, "model") is not None
+    assert partial in scorer.channel_keys()
+    assert cooldown.get_state(stale, "model") is not None
+
+    registry._sync_state_db_with_channels()
+
+    assert scorer.get_stats(stale, "model") is None
+    assert scorer.get_stats(memory_only, "model") is None
+    assert partial not in scorer.channel_keys()
+    assert cooldown.get_state(stale, "model") is None
+    conn = sqlite3.connect(state_db._db_path)
+    try:
+        assert conn.execute(
+            "SELECT count(*) FROM performance_stats WHERE channel_key=?", (stale,),
+        ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT count(*) FROM channel_errors WHERE channel_key=?", (stale,),
+        ).fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_scorer_rename_persists_before_publishing_memory(monkeypatch):
+    old_channel = "api:score-old"
+    new_channel = "api:score-new"
+    scorer._stats.clear()
+    scorer._stats[(old_channel, "model")] = {"total_requests": 1}
+
+    def locked(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(scorer.state_db, "perf_rename_channel", locked)
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        scorer.rename_channel(old_channel, new_channel)
+    assert (old_channel, "model") in scorer._stats
+    assert (new_channel, "model") not in scorer._stats
+
+
+@pytest.mark.parametrize("client", [False, True])
+def test_expiry_read_does_not_delete_concurrently_refreshed_affinity(monkeypatch, client):
+    key = f"race-{'client' if client else 'fp'}-{uuid.uuid4().hex}"
+    old = {
+        "channel_key": "api:old", "model": "model", "last_used": 1,
+    }
+    if not client:
+        old["prompt_cache_key"] = None
+    entries = affinity._client_entries if client else affinity._entries
+    mutation_lock = affinity._client_mutation_lock if client else affinity._mutation_lock
+    entries.clear()
+    entries[key] = old
+
+    observed_stale = threading.Event()
+    real_now_ms = state_db.now_ms
+
+    def controlled_now():
+        observed_stale.set()
+        return 10_000_000
+
+    monkeypatch.setattr(affinity.state_db, "now_ms", controlled_now)
+    monkeypatch.setattr(
+        affinity, "_client_ttl_ms" if client else "_ttl_ms", lambda: 100,
+    )
+    result: list[dict | None] = []
+    getter = affinity.client_get if client else affinity.get
+
+    mutation_lock.acquire()
+    try:
+        thread = threading.Thread(target=lambda: result.append(getter(key)))
+        thread.start()
+        assert observed_stale.wait(timeout=1)
+        refreshed = {
+            "channel_key": "api:new", "model": "model", "last_used": 9_999_950,
+        }
+        if not client:
+            refreshed["prompt_cache_key"] = None
+        if client:
+            state_db.client_affinity_upsert(key, "api:new", "model", last_used=9_999_950)
+            with affinity._client_lock:
+                entries[key] = refreshed
+        else:
+            state_db.affinity_upsert(key, "api:new", "model", last_used=9_999_950)
+            with affinity._lock:
+                entries[key] = refreshed
+    finally:
+        mutation_lock.release()
+    thread.join(timeout=2)
+    monkeypatch.setattr(affinity.state_db, "now_ms", real_now_ms)
+
+    assert not thread.is_alive()
+    assert result == [refreshed]
+    assert entries[key] == refreshed
+
+
+def test_api_delete_is_one_config_snapshot_and_drops_late_generation_writes():
+    from src import channel_state, concurrency, cooldown
+    from src.channel import registry
+
+    state_db.init(); scorer.init(); cooldown.init(); affinity.init(); affinity.client_init()
+    suffix = uuid.uuid4().hex
+    name = f"delete-{suffix}"
+    key = f"api:{name}"
+    entry = {
+        "name": name,
+        "type": "api",
+        "baseUrl": "http://127.0.0.1:9",
+        "apiKey": "***",
+        "protocol": "anthropic",
+        "models": [{"real": "model", "alias": "model"}],
+        "cc_mimicry": True,
+        "enabled": True,
+    }
+
+    def seed(cfg):
+        cfg["channels"] = [dict(entry)]
+        cfg.setdefault("loadBalancing", {})["initialized"] = True
+        cfg["loadBalancing"]["priorityOrders"] = {
+            "anthropic": [key], "openai": [],
+        }
+
+    config.update(seed)
+    registry.rebuild_from_config()
+    scorer.record_success(key, "model", 1, 2, 3)
+    cooldown.record_error(key, "model", "old")
+    affinity.upsert(f"fp-{suffix}", key, "model")
+    affinity.client_upsert(f"client-{suffix}", key, "model")
+    with concurrency._slots_guard:
+        concurrency._slots[key] = concurrency.ChannelSlot(
+            key=key, max_concurrent=1, in_flight=1,
+        )
+    snapshots = []
+
+    def callback(cfg):
+        snapshots.append((
+            [channel.get("name") for channel in cfg.get("channels", [])],
+            list(cfg.get("loadBalancing", {}).get("priorityOrders", {}).get("anthropic", [])),
+        ))
+
+    config.on_reload(callback)
+    try:
+        assert registry.delete_api_channel(name)
+    finally:
+        config._reload_callbacks.remove(callback)
+
+    assert snapshots == [([], [])]
+    assert channel_state.is_deleted(key)
+
+    # Simulate completion side effects from a request holding the old Channel.
+    scorer.record_success(key, "late", 4, 5, 6)
+    scorer.record_failure(key, "late", 4)
+    assert cooldown.record_error(key, "late", "late") == {}
+    affinity.upsert(f"late-fp-{suffix}", key, "late")
+    affinity.client_upsert(f"late-client-{suffix}", key, "late")
+    assert scorer.get_stats(key, "late") is None
+    assert cooldown.get_state(key, "late") is None
+    assert affinity.get(f"late-fp-{suffix}") is None
+    assert affinity.client_get(f"late-client-{suffix}") is None
+    assert state_db.perf_load(key, "late") is None
+    assert state_db.error_load(key, "late") is None
+    concurrency.release(key)
+    assert channel_state.is_deleted(key)
+    with pytest.raises(ValueError, match="restart before reusing"):
+        registry.add_api_channel(dict(entry))
+
+
+def test_legacy_email_delete_cleans_all_accounts_atomically_and_blocks_late_quota():
+    from src import channel_state, concurrency, cooldown, oauth_manager
+
+    state_db.init(); scorer.init(); cooldown.init(); affinity.init(); affinity.client_init()
+    suffix = uuid.uuid4().hex
+    email = f"multi-delete-{suffix}@example.test"
+    claude = {
+        "email": email, "provider": "claude", "access_token": "***",
+        "refresh_token": "***", "models": ["claude-test"], "enabled": True,
+    }
+    openai = {
+        "email": email, "provider": "openai", "access_token": "***",
+        "refresh_token": "***", "chatgpt_account_id": f"ws-{suffix}",
+        "models": ["gpt-test"], "enabled": True,
+    }
+    account_keys = [oauth_manager._canonical_key(claude), oauth_manager._canonical_key(openai)]
+    channel_keys = [f"oauth:{key}" for key in account_keys]
+
+    def seed(cfg):
+        cfg["oauthAccounts"] = [dict(claude), dict(openai)]
+        cfg.setdefault("loadBalancing", {})["initialized"] = True
+        cfg["loadBalancing"]["priorityOrders"] = {
+            "anthropic": [channel_keys[0]], "openai": [channel_keys[1]],
+        }
+
+    config.update(seed)
+    for account_key, channel_key in zip(account_keys, channel_keys):
+        scorer.record_success(channel_key, "model", 1, 2, 3)
+        cooldown.record_error(channel_key, "model", "old")
+        affinity.upsert(f"fp-{account_key}", channel_key, "model")
+        affinity.client_upsert(f"client-{account_key}", channel_key, "model")
+        state_db.quota_save(account_key, {"fetched_at": 1}, email=email)
+        with concurrency._slots_guard:
+            concurrency._slots[channel_key] = concurrency.ChannelSlot(
+                key=channel_key, max_concurrent=1, in_flight=1,
+            )
+    snapshots = []
+
+    def callback(cfg):
+        snapshots.append((
+            len(cfg.get("oauthAccounts", [])),
+            dict(cfg.get("loadBalancing", {}).get("priorityOrders", {})),
+        ))
+
+    config.on_reload(callback)
+    try:
+        oauth_manager.delete_account(email)
+    finally:
+        config._reload_callbacks.remove(callback)
+
+    assert snapshots == [(0, {"anthropic": [], "openai": []})]
+    for account_key, channel_key in zip(account_keys, channel_keys):
+        assert channel_state.is_deleted(channel_key)
+        assert scorer.get_stats(channel_key, "model") is None
+        assert cooldown.get_state(channel_key, "model") is None
+        assert affinity.get(f"fp-{account_key}") is None
+        assert affinity.client_get(f"client-{account_key}") is None
+        assert state_db.quota_load(account_key) is None
+
+        scorer.record_success(channel_key, "late", 4, 5, 6)
+        cooldown.record_error(channel_key, "late", "late")
+        affinity.upsert(f"late-fp-{account_key}", channel_key, "late")
+        affinity.client_upsert(f"late-client-{account_key}", channel_key, "late")
+        state_db.quota_save(account_key, {"fetched_at": 2}, email=email)
+        state_db.quota_patch_passive(account_key, {"five_hour_util": 9}, email=email)
+        assert scorer.get_stats(channel_key, "late") is None
+        assert cooldown.get_state(channel_key, "late") is None
+        assert state_db.quota_load(account_key) is None
+
+    for channel_key in channel_keys:
+        concurrency.release(channel_key)
+        assert channel_state.is_deleted(channel_key)
+    with pytest.raises(ValueError, match="restart before reusing"):
+        oauth_manager.add_account(dict(openai))
+
+
+def test_failed_delete_config_write_restores_generation_reusability(monkeypatch):
+    from src import channel_state
+    from src.channel import registry
+
+    suffix = uuid.uuid4().hex
+    name = f"delete-rollback-{suffix}"
+    key = f"api:{name}"
+    entry = {
+        "name": name, "type": "api", "baseUrl": "http://127.0.0.1:9",
+        "apiKey": "***", "protocol": "anthropic", "models": [],
+        "cc_mimicry": True, "enabled": True,
+    }
+    config.update(lambda cfg: cfg.__setitem__("channels", [dict(entry)]))
+    monkeypatch.setattr(
+        config, "_write_atomic",
+        lambda _cfg: (_ for _ in ()).throw(OSError("write failed")),
+    )
+    with pytest.raises(OSError, match="write failed"):
+        registry.delete_api_channel(name)
+    assert not channel_state.is_deleted(key)
+    assert any(
+        channel.get("name") == name
+        for channel in config.get().get("channels", [])
+    )
+
+
+def test_delete_without_tracked_slot_keeps_process_lifetime_tombstone():
+    from src import channel_state, concurrency, cooldown
+    from src.channel import registry
+
+    state_db.init(); scorer.init(); cooldown.init(); affinity.init(); affinity.client_init()
+    suffix = uuid.uuid4().hex
+    name = f"delete-no-slot-{suffix}"
+    key = f"api:{name}"
+    entry = {
+        "name": name, "type": "api", "baseUrl": "http://127.0.0.1:9",
+        "apiKey": "***", "protocol": "anthropic", "models": [],
+        "cc_mimicry": True, "enabled": True,
+    }
+    config.update(lambda cfg: cfg.__setitem__("channels", [dict(entry)]))
+    registry.rebuild_from_config()
+    with concurrency._slots_guard:
+        concurrency._slots.pop(key, None)
+
+    assert registry.delete_api_channel(name)
+    assert channel_state.is_deleted(key)
+
+    # A request may have selected the channel before deletion but not reached
+    # concurrency acquire yet (or concurrency may be disabled). Its late side
+    # effects must remain rejected even though no slot existed at delete time.
+    scorer.record_success(key, "late", 1, 2, 3)
+    cooldown.record_error(key, "late", "late")
+    affinity.upsert(f"late-no-slot-{suffix}", key, "late")
+    assert scorer.get_stats(key, "late") is None
+    assert cooldown.get_state(key, "late") is None
+    assert affinity.get(f"late-no-slot-{suffix}") is None
+    with pytest.raises(ValueError, match="restart before reusing"):
+        registry.add_api_channel(dict(entry))
+
+
+def test_delete_renamed_destination_waits_for_old_generation_to_drain():
+    from src import channel_state, concurrency, cooldown
+    from src.channel import registry
+
+    state_db.init(); scorer.init(); cooldown.init(); affinity.init(); affinity.client_init()
+    suffix = uuid.uuid4().hex
+    old_name = f"delete-alias-old-{suffix}"
+    new_name = f"delete-alias-new-{suffix}"
+    old_key = f"api:{old_name}"
+    new_key = f"api:{new_name}"
+    entry = {
+        "name": old_name, "type": "api", "baseUrl": "http://127.0.0.1:9",
+        "apiKey": "***", "protocol": "anthropic",
+        "models": [{"real": "model", "alias": "model"}],
+        "cc_mimicry": True, "enabled": True,
+    }
+    config.update(lambda cfg: cfg.__setitem__("channels", [dict(entry)]))
+    registry.rebuild_from_config()
+    with concurrency._slots_guard:
+        concurrency._slots[old_key] = concurrency.ChannelSlot(
+            key=old_key, max_concurrent=1, in_flight=1,
+        )
+
+    registry.update_api_channel(old_name, {"name": new_name})
+    assert channel_state.resolve(old_key) == new_key
+    assert registry.delete_api_channel(new_name)
+    assert channel_state.is_deleted(new_key)
+
+    # The request acquired before rename still reports using old_key. It must
+    # resolve to the deleted destination and be ignored until old_key drains.
+    scorer.record_success(old_key, "late", 1, 2, 3)
+    cooldown.record_error(old_key, "late", "late")
+    affinity.upsert(f"late-fp-{suffix}", old_key, "late")
+    assert scorer.get_stats(new_key, "late") is None
+    assert cooldown.get_state(new_key, "late") is None
+    assert affinity.get(f"late-fp-{suffix}") is None
+
+    concurrency.release(old_key)
+    assert channel_state.is_deleted(new_key)
+    with pytest.raises(ValueError, match="restart before reusing"):
+        registry.add_api_channel(dict(entry, name=new_name))

--- a/src/tests/test_sqlite_lock_root_fix.py
+++ b/src/tests/test_sqlite_lock_root_fix.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 import json
+import os
 from pathlib import Path
 import shutil
 import sqlite3
+import stat
 import subprocess
 import sys
 import threading
@@ -37,6 +40,7 @@ def isolated_store(monkeypatch):
     # by isolated_pytest.py; a relative dbPath must never fall back to BASE_DIR.
     root = Path(config.DATA_DIR) / f"sqlite-root-fix-{uuid.uuid4().hex}"
     root.mkdir(parents=True)
+    root.chmod(0o700)
     cfg = {
         "stateDbPath": "state.db",
         "openai": {"store": {
@@ -166,6 +170,116 @@ def test_relative_store_path_cannot_escape_through_symlink(isolated_store):
         shutil.rmtree(outside, ignore_errors=True)
 
 
+def test_store_rejects_final_symlink_even_when_target_stays_in_data_dir(isolated_store):
+    root, cfg = isolated_store
+    target = root / "private-target.db"
+    target.touch(mode=0o600)
+    link = root / "store-link.db"
+    link.symlink_to(target)
+    cfg["openai"]["store"]["dbPath"] = link.name
+    store._reset_for_test(reinitialize=True)
+    with pytest.raises(RuntimeError, match="not a regular file"):
+        store.init()
+
+
+def test_store_db_wal_and_shm_are_private_under_umask_022(isolated_store):
+    root, _cfg = isolated_store
+    store._reset_for_test(reinitialize=True)
+    for suffix in ("", "-wal", "-shm"):
+        (root / f"responses.db{suffix}").unlink(missing_ok=True)
+
+    previous_umask = os.umask(0o022)
+    try:
+        store.init()
+        _save("private-modes")
+        # Keep the WAL connection open while checking all three inodes.
+        store._get_conn().execute("SELECT 1").fetchone()
+    finally:
+        os.umask(previous_umask)
+
+    assert stat.S_IMODE(root.stat().st_mode) == 0o700
+    for suffix in ("", "-wal", "-shm"):
+        path = root / f"responses.db{suffix}"
+        assert path.is_file(), path
+        assert path.stat().st_uid == os.geteuid(), path
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600, path
+
+
+def test_store_accepts_owner_held_source_root_mode_0755(isolated_store):
+    root, _cfg = isolated_store
+    store._reset_for_test(reinitialize=True)
+    root.chmod(0o755)
+    try:
+        store.init()
+        _save("source-root-0755")
+        assert store.lookup(
+            "source-root-0755", api_key_name="key-a",
+        ).response_id == "source-root-0755"
+        assert stat.S_IMODE((root / "responses.db").stat().st_mode) == 0o600
+    finally:
+        root.chmod(0o700)
+
+
+def test_store_rejects_group_world_writable_parent(isolated_store):
+    root, _cfg = isolated_store
+    store._reset_for_test(reinitialize=True)
+    root.chmod(0o777)
+    try:
+        with pytest.raises(RuntimeError, match="group/world writable"):
+            store.init()
+    finally:
+        root.chmod(0o700)
+
+
+def test_store_rejects_insecure_existing_database_mode(isolated_store):
+    root, _cfg = isolated_store
+    store._reset_for_test(reinitialize=True)
+    db_path = root / "responses.db"
+    for suffix in ("", "-wal", "-shm"):
+        (root / f"responses.db{suffix}").unlink(missing_ok=True)
+    db_path.touch(mode=0o644)
+    db_path.chmod(0o644)
+
+    with pytest.raises(RuntimeError, match="mode 0600"):
+        store.init()
+
+    # Let the fixture cleanup/reinitialization inspect this path safely.
+    db_path.chmod(0o600)
+
+
+def test_store_rejects_insecure_existing_wal_before_sqlite_opens_it(isolated_store):
+    root, _cfg = isolated_store
+    store._reset_for_test(reinitialize=True)
+    db_path = root / "responses.db"
+    wal_path = root / "responses.db-wal"
+    for suffix in ("", "-wal", "-shm"):
+        (root / f"responses.db{suffix}").unlink(missing_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE marker (value TEXT)")
+    db_path.chmod(0o600)
+    wal_path.write_bytes(b"must-not-be-opened")
+    wal_path.chmod(0o644)
+
+    with pytest.raises(RuntimeError, match="mode 0600"):
+        store.init()
+    assert wal_path.read_bytes() == b"must-not-be-opened"
+
+    wal_path.unlink()
+
+
+def test_store_rejects_foreign_owner_before_sqlite_open(isolated_store, monkeypatch):
+    root, _cfg = isolated_store
+    store._reset_for_test(reinitialize=True)
+    db_path = root / "responses.db"
+    for suffix in ("", "-wal", "-shm"):
+        (root / f"responses.db{suffix}").unlink(missing_ok=True)
+    db_path.touch(mode=0o600)
+    actual_uid = os.geteuid()
+    monkeypatch.setattr(store.os, "geteuid", lambda: actual_uid + 1)
+    with pytest.raises(RuntimeError, match="must be owned"):
+        store.init()
+
+
 def test_legacy_fallback_is_read_only_and_new_database_wins(isolated_store):
     root, _cfg = isolated_store
     legacy = root / "state.db"
@@ -218,6 +332,55 @@ def test_legacy_fallback_preserves_expired_and_forbidden_semantics(isolated_stor
         store.lookup("legacy-expired", api_key_name="key-a")
     with pytest.raises(store.ResponseForbidden):
         store.lookup("legacy-forbidden", api_key_name="key-a")
+
+
+def test_response_id_collision_cannot_replace_another_api_key(isolated_store):
+    store.save(
+        "shared-upstream-id", None,
+        api_key_name="key-a", model="model-a", channel_key="api:a",
+        input_items=[{"owner": "a"}], output_items=[{"answer": "a"}],
+    )
+
+    with pytest.raises(store.ResponseIdConflict):
+        store.save(
+            "shared-upstream-id", None,
+            api_key_name="key-b", model="model-b", channel_key="api:b",
+            input_items=[{"owner": "b"}], output_items=[{"answer": "b"}],
+        )
+
+    original = store.lookup("shared-upstream-id", api_key_name="key-a")
+    assert original.model == "model-a"
+    assert original.input_items == [{"owner": "a"}]
+    with pytest.raises(store.ResponseForbidden):
+        store.lookup("shared-upstream-id", api_key_name="key-b")
+
+    # The owning key may still update/retry the same upstream id.
+    store.save(
+        "shared-upstream-id", None,
+        api_key_name="key-a", model="model-a2", channel_key="api:a",
+        input_items=[{"owner": "a2"}], output_items=[],
+    )
+    updated = store.lookup("shared-upstream-id", api_key_name="key-a")
+    assert updated.model == "model-a2"
+    assert updated.input_items == [{"owner": "a2"}]
+
+
+def test_legacy_response_id_collision_is_rejected_before_shadowing(isolated_store):
+    root, _cfg = isolated_store
+    now = time.time()
+    with sqlite3.connect(root / "state.db") as conn:
+        conn.execute(LEGACY_SCHEMA)
+        conn.execute(
+            "INSERT INTO openai_response_store VALUES (?, NULL, ?, 'old', '', ?, ?, '[]', '[]')",
+            ("legacy-owned-id", "key-a", now, now + 3600),
+        )
+    with pytest.raises(store.ResponseIdConflict):
+        store.save(
+            "legacy-owned-id", None,
+            api_key_name="key-b", model="new", channel_key="api:new",
+            input_items=[], output_items=[],
+        )
+    assert store.lookup("legacy-owned-id", api_key_name="key-a").model == "old"
 
 
 def test_expand_history_cycle_and_depth_are_bounded(isolated_store):
@@ -1333,6 +1496,147 @@ def test_oauth_refresh_rejects_duplicate_destination_identity():
     assert scorer.get_stats(f"oauth:{old_key}", "model") is not None
 
 
+def test_late_openai_refresh_after_delete_cannot_mutate_same_email_claude(monkeypatch):
+    """Refresh result is bound to provider + canonical generation, never email."""
+    from src import cooldown, oauth_manager
+
+    state_db.init(); scorer.init(); cooldown.init(); affinity.init(); affinity.client_init()
+    suffix = uuid.uuid4().hex
+    email = f"shared-refresh-{suffix}@example.test"
+    claude = {
+        "email": email, "provider": "claude",
+        "access_token": "claude-access", "refresh_token": "claude-refresh",
+        "disabled_reason": "auth_error", "enabled": False,
+    }
+    openai = {
+        "email": email, "provider": "openai",
+        "access_token": "openai-access", "refresh_token": "openai-refresh",
+        "chatgpt_account_id": f"workspace-{suffix}", "enabled": True,
+    }
+    openai_key = oauth_manager._canonical_key(openai)
+    config.update(
+        lambda cfg: cfg.__setitem__(
+            "oauthAccounts", [dict(claude), dict(openai)],
+        )
+    )
+
+    refresh_started = threading.Event()
+    allow_refresh = threading.Event()
+    results: list[str] = []
+    errors: list[BaseException] = []
+
+    def paused_refresh(*_args, **_kwargs):
+        refresh_started.set()
+        assert allow_refresh.wait(5)
+        return {
+            "access_token": "late-openai-access",
+            "refresh_token": "late-openai-refresh",
+            "expires_in": 3600,
+        }
+
+    monkeypatch.setattr(oauth_manager.openai_provider, "refresh_sync", paused_refresh)
+
+    def worker():
+        try:
+            results.append(oauth_manager._refresh_sync_locked(openai_key, True))
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    try:
+        assert refresh_started.wait(5)
+        oauth_manager.delete_account(openai_key)
+        remaining = config.get().get("oauthAccounts", [])
+        assert [oauth_manager._canonical_key(account) for account in remaining] == [
+            oauth_manager._canonical_key(claude)
+        ]
+        allow_refresh.set()
+        thread.join(5)
+    finally:
+        allow_refresh.set()
+        thread.join(5)
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert results == ["late-openai-access"]
+    remaining = config.get().get("oauthAccounts", [])
+    assert len(remaining) == 1
+    assert remaining[0]["provider"] == "claude"
+    assert remaining[0]["access_token"] == "claude-access"
+    assert remaining[0]["refresh_token"] == "claude-refresh"
+    assert remaining[0]["disabled_reason"] == "auth_error"
+    assert remaining[0]["enabled"] is False
+    assert oauth_manager.get_account(openai_key) is None
+
+
+def test_late_refresh_follows_exact_openai_rename_generation(monkeypatch):
+    """A renamed generation accepts its own late refresh without email lookup."""
+    from src import cooldown, oauth_manager
+    from src.channel import registry
+
+    state_db.init(); scorer.init(); cooldown.init(); affinity.init(); affinity.client_init()
+    suffix = uuid.uuid4().hex
+    email = f"rename-refresh-{suffix}@example.test"
+    old_account = {
+        "email": email, "provider": "openai",
+        "access_token": "old-access", "refresh_token": "old-refresh",
+        "chatgpt_account_id": f"old-workspace-{suffix}", "enabled": True,
+    }
+    old_key = oauth_manager._canonical_key(old_account)
+    new_workspace = f"new-workspace-{suffix}"
+    new_key = f"openai:{email}:{new_workspace}"
+    config.update(
+        lambda cfg: cfg.__setitem__("oauthAccounts", [dict(old_account)])
+    )
+    registry.rebuild_from_config()
+
+    refresh_started = threading.Event()
+    allow_refresh = threading.Event()
+    results: list[str] = []
+    errors: list[BaseException] = []
+
+    def paused_refresh(*_args, **_kwargs):
+        refresh_started.set()
+        assert allow_refresh.wait(5)
+        return {
+            "access_token": "late-access",
+            "refresh_token": "late-refresh",
+            "expires_in": 3600,
+        }
+
+    monkeypatch.setattr(oauth_manager.openai_provider, "refresh_sync", paused_refresh)
+    def worker():
+        try:
+            results.append(oauth_manager._refresh_sync_locked(old_key, True))
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    try:
+        assert refresh_started.wait(5)
+        assert oauth_manager._save_token_fields(
+            old_key, {"chatgpt_account_id": new_workspace},
+        )
+        assert oauth_manager.get_account(new_key) is not None
+        allow_refresh.set()
+        thread.join(5)
+    finally:
+        allow_refresh.set()
+        thread.join(5)
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert results == ["late-access"]
+    renamed = oauth_manager.get_account(new_key)
+    assert renamed is not None
+    assert renamed["provider"] == "openai"
+    assert renamed["access_token"] == "late-access"
+    assert renamed["refresh_token"] == "late-refresh"
+    assert oauth_manager.get_account(old_key) is None
+
+
 def test_concurrent_reload_waits_until_oauth_state_rename_is_published(monkeypatch):
     from src import oauth_manager
     from src.channel import registry
@@ -1900,3 +2204,101 @@ def test_delete_renamed_destination_waits_for_old_generation_to_drain():
     assert channel_state.is_deleted(new_key)
     with pytest.raises(ValueError, match="restart before reusing"):
         registry.add_api_channel(dict(entry, name=new_name))
+
+
+@pytest.mark.asyncio
+async def test_delete_cancels_pre_acquire_waiter_and_rejects_disabled_limit_path():
+    """A successful delete must prevent queued/limit-disabled old-key use."""
+    from src import concurrency
+    from src.channel import registry
+
+    suffix = uuid.uuid4().hex
+    name = f"queued-delete-{suffix}"
+    key = f"api:{name}"
+    entry = {
+        "name": name, "type": "api", "baseUrl": "http://127.0.0.1:9",
+        "apiKey": "***", "protocol": "anthropic",
+        "models": [{"real": "model", "alias": "model"}],
+        "cc_mimicry": True, "enabled": True, "maxConcurrent": 1,
+    }
+
+    def seed(cfg):
+        cfg["channels"] = [dict(entry)]
+        cfg.setdefault("concurrency", {})["enabled"] = True
+        cfg["concurrency"]["defaultMaxConcurrent"] = 1
+
+    config.update(seed)
+    registry.rebuild_from_config()
+    assert await concurrency.try_acquire(key)
+    waiter = asyncio.create_task(
+        concurrency.acquire_from_candidates([(key, "old-credential")], 5),
+    )
+    for _ in range(20):
+        await asyncio.sleep(0)
+        with concurrency._slots_guard:
+            slot = concurrency._slots.get(key)
+            if slot is not None and slot.waiters:
+                break
+    with concurrency._slots_guard:
+        assert len(concurrency._slots[key].waiters) == 1
+
+    assert registry.delete_api_channel(name)
+    result = await asyncio.wait_for(waiter, timeout=1)
+    assert result is None
+    assert not await concurrency.try_acquire(key)
+
+    # The generation check must run before the old "limits disabled => True"
+    # shortcut as well.
+    config.update(
+        lambda cfg: cfg.setdefault("concurrency", {}).__setitem__("enabled", False)
+    )
+    assert not await concurrency.try_acquire(key)
+
+    concurrency.release(key)
+    config.update(
+        lambda cfg: cfg.setdefault("concurrency", {}).__setitem__("enabled", True)
+    )
+
+
+@pytest.mark.asyncio
+async def test_rename_still_allows_old_generation_waiter_to_drain():
+    """Deletion rejection must not change the existing rename-drain contract."""
+    from src import concurrency
+    from src.channel import registry
+
+    suffix = uuid.uuid4().hex
+    old_name = f"queued-rename-old-{suffix}"
+    new_name = f"queued-rename-new-{suffix}"
+    old_key = f"api:{old_name}"
+    entry = {
+        "name": old_name, "type": "api", "baseUrl": "http://127.0.0.1:9",
+        "apiKey": "***", "protocol": "anthropic",
+        "models": [{"real": "model", "alias": "model"}],
+        "cc_mimicry": True, "enabled": True, "maxConcurrent": 1,
+    }
+
+    def seed(cfg):
+        cfg["channels"] = [dict(entry)]
+        cfg.setdefault("concurrency", {})["enabled"] = True
+        cfg["concurrency"]["defaultMaxConcurrent"] = 1
+
+    config.update(seed)
+    registry.rebuild_from_config()
+    assert await concurrency.try_acquire(old_key)
+    waiter = asyncio.create_task(
+        concurrency.acquire_from_candidates([(old_key, "old-generation")], 5),
+    )
+    for _ in range(20):
+        await asyncio.sleep(0)
+        with concurrency._slots_guard:
+            slot = concurrency._slots.get(old_key)
+            if slot is not None and slot.waiters:
+                break
+    with concurrency._slots_guard:
+        assert len(concurrency._slots[old_key].waiters) == 1
+
+    assert registry.update_api_channel(old_name, {"name": new_name}) is not None
+    concurrency.release(old_key)
+    acquired = await asyncio.wait_for(waiter, timeout=1)
+    assert acquired == (old_key, "old-generation")
+    concurrency.release(old_key)

--- a/src/tests/test_unified_usage_and_auto_disable.py
+++ b/src/tests/test_unified_usage_and_auto_disable.py
@@ -70,7 +70,9 @@ def _setup(m):
     m["config"].update(clear_accounts)
     m["oauth_manager"]._refresh_locks.clear()
     m["failover"]._codex_snapshot_last.clear()
+    m["failover"]._codex_snapshot_inflight.clear()
     m["failover"]._anthropic_snapshot_last.clear()
+    m["failover"]._anthropic_snapshot_inflight.clear()
     m["oauth_manager"]._OPENAI_PROBE_LAST.clear()
     m["cooldown"].init()
     m["cooldown"].clear_all()
@@ -337,6 +339,75 @@ def test_openai_auto_disable_primary_over_threshold(m):
     assert acc_after["disabled_reason"] == "quota", acc_after
     assert acc_after["enabled"] is False
     print("  [PASS] openai: primary 98% (>=95) → auto-disabled")
+
+
+def test_openai_auto_disable_survives_locked_quota_cache(m, monkeypatch):
+    """A failed auxiliary snapshot write must not bypass realtime disable."""
+    import sqlite3
+
+    _setup(m)
+    email = "locked-cache@o.io"
+    account_key = f"openai:{email}:acct-123"
+    _add_openai(m, email)
+    acc = m["oauth_manager"].get_account(account_key)
+    ch = m["OpenAIOAuthChannel"](acc)
+    resp = _FakeResp({
+        "x-codex-primary-used-percent": "98",
+        "x-codex-primary-reset-after-seconds": "600",
+        "x-codex-primary-window-minutes": "10080",
+    })
+    attempts = []
+
+    def locked(*_args, **_kwargs):
+        attempts.append("write")
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(m["state_db"], "quota_save_openai_snapshot", locked)
+    m["failover"]._maybe_record_codex_snapshot(ch, resp)
+
+    current = m["oauth_manager"].get_account(account_key)
+    assert current["enabled"] is False, current
+    assert current["disabled_reason"] == "quota", current
+    assert account_key not in m["failover"]._codex_snapshot_last
+    assert account_key not in m["failover"]._codex_snapshot_inflight
+
+    # A failed write must not advance the 30s throttle; the next response
+    # retries persistence immediately (disable remains idempotent).
+    m["failover"]._maybe_record_codex_snapshot(ch, resp)
+    assert attempts == ["write", "write"]
+
+
+def test_anthropic_auto_disable_survives_locked_quota_cache(m, monkeypatch):
+    """The Anthropic passive sampler follows the same fail-open cache rule."""
+    import sqlite3
+
+    _setup(m)
+    email = "locked-cache@c.io"
+    account_key = f"claude:{email}"
+    _add_claude(m, email)
+    acc = m["oauth_manager"].get_account(account_key)
+    ch = m["OAuthChannel"](acc, [])
+    resp = _FakeResp({
+        "anthropic-ratelimit-unified-5h-utilization": "1.0",
+        "anthropic-ratelimit-unified-5h-surpassed-threshold": "true",
+        "anthropic-ratelimit-unified-5h-reset": str(int(time.time() + 600)),
+    })
+    attempts = []
+
+    def locked(*_args, **_kwargs):
+        attempts.append("write")
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(m["state_db"], "quota_patch_passive", locked)
+    m["failover"]._maybe_record_anthropic_snapshot(ch, resp)
+
+    current = m["oauth_manager"].get_account(account_key)
+    assert current["enabled"] is False, current
+    assert current["disabled_reason"] == "quota", current
+    assert account_key not in m["failover"]._anthropic_snapshot_last
+    assert account_key not in m["failover"]._anthropic_snapshot_inflight
+    m["failover"]._maybe_record_anthropic_snapshot(ch, resp)
+    assert attempts == ["write", "write"]
 
 
 def test_openai_no_auto_disable_below_threshold(m):


### PR DESCRIPTION
## Summary

- move OpenAI Responses history out of `state.db` into a dedicated `openai_response_store.db`, with read-only legacy fallback for existing `previous_response_id` records
- bound expired-history cleanup by rows, bytes, batches, and time while committing each batch independently
- make SQLite state writes rollback-safe and keep transient BUSY/LOCKED/I/O/FULL failures from breaking an otherwise successful response
- serialize channel/OAuth rename and delete lifecycles across config, priority orders, SQLite state, in-memory mirrors, affinity, cooldown, scorer, quota snapshots, and concurrency generations
- route late writes from renamed generations to the current key and reject late writes from deleted generations
- close the five review blockers: exact OAuth refresh generation identity, fail-open quota cache persistence, deleted FIFO waiter cancellation, private Store files, and cross-key response-id collision rejection
- update configuration/database/scheduler/lifecycle/OpenAI Store documentation

## Important behavior

- deleted channel keys remain tombstoned for the lifetime of the process and cannot be reused until restart
- requests that already acquired a deleted generation may drain, but queued/pre-acquire waiters are cancelled and cannot use the deleted credential; rename generations retain their existing drain behavior
- OAuth refresh results are saved only to the exact provider + canonical generation; rename aliases may forward to their exact destination, while deleted/missing generations discard the result without bare-email fallback
- realtime quota auto-disable executes independently of optional snapshot persistence; a failed cache write does not advance the persistence throttle
- `openai.store.dbPath` defaults to `openai_response_store.db` and must not resolve to the configured `stateDbPath`
- Store DB/WAL/SHM files are explicitly created/validated as owner-only `0600`; the container data directory is `0700`, existing source roots may be owner-held `0755` but cannot be group/world writable, and symlink/foreign-owner/insecure files fail closed
- Store response-id updates are owner-conditional; a different API key receives `ResponseIdConflict` instead of replacing history, including legacy-fallback collisions
- legacy Store rows are not moved online; the old `state.db` table is queried read-only on a miss until those records expire

## Validation

Rebased onto `origin/main` `5ccac54` (`v0.28.1`) and validated on Hytron in an isolated tree:

- five review-blocker deterministic gates: `12 passed`
- focused SQLite/lifecycle/quota suite: `117 passed`
- final full suite: `1629 passed, 18 skipped`
- per-file isolated pass: `95/95` test files, `0 failed`
- `compileall`, `shellcheck`, `sh -n`, `git diff --check`, conflict-marker scan, and incremental secret scan passed
- final Docker image: `sha256:dfeadf14f83cf2e56abd95dcabbfeab274336b455342ee57e17090a88db5ca62`
- isolated container smoke used `network_mode: none`; process ran as uid/gid `1000:1000`, `/health` returned HTTP 200, Store write+lookup passed, data directory was `0700`, DB/WAL/SHM were `0600`, and logs contained no traceback, permission, readonly, or SQLite lock error

The 18 skips are the repository's existing unavailable external-fixture skips. No production Parrot configuration, data, container, or runtime was modified during this validation.
