### PR TITLE
fix: resume OpenAI quota accounts after early upstream reset

### DIFF
--- a/src/failover.py
+++ b/src/failover.py
@@ -259,7 +259,8 @@ def forget_anthropic_snapshot(account_key_or_email: str) -> None:
 #   - Anthropic: surpassed-threshold=true OR utilization>=1.0（任一窗口）
 #   - OpenAI  : primary/secondary used_percent ≥ disableThresholdPercent (default 95)
 #
-# 幂等：账号已是 disabled_reason="quota" 时不重复置位。
+# 幂等：账号已是 disabled_reason="quota" 时不重复通知或移动恢复时间，但仍
+# 持久化最新 observation generation，供并发恢复 CAS 使用。
 # auth_error / user 禁用的账号不碰（保留原始禁用原因）。
 
 
@@ -334,7 +335,7 @@ def _maybe_auto_disable_by_codex_snapshot(account_key: str, email: str,
     from . import oauth_manager
 
     acc = oauth_manager.get_account(account_key)
-    if acc is None or acc.get("disabled_reason"):
+    if acc is None or acc.get("disabled_reason") not in (None, "quota"):
         return
 
     threshold = _get_quota_disable_threshold_pct()
@@ -378,9 +379,18 @@ def _maybe_auto_disable_by_codex_snapshot(account_key: str, email: str,
         latest_iso = latest.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     try:
-        oauth_manager.set_disabled_by_quota(account_key, latest_iso)
+        disable_result = oauth_manager.set_disabled_by_quota(
+            account_key,
+            latest_iso,
+            observation=oauth_manager.codex_quota_observation(snap),
+        )
     except Exception as exc:
         print(f"[failover] auto-disable (codex) failed for {account_key}: {exc}")
+        return
+
+    # A quota-disabled account still records a new generation/observation for
+    # recovery CAS, but only the transition from enabled emits a notification.
+    if (disable_result or {}).get("state") != "disabled":
         return
 
     try:

--- a/src/oauth/openai.py
+++ b/src/oauth/openai.py
@@ -1105,17 +1105,14 @@ def parse_rate_limit_headers(headers: Any) -> dict | None:
     return snap
 
 
-def normalize_codex_snapshot(snap: dict) -> dict:
-    """把 primary/secondary 映射到 5h/7d。参考 sub2api `Normalize()`。
+def codex_snapshot_window_map(snap: dict) -> dict[str, str]:
+    """Map Codex primary/secondary headers to semantic 5h/7d windows.
 
-    策略：有 window_minutes 时，较小窗口归为 5h、较大归为 7d；只有一边
-    window_minutes 时按 ≤360 min 判 5h。两边都缺 → 回落把 primary 当 7d。
-    返回 {"five_hour_util", "five_hour_reset_sec", "seven_day_util", ...}
-    （沿用现有 `oauth_quota_cache.five_hour_*` 列名，避免多套展示逻辑）。
+    Keep this mapping in one place: quota persistence and recovery must agree
+    about which fresh WHAM window can supersede each response-header window.
     """
-    p_win = snap.get("primary_window_min")
-    s_win = snap.get("secondary_window_min")
-
+    p_win = _coerce_int(snap.get("primary_window_min"))
+    s_win = _coerce_int(snap.get("secondary_window_min"))
     use_5h_from_primary = False
     if p_win is not None and s_win is not None:
         if p_win < s_win:
@@ -1136,6 +1133,21 @@ def normalize_codex_snapshot(snap: dict) -> dict:
         pass        # 两边都没有 window_min：回落
 
     if use_5h_from_primary:
+        return {"primary": "five_hour", "secondary": "seven_day"}
+    return {"primary": "seven_day", "secondary": "five_hour"}
+
+
+def normalize_codex_snapshot(snap: dict) -> dict:
+    """把 primary/secondary 映射到 5h/7d。参考 sub2api `Normalize()`。
+
+    策略：有 window_minutes 时，较小窗口归为 5h、较大归为 7d；只有一边
+    window_minutes 时按 ≤360 min 判 5h。两边都缺 → 回落把 primary 当 7d。
+    返回 {"five_hour_util", "five_hour_reset_sec", "seven_day_util", ...}
+    （沿用现有 `oauth_quota_cache.five_hour_*` 列名，避免多套展示逻辑）。
+    """
+    window_map = codex_snapshot_window_map(snap)
+
+    if window_map["primary"] == "five_hour":
         five_util, five_reset = snap.get("primary_used_pct"), snap.get("primary_reset_sec")
         seven_util, seven_reset = snap.get("secondary_used_pct"), snap.get("secondary_reset_sec")
     else:

--- a/src/oauth_manager.py
+++ b/src/oauth_manager.py
@@ -1408,6 +1408,13 @@ def _latest_iso(*values: str | None) -> str | None:
 
 _CODEX_MISSING_RESET_FALLBACK_SECONDS = 10 * 60
 
+# A cached Codex response-header snapshot only guards the WHAM/Codex boundary,
+# where both sources describe roughly the same moment. Once fresh WHAM usage is
+# clearly newer than the snapshot, the snapshot is a stale observation and must
+# not veto recovery. Keep the margin comfortably above WHAM propagation delay
+# and the 30s response-header sampling throttle.
+_CODEX_SNAPSHOT_SUPERSEDED_BY_USAGE_MS = 15 * 60 * 1000
+
 
 def _codex_cached_reset_ms(row: dict, base_ms: int | None,
                            reset_key: str) -> int | None:
@@ -1430,6 +1437,22 @@ def _codex_cached_reset_ms(row: dict, base_ms: int | None,
     return base_ms + _CODEX_MISSING_RESET_FALLBACK_SECONDS * 1000
 
 
+def _codex_snapshot_superseded_by_usage(row: dict) -> bool:
+    """Whether the cached Codex header snapshot predates fresh WHAM usage.
+
+    ``fetched_at`` is written by ``quota_save`` from an active WHAM fetch, while
+    ``last_passive_update_at`` is written by passive Codex response-header
+    sampling. When WHAM data is clearly newer, the header snapshot is an old
+    observation: upstream may have reset the window early, so its locally
+    predicted reset time is no longer evidence of an over-quota state.
+    """
+    passive_ms = _ms_timestamp(row.get("last_passive_update_at"))
+    usage_ms = _ms_timestamp(row.get("fetched_at"))
+    if passive_ms is None or usage_ms is None:
+        return False
+    return usage_ms - passive_ms >= _CODEX_SNAPSHOT_SUPERSEDED_BY_USAGE_MS
+
+
 def _cached_openai_codex_quota_hit(account_key: str, threshold: float) -> dict:
     """Return active Codex response-header quota hits cached for an OpenAI account.
 
@@ -1439,9 +1462,16 @@ def _cached_openai_codex_quota_hit(account_key: str, threshold: float) -> dict:
     below threshold. Use last_passive_update_at + reset_after_seconds so expired
     header snapshots don't keep accounts disabled forever. If a rare snapshot has
     no reset-after header, bound it by a short TTL.
+
+    The snapshot is also dropped once fresh WHAM usage is clearly newer than it:
+    the locally predicted reset time assumes a full window, so an early upstream
+    reset would otherwise keep the account disabled for days.
     """
     row = state_db.quota_load(account_key)
     if not row:
+        return {"any_over": False, "hit_windows": [], "latest_reset": None}
+
+    if _codex_snapshot_superseded_by_usage(row):
         return {"any_over": False, "hit_windows": [], "latest_reset": None}
 
     base_ms = _ms_timestamp(row.get("last_passive_update_at")) or _ms_timestamp(row.get("fetched_at"))

--- a/src/oauth_manager.py
+++ b/src/oauth_manager.py
@@ -1414,6 +1414,51 @@ _CODEX_MISSING_RESET_FALLBACK_SECONDS = 10 * 60
 # not veto recovery. Keep the margin comfortably above WHAM propagation delay
 # and the 30s response-header sampling throttle.
 _CODEX_SNAPSHOT_SUPERSEDED_BY_USAGE_MS = 15 * 60 * 1000
+_QUOTA_OBSERVATION_GENERATION_FIELD = "quota_observation_generation"
+_QUOTA_OBSERVATION_FIELD = "quota_observation"
+_CODEX_OBSERVATION_SOURCE = "openai_codex_headers"
+
+
+def _quota_observation_generation(acc: dict | None) -> int | None:
+    """Return the persistent quota-observation generation, or None if corrupt."""
+    if not isinstance(acc, dict):
+        return None
+    value = acc.get(_QUOTA_OBSERVATION_GENERATION_FIELD, 0)
+    if type(value) is not int or value < 0:
+        return None
+    return value
+
+
+def codex_quota_observation(snap: dict) -> dict:
+    """Build a JSON-safe persistent observation from Codex response headers."""
+    observed_at = _ms_timestamp(snap.get("fetched_at"))
+    if observed_at is None:
+        observed_at = int(datetime.now(timezone.utc).timestamp() * 1000)
+
+    sanitized: dict[str, int | float] = {}
+    for name in ("primary", "secondary"):
+        pct_key = f"{name}_used_pct"
+        try:
+            pct = float(snap.get(pct_key)) if snap.get(pct_key) is not None else None
+        except (TypeError, ValueError):
+            pct = None
+        if pct is not None and math.isfinite(pct):
+            sanitized[pct_key] = pct
+
+        for suffix in ("reset_sec", "window_min"):
+            key = f"{name}_{suffix}"
+            try:
+                value = int(snap.get(key)) if snap.get(key) is not None else None
+            except (TypeError, ValueError):
+                value = None
+            if value is not None and value >= 0:
+                sanitized[key] = value
+
+    return {
+        "source": _CODEX_OBSERVATION_SOURCE,
+        "observed_at": observed_at,
+        "snapshot": sanitized,
+    }
 
 
 def _codex_cached_reset_ms(row: dict, base_ms: int | None,
@@ -1437,23 +1482,110 @@ def _codex_cached_reset_ms(row: dict, base_ms: int | None,
     return base_ms + _CODEX_MISSING_RESET_FALLBACK_SECONDS * 1000
 
 
-def _codex_snapshot_superseded_by_usage(row: dict) -> bool:
-    """Whether the cached Codex header snapshot predates fresh WHAM usage.
+def _codex_snapshot_from_quota_row(row: dict) -> dict:
+    return {
+        f"{name}_{suffix}": row.get(f"codex_{name}_{suffix}")
+        for name in ("primary", "secondary")
+        for suffix in ("used_pct", "reset_sec", "window_min")
+    }
 
-    ``fetched_at`` is written by ``quota_save`` from an active WHAM fetch, while
-    ``last_passive_update_at`` is written by passive Codex response-header
-    sampling. When WHAM data is clearly newer, the header snapshot is an old
-    observation: upstream may have reset the window early, so its locally
-    predicted reset time is no longer evidence of an over-quota state.
+
+def _persistent_codex_observation(account_key: str) -> tuple[dict | None, int | None]:
+    acc = get_account(account_key)
+    observation = acc.get(_QUOTA_OBSERVATION_FIELD) if isinstance(acc, dict) else None
+    if not isinstance(observation, dict):
+        return None, None
+    if observation.get("source") != _CODEX_OBSERVATION_SOURCE:
+        return None, None
+    snapshot = observation.get("snapshot")
+    if not isinstance(snapshot, dict):
+        return None, None
+    return snapshot, _ms_timestamp(observation.get("observed_at"))
+
+
+def _codex_window_candidates(account_key: str, row: dict) -> dict[str, list[dict]]:
+    """Return newest known Codex evidence for each semantic quota window.
+
+    The config observation is written before the auxiliary SQLite snapshot, so
+    it covers BUSY/FULL/READONLY failures. Partial snapshots are merged per
+    semantic window rather than allowing one newly observed window to erase an
+    older, still-relevant other window.
     """
-    passive_ms = _ms_timestamp(row.get("last_passive_update_at"))
-    usage_ms = _ms_timestamp(row.get("fetched_at"))
-    if passive_ms is None or usage_ms is None:
-        return False
-    return usage_ms - passive_ms >= _CODEX_SNAPSHOT_SUPERSEDED_BY_USAGE_MS
+    grouped: dict[str, list[dict]] = {"five_hour": [], "seven_day": []}
+
+    def add(snapshot: dict | None, observed_ms: int | None, *, row_fallback: dict | None = None):
+        if not isinstance(snapshot, dict):
+            return
+        window_map = openai_provider.codex_snapshot_window_map(snapshot)
+        for raw_name in ("primary", "secondary"):
+            pct_key = f"{raw_name}_used_pct"
+            try:
+                pct = float(snapshot.get(pct_key)) if snapshot.get(pct_key) is not None else None
+            except (TypeError, ValueError):
+                pct = None
+            if pct is None or not math.isfinite(pct):
+                continue
+            semantic = window_map[raw_name]
+            reset_ms = _codex_cached_reset_ms(
+                snapshot, observed_ms, f"{raw_name}_reset_sec",
+            )
+            if reset_ms is None and row_fallback is not None:
+                reset_dt = _parse_iso(row_fallback.get(f"{semantic}_reset"))
+                if reset_dt is not None:
+                    reset_ms = int(reset_dt.timestamp() * 1000)
+            grouped[semantic].append({
+                "raw_name": raw_name,
+                "semantic": semantic,
+                "pct": pct,
+                "observed_ms": observed_ms,
+                "reset_ms": reset_ms,
+            })
+
+    add(
+        _codex_snapshot_from_quota_row(row),
+        _ms_timestamp(row.get("last_passive_update_at")),
+        row_fallback=row,
+    )
+    persistent_snapshot, persistent_ms = _persistent_codex_observation(account_key)
+    add(persistent_snapshot, persistent_ms)
+
+    # Known timestamps are comparable, so only the newest observation for that
+    # semantic window remains relevant. Timestamp-less legacy evidence stays as
+    # an additional fail-closed candidate until its absolute reset expires.
+    for semantic, candidates in tuple(grouped.items()):
+        unknown = [item for item in candidates if item["observed_ms"] is None]
+        known = [item for item in candidates if item["observed_ms"] is not None]
+        newest = max(known, key=lambda item: item["observed_ms"]) if known else None
+        grouped[semantic] = unknown + ([newest] if newest is not None else [])
+    return grouped
 
 
-def _cached_openai_codex_quota_hit(account_key: str, threshold: float) -> dict:
+def _fresh_wham_window_utils(usage: dict | None) -> dict[str, float | None]:
+    openai = usage.get("openai") if isinstance(usage, dict) else None
+    if not isinstance(openai, dict) or openai.get("source") != "wham_usage":
+        return {}
+
+    def explicit_util(name: str) -> float | None:
+        block = usage.get(name) if isinstance(usage, dict) else None
+        raw = block.get("utilization") if isinstance(block, dict) else None
+        if isinstance(raw, bool) or raw is None:
+            return None
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(value) or value < 0 or value > 100:
+            return None
+        return value
+
+    return {
+        "five_hour": explicit_util("five_hour"),
+        "seven_day": explicit_util("seven_day"),
+    }
+
+
+def _cached_openai_codex_quota_hit(account_key: str, threshold: float,
+                                    usage: dict | None = None) -> dict:
     """Return active Codex response-header quota hits cached for an OpenAI account.
 
     WHAM /usage and Codex response headers can disagree near reset boundaries.
@@ -1463,43 +1595,45 @@ def _cached_openai_codex_quota_hit(account_key: str, threshold: float) -> dict:
     header snapshots don't keep accounts disabled forever. If a rare snapshot has
     no reset-after header, bound it by a short TTL.
 
-    The snapshot is also dropped once fresh WHAM usage is clearly newer than it:
-    the locally predicted reset time assumes a full window, so an early upstream
-    reset would otherwise keep the account disabled for days.
+    A Codex window is superseded only when active WHAM usage is clearly newer
+    *and* contains the corresponding semantic window explicitly below threshold.
+    Missing 5h/7d evidence never clears the other window. A persistent config
+    observation closes the safety gap when auxiliary SQLite snapshot writes fail
+    and also provides the generation used by the final account-enable CAS.
     """
-    row = state_db.quota_load(account_key)
-    if not row:
-        return {"any_over": False, "hit_windows": [], "latest_reset": None}
+    row = state_db.quota_load(account_key) or {}
 
-    if _codex_snapshot_superseded_by_usage(row):
-        return {"any_over": False, "hit_windows": [], "latest_reset": None}
-
-    base_ms = _ms_timestamp(row.get("last_passive_update_at")) or _ms_timestamp(row.get("fetched_at"))
     now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    usage_ms = _ms_timestamp(row.get("fetched_at"))
+    wham_windows = _fresh_wham_window_utils(usage)
     hits: list[str] = []
     resets: list[str | None] = []
 
-    for label, pct_key, reset_key in (
-        ("codex primary", "codex_primary_used_pct", "codex_primary_reset_sec"),
-        ("codex secondary", "codex_secondary_used_pct", "codex_secondary_reset_sec"),
-    ):
-        try:
-            pct = float(row.get(pct_key)) if row.get(pct_key) is not None else None
-        except (TypeError, ValueError):
-            pct = None
-        if pct is None or pct < threshold:
-            continue
+    for semantic, candidates in _codex_window_candidates(account_key, row).items():
+        for candidate in candidates:
+            pct = candidate["pct"]
+            if pct < threshold:
+                continue
+            reset_ms = candidate["reset_ms"]
+            if reset_ms is not None and reset_ms <= now_ms:
+                continue
 
-        reset_ms = _codex_cached_reset_ms(row, base_ms, reset_key)
-        reset_iso = _iso_from_ms(reset_ms)
+            observed_ms = candidate["observed_ms"]
+            wham_pct = wham_windows.get(semantic)
+            superseded = bool(
+                observed_ms is not None
+                and usage_ms is not None
+                and usage_ms - observed_ms >= _CODEX_SNAPSHOT_SUPERSEDED_BY_USAGE_MS
+                and wham_pct is not None
+                and wham_pct < threshold
+            )
+            if superseded:
+                continue
 
-        # The cached header said "over threshold", but its reset time has passed;
-        # ignore it and let fresh WHAM usage decide recovery.
-        if reset_ms is not None and reset_ms <= now_ms:
-            continue
-
-        hits.append(f"{label} {pct:.0f}%")
-        resets.append(reset_iso)
+            label = f"codex {candidate['raw_name']} {pct:.0f}%"
+            if label not in hits:
+                hits.append(label)
+            resets.append(_iso_from_ms(reset_ms))
 
     return {
         "any_over": bool(hits),
@@ -1562,6 +1696,7 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
         return {"action": "noop_missing", "utils": utils, "any_over": any_over,
                 "hit_windows": hit_windows, "disabled_until": None}
     reason = acc.get("disabled_reason")
+    expected_quota_generation = _quota_observation_generation(acc)
     if reason in ("user", "auth_error"):
         return {"action": f"noop_{reason}", "utils": utils, "any_over": any_over,
                 "hit_windows": hit_windows,
@@ -1579,19 +1714,33 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
                     "disabled_until": acc.get("disabled_until")}
         latest_reset = reset_iso_for_hit_windows(usage, threshold)
         try:
-            set_disabled_by_quota(account_key, latest_reset)
+            disable_result = set_disabled_by_quota(account_key, latest_reset)
         except Exception as exc:
             print(f"[oauth] evaluate WHAM disable failed for {account_key}: {exc}")
             return {"action": "disable_failed", "utils": utils,
                     "any_over": True, "hit_windows": hit_windows,
                     "disabled_until": None}
+        disable_state = (disable_result or {}).get("state")
+        if disable_state != "disabled":
+            return {"action": (
+                        "wham_limit_keep_disabled"
+                        if disable_state == "already_quota_disabled"
+                        else disable_state or "disable_failed"
+                    ),
+                    "utils": utils, "any_over": True,
+                    "hit_windows": hit_windows,
+                    "disabled_until": (disable_result or {}).get("disabled_until"),
+                    "disabled_reason": (disable_result or {}).get("disabled_reason"),
+                    "error_code": "account_state_conflict"}
         return {"action": "wham_limit_disabled", "utils": utils,
                 "any_over": True, "hit_windows": hit_windows,
                 "disabled_until": latest_reset}
 
     cached_codex_hit = None
     if provider_of(account_key) == "openai":
-        cached_codex_hit = _cached_openai_codex_quota_hit(account_key, threshold)
+        cached_codex_hit = _cached_openai_codex_quota_hit(
+            account_key, threshold, usage if fresh else None,
+        )
         if cached_codex_hit.get("any_over"):
             any_over = True
             for _hit in cached_codex_hit.get("hit_windows") or []:
@@ -1608,12 +1757,24 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
             (cached_codex_hit or {}).get("latest_reset"),
         )
         try:
-            set_disabled_by_quota(account_key, latest_reset)
+            disable_result = set_disabled_by_quota(account_key, latest_reset)
         except Exception as exc:
             print(f"[oauth] evaluate set_disabled_by_quota failed for {account_key}: {exc}")
             return {"action": "disable_failed", "utils": utils,
                     "any_over": True, "hit_windows": hit_windows,
                     "disabled_until": None}
+        disable_state = (disable_result or {}).get("state")
+        if disable_state != "disabled":
+            return {"action": (
+                        "still_over_quota"
+                        if disable_state == "already_quota_disabled"
+                        else disable_state or "disable_failed"
+                    ),
+                    "utils": utils, "any_over": True,
+                    "hit_windows": hit_windows,
+                    "disabled_until": (disable_result or {}).get("disabled_until"),
+                    "disabled_reason": (disable_result or {}).get("disabled_reason"),
+                    "error_code": "account_state_conflict"}
         return {"action": "disabled", "utils": utils, "any_over": True,
                 "hit_windows": hit_windows, "disabled_until": latest_reset}
 
@@ -1631,6 +1792,11 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
                 return {"action": "quota_stale_keep_disabled", "utils": utils,
                         "any_over": False, "hit_windows": [],
                         "disabled_until": acc.get("disabled_until")}
+        if expected_quota_generation is None:
+            return {"action": "resume_failed", "utils": utils,
+                    "any_over": False, "hit_windows": [],
+                    "disabled_until": acc.get("disabled_until"),
+                    "error_code": "quota_observation_generation_invalid"}
         runtime_state = None
         if provider == "openai" and fresh:
             # Clear persistent/runtime routing blockers before enabling. The
@@ -1654,6 +1820,7 @@ def evaluate_and_toggle_by_usage(account_key: str, usage: dict,
         try:
             enable_result = set_enabled(
                 account_key, True, expected_disabled_reason="quota",
+                expected_quota_observation_generation=expected_quota_generation,
             )
         except Exception as exc:
             print(f"[oauth] evaluate set_enabled failed for {account_key}: {exc}")
@@ -2249,17 +2416,29 @@ def _delete_account_serialized(account_key: str) -> None:
 
 
 _EXPECTED_REASON_UNSET = object()
+_EXPECTED_QUOTA_GENERATION_UNSET = object()
 
 
 def set_enabled(account_key: str, enabled: bool, reason: str | None = None,
                 disabled_until: str | None = None, *,
-                expected_disabled_reason=_EXPECTED_REASON_UNSET) -> dict | None:
-    """Set account state; recovery may require the account to still be quota-disabled."""
+                expected_disabled_reason=_EXPECTED_REASON_UNSET,
+                expected_quota_observation_generation=_EXPECTED_QUOTA_GENERATION_UNSET,
+                ) -> dict | None:
+    """Set account state with optional quota reason/generation CAS guards."""
     canonical = _resolve_existing_account_key(account_key)
     has_prov = ":" in account_key
     target_provider, target_identity = _split_ak(account_key)
-    conditional = expected_disabled_reason is not _EXPECTED_REASON_UNSET
-    decision = {"state": "missing", "disabled_reason": None, "disabled_until": None}
+    reason_conditional = expected_disabled_reason is not _EXPECTED_REASON_UNSET
+    generation_conditional = (
+        expected_quota_observation_generation is not _EXPECTED_QUOTA_GENERATION_UNSET
+    )
+    conditional = reason_conditional or generation_conditional
+    decision = {
+        "state": "missing",
+        "disabled_reason": None,
+        "disabled_until": None,
+        "quota_observation_generation": None,
+    }
 
     def mutate(cfg):
         for acc in cfg.get("oauthAccounts", []):
@@ -2274,8 +2453,10 @@ def set_enabled(account_key: str, enabled: bool, reason: str | None = None,
             if conditional:
                 current_reason = acc.get("disabled_reason")
                 current_enabled = acc.get("enabled")
+                current_generation = _quota_observation_generation(acc)
                 decision.update(disabled_reason=current_reason,
-                                disabled_until=acc.get("disabled_until"))
+                                disabled_until=acc.get("disabled_until"),
+                                quota_observation_generation=current_generation)
                 if type(current_enabled) is not bool:
                     decision["state"] = "invalid_state"
                     return
@@ -2284,24 +2465,99 @@ def set_enabled(account_key: str, enabled: bool, reason: str | None = None,
                         "already_enabled" if not current_reason else "invalid_state"
                     )
                     return
-                if current_reason != expected_disabled_reason:
+                if reason_conditional and current_reason != expected_disabled_reason:
                     decision["state"] = "state_conflict"
+                    return
+                if generation_conditional and (
+                    current_generation is None
+                    or current_generation != expected_quota_observation_generation
+                ):
+                    decision["state"] = "quota_observation_conflict"
                     return
                 decision["state"] = "enabled"
             acc["enabled"] = enabled
             if enabled:
                 acc["disabled_reason"] = None
                 acc["disabled_until"] = None
+                acc.pop(_QUOTA_OBSERVATION_FIELD, None)
             else:
                 acc["disabled_reason"] = reason or "user"
                 acc["disabled_until"] = disabled_until
+                if (reason or "user") != "quota":
+                    acc.pop(_QUOTA_OBSERVATION_FIELD, None)
             return
     config.update(mutate, skip_if_unchanged=conditional)
     return decision if conditional else None
 
 
-def set_disabled_by_quota(account_key: str, resets_at: str | None) -> None:
-    set_enabled(account_key, False, reason="quota", disabled_until=resets_at)
+def set_disabled_by_quota(account_key: str, resets_at: str | None, *,
+                          observation: dict | None = None) -> dict:
+    """Persist a quota disable and advance its observation generation.
+
+    Repeated real-time observations keep the original disabled_until but still
+    advance the generation. This makes a concurrent recovery CAS fail even when
+    the auxiliary SQLite snapshot could not be written.
+    """
+    canonical = _resolve_existing_account_key(account_key)
+    has_prov = ":" in account_key
+    target_provider, target_identity = _split_ak(account_key)
+    decision = {
+        "state": "missing",
+        "disabled_reason": None,
+        "disabled_until": None,
+        "quota_observation_generation": None,
+    }
+
+    def mutate(cfg):
+        for acc in cfg.get("oauthAccounts", []):
+            if canonical:
+                if _canonical_key(acc) != canonical:
+                    continue
+            else:
+                if acc.get("email") != target_identity:
+                    continue
+                if has_prov and _acc_provider(acc) != target_provider:
+                    continue
+
+            current_enabled = acc.get("enabled", True)
+            current_reason = acc.get("disabled_reason")
+            decision.update(
+                disabled_reason=current_reason,
+                disabled_until=acc.get("disabled_until"),
+            )
+            if type(current_enabled) is not bool:
+                decision["state"] = "invalid_state"
+                return
+            if current_reason not in (None, "quota"):
+                decision["state"] = "state_conflict"
+                return
+            if current_enabled and current_reason is not None:
+                decision["state"] = "invalid_state"
+                return
+            if not current_enabled and current_reason != "quota":
+                decision["state"] = "invalid_state"
+                return
+
+            current_generation = _quota_observation_generation(acc)
+            next_generation = (current_generation if current_generation is not None else 0) + 1
+            acc[_QUOTA_OBSERVATION_GENERATION_FIELD] = next_generation
+            if isinstance(observation, dict):
+                acc[_QUOTA_OBSERVATION_FIELD] = copy.deepcopy(observation)
+
+            if current_enabled:
+                acc["enabled"] = False
+                acc["disabled_reason"] = "quota"
+                acc["disabled_until"] = resets_at
+                decision["state"] = "disabled"
+                decision["disabled_reason"] = "quota"
+                decision["disabled_until"] = resets_at
+            else:
+                decision["state"] = "already_quota_disabled"
+            decision["quota_observation_generation"] = next_generation
+            return
+
+    config.update(mutate, skip_if_unchanged=True)
+    return decision
 
 
 def _clear_oauth_runtime_state(canonical: str, *, clear_quota_cache: bool,

--- a/src/tests/test_openai_oauth_quota.py
+++ b/src/tests/test_openai_oauth_quota.py
@@ -496,6 +496,154 @@ def test_openai_quota_ignores_expired_codex_snapshot_missing_reset(m):
     print("  [PASS] OpenAI quota ignores stale Codex over-threshold snapshot without reset")
 
 
+def _save_codex_over_threshold_snapshot(m, key, email, *, reset_after_seconds="604800"):
+    """Persist a Codex response-header snapshot that is over threshold."""
+    headers = {
+        "x-codex-primary-used-percent": "95",
+        "x-codex-primary-window-minutes": "10080",
+        "x-codex-secondary-used-percent": "0",
+        "x-codex-secondary-window-minutes": "300",
+    }
+    if reset_after_seconds is not None:
+        headers["x-codex-primary-reset-after-seconds"] = reset_after_seconds
+    snap = m["openai_provider"].parse_rate_limit_headers(headers)
+    assert snap is not None
+    m["state_db"].quota_save_openai_snapshot(
+        key, snap, m["openai_provider"].normalize_codex_snapshot(snap), email=email,
+    )
+
+
+def _set_quota_timestamps(m, key, *, passive_ms, usage_ms):
+    conn = m["state_db"]._get_conn()
+    conn.execute(
+        "UPDATE oauth_quota_cache SET last_passive_update_at=?, fetched_at=? "
+        "WHERE account_key=?",
+        (passive_ms, usage_ms, key),
+    )
+    conn.commit()
+
+
+def test_openai_quota_resumes_when_fresh_wham_supersedes_codex_snapshot(m):
+    """An early upstream reset must not stay blocked by an older header snapshot.
+
+    Regression: the cached snapshot predicted its reset as
+    ``last_passive_update_at + reset_after_seconds``, i.e. a full 7d window. When
+    OpenAI resets the window early, WHAM reports 0% while that prediction is
+    still in the future, so the account stayed quota-disabled for days.
+    """
+    _setup(m)
+    email = "early-reset@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    m["oauth_manager"].set_disabled_by_quota(key, "2099-01-01T00:00:00Z")
+    _save_codex_over_threshold_snapshot(m, key, email)
+
+    now = m["state_db"].now_ms()
+    # Header snapshot sampled a day ago; WHAM refreshed just now.
+    _set_quota_timestamps(m, key, passive_ms=now - 24 * 3600 * 1000, usage_ms=now)
+
+    result = m["oauth_manager"].evaluate_and_toggle_by_usage(
+        key, _low_wham(), threshold=95, fresh=True,
+    )
+    acc = m["oauth_manager"].get_account(key)
+    assert result["action"] == "resumed", result
+    assert result["any_over"] is False, result
+    assert result["hit_windows"] == [], result
+    assert acc.get("enabled") is True, acc
+    assert acc.get("disabled_reason") is None, acc
+    assert acc.get("disabled_until") is None, acc
+    print("  [PASS] OpenAI quota resumes when fresh WHAM supersedes Codex snapshot")
+
+
+def test_openai_quota_keeps_boundary_codex_snapshot_authoritative(m):
+    """Near-simultaneous WHAM/Codex data must still let the snapshot win.
+
+    This is the original guard: WHAM can briefly report low usage right after a
+    Codex response header said the window is exhausted. Only clearly older
+    snapshots may be discarded.
+    """
+    _setup(m)
+    email = "boundary@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    m["oauth_manager"].set_disabled_by_quota(key, "2099-01-01T00:00:00Z")
+    _save_codex_over_threshold_snapshot(m, key, email)
+
+    now = m["state_db"].now_ms()
+    # WHAM is newer, but only by a minute: inside the boundary margin.
+    _set_quota_timestamps(m, key, passive_ms=now - 60 * 1000, usage_ms=now)
+
+    result = m["oauth_manager"].evaluate_and_toggle_by_usage(
+        key, _low_wham(), threshold=95, fresh=True,
+    )
+    acc = m["oauth_manager"].get_account(key)
+    assert result["action"] == "still_over_quota", result
+    assert result["any_over"] is True, result
+    assert "codex primary 95%" in result["hit_windows"], result
+    assert acc.get("enabled") is False, acc
+    assert acc.get("disabled_reason") == "quota", acc
+    print("  [PASS] OpenAI quota keeps boundary Codex snapshot authoritative")
+
+
+def test_codex_snapshot_superseded_helper_requires_both_timestamps(m):
+    """Missing/sentinel timestamps must never discard the snapshot."""
+    om = m["oauth_manager"]
+    margin = om._CODEX_SNAPSHOT_SUPERSEDED_BY_USAGE_MS
+    now = m["state_db"].now_ms()
+
+    assert om._codex_snapshot_superseded_by_usage(
+        {"last_passive_update_at": now - margin, "fetched_at": now}) is True
+    assert om._codex_snapshot_superseded_by_usage(
+        {"last_passive_update_at": now - margin + 1000, "fetched_at": now}) is False
+    # fetched_at=0 is the "never actively synced" sentinel written by
+    # quota_patch_passive; it must not look like fresh WHAM usage.
+    assert om._codex_snapshot_superseded_by_usage(
+        {"last_passive_update_at": now, "fetched_at": 0}) is False
+    assert om._codex_snapshot_superseded_by_usage(
+        {"last_passive_update_at": None, "fetched_at": now}) is False
+    assert om._codex_snapshot_superseded_by_usage({}) is False
+    # WHAM older than the header snapshot keeps the snapshot authoritative.
+    assert om._codex_snapshot_superseded_by_usage(
+        {"last_passive_update_at": now, "fetched_at": now - 10 * margin}) is False
+    print("  [PASS] Codex snapshot supersede helper needs both fresh timestamps")
+
+
+def test_quota_monitor_resumes_openai_after_early_upstream_reset(m):
+    """End-to-end monitor tick: save fresh WHAM, then resume the account."""
+    import asyncio
+
+    _setup(m)
+    email = "monitor-early-reset@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    m["oauth_manager"].set_disabled_by_quota(key, "2099-01-01T00:00:00Z")
+    _save_codex_over_threshold_snapshot(m, key, email)
+
+    now = m["state_db"].now_ms()
+    _set_quota_timestamps(m, key, passive_ms=now - 24 * 3600 * 1000, usage_ms=now - 24 * 3600 * 1000)
+
+    async def _fake_fetch_usage(account_key):
+        assert account_key == key, account_key
+        return _low_wham()
+
+    original = m["oauth_manager"].fetch_usage
+    m["oauth_manager"].fetch_usage = _fake_fetch_usage
+    try:
+        out = asyncio.run(m["oauth_manager"].quota_monitor_once())
+    finally:
+        m["oauth_manager"].fetch_usage = original
+
+    acc = m["oauth_manager"].get_account(key)
+    assert out.get(email) == "resumed", out
+    assert acc.get("enabled") is True, acc
+    assert acc.get("disabled_reason") is None, acc
+    row = m["state_db"].quota_load(key)
+    # The monitor writes fresh WHAM usage; the old header snapshot columns stay
+    # but no longer veto recovery.
+    assert row["fetched_at"] > row["last_passive_update_at"], row
+    print("  [PASS] quota_monitor resumes OpenAI account after early upstream reset")
+
+
 def test_openai_quota_resume_uses_fresh_usage_over_future_disabled_until(m):
     """Fresh low usage must override an obsolete predicted disabled_until."""
     _setup(m)
@@ -1211,6 +1359,10 @@ def main():
         test_oauth_menu_refresh_usage_openai_auto_disables_over_quota,
         test_openai_quota_resume_respects_active_codex_snapshot,
         test_openai_quota_ignores_expired_codex_snapshot_missing_reset,
+        test_openai_quota_resumes_when_fresh_wham_supersedes_codex_snapshot,
+        test_openai_quota_keeps_boundary_codex_snapshot_authoritative,
+        test_codex_snapshot_superseded_helper_requires_both_timestamps,
+        test_quota_monitor_resumes_openai_after_early_upstream_reset,
         test_openai_quota_resume_uses_fresh_usage_over_future_disabled_until,
         test_quota_monitor_notifies_when_openai_quota_really_resumes,
         test_openai_plan_workspace_label_disambiguates_same_email,

--- a/src/tests/test_openai_oauth_quota.py
+++ b/src/tests/test_openai_oauth_quota.py
@@ -496,16 +496,29 @@ def test_openai_quota_ignores_expired_codex_snapshot_missing_reset(m):
     print("  [PASS] OpenAI quota ignores stale Codex over-threshold snapshot without reset")
 
 
-def _save_codex_over_threshold_snapshot(m, key, email, *, reset_after_seconds="604800"):
+def _save_codex_over_threshold_snapshot(
+    m,
+    key,
+    email,
+    *,
+    primary_pct=95,
+    primary_window_min=10080,
+    primary_reset_after="604800",
+    secondary_pct=0,
+    secondary_window_min=300,
+    secondary_reset_after="18000",
+):
     """Persist a Codex response-header snapshot that is over threshold."""
     headers = {
-        "x-codex-primary-used-percent": "95",
-        "x-codex-primary-window-minutes": "10080",
-        "x-codex-secondary-used-percent": "0",
-        "x-codex-secondary-window-minutes": "300",
+        "x-codex-primary-used-percent": str(primary_pct),
+        "x-codex-primary-window-minutes": str(primary_window_min),
+        "x-codex-secondary-used-percent": str(secondary_pct),
+        "x-codex-secondary-window-minutes": str(secondary_window_min),
     }
-    if reset_after_seconds is not None:
-        headers["x-codex-primary-reset-after-seconds"] = reset_after_seconds
+    if primary_reset_after is not None:
+        headers["x-codex-primary-reset-after-seconds"] = str(primary_reset_after)
+    if secondary_reset_after is not None:
+        headers["x-codex-secondary-reset-after-seconds"] = str(secondary_reset_after)
     snap = m["openai_provider"].parse_rate_limit_headers(headers)
     assert snap is not None
     m["state_db"].quota_save_openai_snapshot(
@@ -585,27 +598,92 @@ def test_openai_quota_keeps_boundary_codex_snapshot_authoritative(m):
     print("  [PASS] OpenAI quota keeps boundary Codex snapshot authoritative")
 
 
-def test_codex_snapshot_superseded_helper_requires_both_timestamps(m):
-    """Missing/sentinel timestamps must never discard the snapshot."""
-    om = m["oauth_manager"]
-    margin = om._CODEX_SNAPSHOT_SUPERSEDED_BY_USAGE_MS
-    now = m["state_db"].now_ms()
+def test_openai_quota_keeps_old_7d_codex_hit_when_wham_only_has_low_5h(m):
+    """A low WHAM 5h window cannot supersede a missing WHAM 7d window."""
+    _setup(m)
+    email = "partial-wham-7d@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    m["oauth_manager"].set_disabled_by_quota(key, "2099-01-01T00:00:00Z")
+    _save_codex_over_threshold_snapshot(m, key, email)
 
-    assert om._codex_snapshot_superseded_by_usage(
-        {"last_passive_update_at": now - margin, "fetched_at": now}) is True
-    assert om._codex_snapshot_superseded_by_usage(
-        {"last_passive_update_at": now - margin + 1000, "fetched_at": now}) is False
-    # fetched_at=0 is the "never actively synced" sentinel written by
-    # quota_patch_passive; it must not look like fresh WHAM usage.
-    assert om._codex_snapshot_superseded_by_usage(
-        {"last_passive_update_at": now, "fetched_at": 0}) is False
-    assert om._codex_snapshot_superseded_by_usage(
-        {"last_passive_update_at": None, "fetched_at": now}) is False
-    assert om._codex_snapshot_superseded_by_usage({}) is False
-    # WHAM older than the header snapshot keeps the snapshot authoritative.
-    assert om._codex_snapshot_superseded_by_usage(
-        {"last_passive_update_at": now, "fetched_at": now - 10 * margin}) is False
-    print("  [PASS] Codex snapshot supersede helper needs both fresh timestamps")
+    now = m["state_db"].now_ms()
+    _set_quota_timestamps(m, key, passive_ms=now - 24 * 3600 * 1000, usage_ms=now)
+    usage = _low_wham()
+    usage["seven_day"] = {}
+
+    result = m["oauth_manager"].evaluate_and_toggle_by_usage(
+        key, usage, threshold=95, fresh=True,
+    )
+    acc = m["oauth_manager"].get_account(key)
+    assert result["action"] == "still_over_quota", result
+    assert "codex primary 95%" in result["hit_windows"], result
+    assert acc["enabled"] is False and acc["disabled_reason"] == "quota", acc
+    print("  [PASS] low WHAM 5h cannot clear an old Codex 7d hit")
+
+
+def test_openai_quota_keeps_old_5h_codex_hit_when_wham_only_has_low_7d(m):
+    """A low WHAM 7d window cannot supersede a missing WHAM 5h window."""
+    _setup(m)
+    email = "partial-wham-5h@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    m["oauth_manager"].set_disabled_by_quota(key, "2099-01-01T00:00:00Z")
+    _save_codex_over_threshold_snapshot(
+        m,
+        key,
+        email,
+        primary_pct=0,
+        secondary_pct=95,
+    )
+
+    now = m["state_db"].now_ms()
+    _set_quota_timestamps(m, key, passive_ms=now - 3600 * 1000, usage_ms=now)
+    usage = _low_wham()
+    usage["five_hour"] = {}
+
+    result = m["oauth_manager"].evaluate_and_toggle_by_usage(
+        key, usage, threshold=95, fresh=True,
+    )
+    acc = m["oauth_manager"].get_account(key)
+    assert result["action"] == "still_over_quota", result
+    assert "codex secondary 95%" in result["hit_windows"], result
+    assert acc["enabled"] is False and acc["disabled_reason"] == "quota", acc
+    print("  [PASS] low WHAM 7d cannot clear an old Codex 5h hit")
+
+
+def test_codex_window_supersede_requires_active_newer_wham(m):
+    """Missing, stale, boundary-new and non-WHAM evidence remains fail-closed."""
+    _setup(m)
+    email = "supersede-gates@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    _save_codex_over_threshold_snapshot(m, key, email)
+    om = m["oauth_manager"]
+    now = m["state_db"].now_ms()
+    margin = om._CODEX_SNAPSHOT_SUPERSEDED_BY_USAGE_MS
+
+    for passive_ms, usage_ms, usage in (
+        (None, now, _low_wham()),
+        (now, 0, _low_wham()),
+        (now, now - margin, _low_wham()),
+        (now - margin + 1, now, _low_wham()),
+        (now - margin, now, {**_low_wham(), "openai": {"source": "cache"}}),
+    ):
+        _set_quota_timestamps(m, key, passive_ms=passive_ms, usage_ms=usage_ms)
+        hit = om._cached_openai_codex_quota_hit(key, 95, usage)
+        assert hit["any_over"] is True, (passive_ms, usage_ms, usage, hit)
+
+    _set_quota_timestamps(m, key, passive_ms=now - margin, usage_ms=now)
+    hit = om._cached_openai_codex_quota_hit(key, 95, _low_wham())
+    assert hit["any_over"] is False, hit
+
+    for invalid in (-1, float("nan"), False, "not-a-number"):
+        usage = _low_wham()
+        usage["seven_day"] = {"utilization": invalid}
+        hit = om._cached_openai_codex_quota_hit(key, 95, usage)
+        assert hit["any_over"] is True, (invalid, hit)
+    print("  [PASS] Codex supersede requires active WHAM and the full time margin")
 
 
 def test_quota_monitor_resumes_openai_after_early_upstream_reset(m):
@@ -642,6 +720,169 @@ def test_quota_monitor_resumes_openai_after_early_upstream_reset(m):
     # but no longer veto recovery.
     assert row["fetched_at"] > row["last_passive_update_at"], row
     print("  [PASS] quota_monitor resumes OpenAI account after early upstream reset")
+
+
+def test_new_codex_hit_survives_sqlite_snapshot_write_failure(m):
+    """A real-time high header must survive an auxiliary SQLite write failure."""
+    import asyncio
+
+    _setup(m)
+    email = "snapshot-write-failure@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    _save_codex_over_threshold_snapshot(m, key, email)
+    now = m["state_db"].now_ms()
+    _set_quota_timestamps(
+        m, key, passive_ms=now - 24 * 3600 * 1000, usage_ms=now - 24 * 3600 * 1000,
+    )
+
+    ch = m["OpenAIOAuthChannel"](m["oauth_manager"].get_account(key))
+    response = _MockResp({
+        "x-codex-primary-used-percent": "99",
+        "x-codex-primary-window-minutes": "10080",
+        "x-codex-primary-reset-after-seconds": "604800",
+        "x-codex-secondary-used-percent": "0",
+        "x-codex-secondary-window-minutes": "300",
+    })
+    original_save = m["state_db"].quota_save_openai_snapshot
+
+    def _locked(*args, **kwargs):
+        raise RuntimeError("database is locked")
+
+    m["state_db"].quota_save_openai_snapshot = _locked
+    try:
+        m["failover"]._maybe_record_codex_snapshot(ch, response)
+    finally:
+        m["state_db"].quota_save_openai_snapshot = original_save
+
+    acc = m["oauth_manager"].get_account(key)
+    assert acc["enabled"] is False and acc["disabled_reason"] == "quota", acc
+    assert acc.get("quota_observation_generation") == 1, acc
+    observation = acc.get("quota_observation") or {}
+    assert observation.get("source") == "openai_codex_headers", observation
+    assert observation.get("snapshot", {}).get("primary_used_pct") == 99.0, observation
+    disk_acc = _disk_account(m["config"], email)
+    assert disk_acc.get("quota_observation_generation") == 1, disk_acc
+    assert key not in m["failover"]._codex_snapshot_last
+
+    # A monitor tick writes fresh low WHAM data, updating fetched_at but leaving
+    # the old SQLite Codex columns. The newer persistent observation must still
+    # win the boundary.
+    usage = _low_wham()
+    original_fetch = m["oauth_manager"].fetch_usage
+
+    async def _fetch(account_key):
+        assert account_key == key, account_key
+        return usage
+
+    m["oauth_manager"].fetch_usage = _fetch
+    try:
+        out = asyncio.run(m["oauth_manager"].quota_monitor_once())
+    finally:
+        m["oauth_manager"].fetch_usage = original_fetch
+
+    acc = m["oauth_manager"].get_account(key)
+    assert out.get(email) == "still_over_quota", out
+    hit = m["oauth_manager"]._cached_openai_codex_quota_hit(key, 95, usage)
+    assert "codex primary 99%" in hit["hit_windows"], hit
+    assert acc["enabled"] is False and acc["disabled_reason"] == "quota", acc
+
+    # Once complete WHAM evidence is genuinely newer than the persistent
+    # observation, recovery is allowed and consumes the observation without
+    # resetting the monotonic generation.
+    def _age_observation(c):
+        target = next(a for a in c["oauthAccounts"] if a.get("email") == email)
+        target["quota_observation"]["observed_at"] = (
+            m["state_db"].now_ms() - 24 * 3600 * 1000
+        )
+
+    m["config"].update(_age_observation)
+    result = m["oauth_manager"].evaluate_and_toggle_by_usage(
+        key, usage, threshold=95, fresh=True,
+    )
+    acc = m["oauth_manager"].get_account(key)
+    assert result["action"] == "resumed", result
+    assert acc["enabled"] is True and acc.get("disabled_reason") is None, acc
+    assert acc.get("quota_observation") is None, acc
+    assert acc.get("quota_observation_generation") == 1, acc
+    print("  [PASS] real-time Codex hit survives SQLite snapshot write failure")
+
+
+def test_new_codex_hit_during_recovery_fails_generation_cas(m):
+    """A high header arriving after evaluation but before enable must win."""
+    _setup(m)
+    email = "recovery-cas@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    m["oauth_manager"].set_disabled_by_quota(key, "2099-01-01T00:00:00Z")
+    _save_codex_over_threshold_snapshot(m, key, email)
+    now = m["state_db"].now_ms()
+    _set_quota_timestamps(m, key, passive_ms=now - 24 * 3600 * 1000, usage_ms=now)
+
+    snap = m["openai_provider"].parse_rate_limit_headers({
+        "x-codex-primary-used-percent": "99",
+        "x-codex-primary-window-minutes": "10080",
+        "x-codex-primary-reset-after-seconds": "604800",
+    })
+    original_clear = m["oauth_manager"]._clear_oauth_runtime_state
+
+    def _clear_then_observe(*args, **kwargs):
+        out = original_clear(*args, **kwargs)
+        m["failover"]._maybe_auto_disable_by_codex_snapshot(key, email, snap)
+        return out
+
+    m["oauth_manager"]._clear_oauth_runtime_state = _clear_then_observe
+    try:
+        result = m["oauth_manager"].evaluate_and_toggle_by_usage(
+            key, _low_wham(), threshold=95, fresh=True,
+        )
+    finally:
+        m["oauth_manager"]._clear_oauth_runtime_state = original_clear
+
+    acc = m["oauth_manager"].get_account(key)
+    assert result["action"] == "quota_observation_conflict", result
+    assert result["error_code"] == "account_state_conflict", result
+    assert acc["enabled"] is False and acc["disabled_reason"] == "quota", acc
+    assert acc.get("quota_observation_generation") == 2, acc
+    assert (acc.get("quota_observation") or {}).get("snapshot", {}).get(
+        "primary_used_pct"
+    ) == 99.0, acc
+    print("  [PASS] recovery enable CAS rejects a newer Codex observation")
+
+
+def test_codex_observation_generation_isolated_per_workspace(m):
+    """Same-email OpenAI workspaces must never share recovery generations."""
+    _setup(m)
+    email = "shared-workspaces@openai.test"
+    for workspace in ("workspace-a", "workspace-b"):
+        m["oauth_manager"].add_account({
+            "email": email,
+            "provider": "openai",
+            "access_token": f"at-{workspace}",
+            "refresh_token": f"rt-{workspace}",
+            "id_token": "h.p.s",
+            "chatgpt_account_id": workspace,
+            "workspace_id": workspace,
+            "plan_type": "team",
+        })
+    key_a = f"openai:{email}:workspace-a"
+    key_b = f"openai:{email}:workspace-b"
+    snap = m["openai_provider"].parse_rate_limit_headers({
+        "x-codex-primary-used-percent": "99",
+        "x-codex-primary-window-minutes": "10080",
+        "x-codex-primary-reset-after-seconds": "604800",
+    })
+
+    m["failover"]._maybe_auto_disable_by_codex_snapshot(key_a, email, snap)
+
+    acc_a = m["oauth_manager"].get_account(key_a)
+    acc_b = m["oauth_manager"].get_account(key_b)
+    assert acc_a["enabled"] is False and acc_a["disabled_reason"] == "quota", acc_a
+    assert acc_a.get("quota_observation_generation") == 1, acc_a
+    assert acc_b["enabled"] is True and acc_b.get("disabled_reason") is None, acc_b
+    assert acc_b.get("quota_observation_generation") is None, acc_b
+    assert acc_b.get("quota_observation") is None, acc_b
+    print("  [PASS] Codex observation generations stay isolated per workspace")
 
 
 def test_openai_quota_resume_uses_fresh_usage_over_future_disabled_until(m):
@@ -1361,8 +1602,13 @@ def main():
         test_openai_quota_ignores_expired_codex_snapshot_missing_reset,
         test_openai_quota_resumes_when_fresh_wham_supersedes_codex_snapshot,
         test_openai_quota_keeps_boundary_codex_snapshot_authoritative,
-        test_codex_snapshot_superseded_helper_requires_both_timestamps,
+        test_openai_quota_keeps_old_7d_codex_hit_when_wham_only_has_low_5h,
+        test_openai_quota_keeps_old_5h_codex_hit_when_wham_only_has_low_7d,
+        test_codex_window_supersede_requires_active_newer_wham,
         test_quota_monitor_resumes_openai_after_early_upstream_reset,
+        test_new_codex_hit_survives_sqlite_snapshot_write_failure,
+        test_new_codex_hit_during_recovery_fails_generation_cas,
+        test_codex_observation_generation_isolated_per_workspace,
         test_openai_quota_resume_uses_fresh_usage_over_future_disabled_until,
         test_quota_monitor_notifies_when_openai_quota_really_resumes,
         test_openai_plan_workspace_label_disambiguates_same_email,


### PR DESCRIPTION
## 问题

OpenAI 已提前重置额度、WHAM `/usage` 已返回低用量时，Parrot 仍可能被旧 Codex 响应头快照锁在 `disabled_reason=quota`，只能人工执行 `reset_quota`。

原实现按 `last_passive_update_at + reset_after_seconds` 推算快照失效时间，隐含假设窗口一定走满。上游提前重置后，这个旧预测仍可能比新鲜 WHAM 事实多阻塞数天。

## 修复

本次同步到最新 `main@c592761`（v0.28.3），并按 review 补齐三个安全边界：

1. **按窗口废弃旧快照**
   - Codex primary/secondary 继续沿用现有窗口长度规则映射到 5h/7d；
   - 每个仍超阈值的 Codex 窗口，只有在主动 `wham_usage` 明确返回对应窗口、值有效且低于阈值、并比快照至少新 15 分钟时才会被废弃；
   - WHAM 只返回一个窗口时，绝不会顺带清除另一个缺失窗口；缺失、NaN/Inf、负值、布尔值、倒序/缺失时间戳均 fail-closed。

2. **SQLite 快照写失败仍保持实时禁用证据**
   - Codex 响应头超限时，先在账号持久配置中写入经过清洗的 observation、时间戳和单调 generation，再尝试辅助 SQLite snapshot；
   - `database is locked` / FULL / READONLY 不再让最新超限事实退化成旧 SQLite 行；
   - 已 quota-disabled 的账号仍记录新 observation generation，但不重复通知、不移动原 `disabled_until`。

3. **恢复启用增加 generation CAS**
   - 恢复开始前捕获 quota observation generation；
   - 清理运行时阻塞后，最终 enable 必须同时匹配 `disabled_reason=quota` 和原 generation；
   - 若新的 Codex 超限响应在判定与 enable 之间到达，CAS 返回 `quota_observation_conflict`，账号继续禁用；
   - 成功恢复后仅清除已消费的 observation，generation 保持单调。

同邮箱多 workspace 的 observation/generation 按 canonical account key 隔离；user/auth_error 禁用状态仍不被自动恢复或覆盖。

## 回归测试

新增覆盖：

- 旧 7d Codex 高用量 + WHAM 仅有低 5h：保持禁用；
- 旧 5h Codex 高用量 + WHAM 仅有低 7d：保持禁用；
- 对应 WHAM 窗口完整、有效、低用量且超过 15 分钟：正常恢复；
- 缺失/0/倒序时间戳、非主动 WHAM 来源及非法利用率：保持禁用；
- 新 Codex 高响应实时禁用成功、SQLite snapshot 写失败，紧接 monitor：不得恢复；
- 新 Codex observation 在恢复检查和 enable 之间到达：generation CAS 拒绝启用；
- 同邮箱多 workspace generation 隔离；
- 成功恢复后 observation 清理且 generation 保持单调；
- 原有 explicit WHAM gate、user/auth 状态、运行时清理与通知测试继续通过。

## 验证

- 全量隔离 pytest：`1642 passed, 18 skipped, 0 failed`
- 95 个测试文件逐文件隔离：`95 passed, 0 failed`
- `compileall`、`git diff --check` 通过
- Docker `--no-cache` 构建通过
- 无外网候选容器：health `ok`，PID 1 为 uid/gid `1000:1000`
- 数据目录权限 `0700`，OpenAI Store `0600`
- `state.db`、月日志库、`image_logs.db`、`translation_cache.db`、`openai_response_store.db` 的 `PRAGMA quick_check` 均为 `ok`
