### PR TITLE
fix: preserve Responses assistant string content

### DIFF
--- a/src/openai/transform/responses_to_chat.py
+++ b/src/openai/transform/responses_to_chat.py
@@ -340,14 +340,22 @@ def _input_items_to_messages(items: list) -> list:
                 # 回喂 chat 上游时要把 refusal parts 单独提取到 message.refusal 字段，
                 # 避免信息被折叠成空 text 丢失
                 refusal_texts: list[str] = []
-                non_refusal_parts: list = []
-                for p in content_parts:
-                    if isinstance(p, dict) and p.get("type") == "refusal":
-                        r = p.get("refusal")
-                        if isinstance(r, str) and r:
-                            refusal_texts.append(r)
-                    else:
-                        non_refusal_parts.append(p)
+                if isinstance(content_parts, str):
+                    # EasyInputMessage.content may be a plain string.  Hermes
+                    # uses this form for locally generated fallback/final
+                    # assistant messages.  Iterating it as content parts would
+                    # drop every character and emit an empty Anthropic text
+                    # block after the Responses→Chat→Anthropic bridge.
+                    non_refusal_parts: Any = content_parts
+                else:
+                    non_refusal_parts = []
+                    for p in content_parts:
+                        if isinstance(p, dict) and p.get("type") == "refusal":
+                            r = p.get("refusal")
+                            if isinstance(r, str) and r:
+                                refusal_texts.append(r)
+                        else:
+                            non_refusal_parts.append(p)
                 # 纯 refusal（无文本/图片 parts）→ content 必须是 null，
                 # 否则严格上游（如官方 gpt-*）会因 assistant.content 为空列表而 400
                 msg_out: dict = {

--- a/src/tests/test_responses_to_anthropic_bridge.py
+++ b/src/tests/test_responses_to_anthropic_bridge.py
@@ -43,6 +43,38 @@ def test_translate_request_composes_responses_input_to_anthropic_messages():
     ]
 
 
+def test_translate_request_preserves_easy_input_string_messages_after_tool_history():
+    """Hermes may append local fallback messages as EasyInputMessage strings."""
+    body = {
+        "model": "resp-model",
+        "stream": True,
+        "input": [
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "start"}]},
+            {"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": '{}'},
+            {"type": "function_call_output", "call_id": "call_1", "output": "result"},
+            {"role": "assistant", "content": "local max-iteration fallback"},
+            {"role": "user", "content": "follow-up"},
+        ],
+        "tools": [{"type": "function", "name": "lookup", "parameters": {"type": "object"}}],
+    }
+
+    out = responses_to_anthropic.translate_request(body)
+
+    assert out["stream"] is True
+    assert out["messages"] == [
+        {"role": "user", "content": [{"type": "text", "text": "start"}]},
+        {"role": "assistant", "content": [{"type": "tool_use", "id": "call_1", "name": "lookup", "input": {}}]},
+        {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "call_1", "content": "result"}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "local max-iteration fallback"}]},
+        {"role": "user", "content": [{"type": "text", "text": "follow-up"}]},
+    ]
+    assert all(
+        part.get("type") != "text" or bool(part.get("text"))
+        for message in out["messages"]
+        for part in message["content"]
+    )
+
+
 def test_translate_request_preserves_parallel_tool_calls():
     body = {
         "model": "resp-model",


### PR DESCRIPTION
## Summary

- preserve plain-string `content` on Responses `EasyInputMessage` items with `role: "assistant"`
- keep refusal extraction limited to typed content-part arrays
- add a streaming regression covering tool history followed by assistant/user string messages

## Root cause

`EasyInputMessage.content` may be either a string or a typed content-part array. The assistant conversion path always iterated `content` as parts, so a string was traversed character by character and every character was discarded. The composed Responses → Chat → Anthropic bridge then emitted an empty text block, which strict Anthropic endpoints reject with:

```text
messages: text content blocks must be non-empty
```

The fix preserves string content at the point where it was lost and leaves the existing list/refusal path unchanged.

## Validation

- regression test verified RED on `main` before the fix and GREEN afterward
- Responses → Anthropic bridge: `34 passed`
- adjacent Chat/Anthropic stream, protocol matrix, and scheduler tests: `124 passed`
- full isolated suite, run twice: `1477 passed, 18 skipped` on each run
- `py_compile` and `git diff --check`
- baseline/candidate differential checks for empty strings, typed arrays, refusal-only/mixed refusal content, and tool history
- no-cache container build and normal-entrypoint startup with the application running as UID/GID 1000
- non-streaming and SSE wire validation through a fake Anthropic upstream that rejects empty text blocks
- isolated test deployment with SQLite integrity and fatal-log checks
