### PR TITLE
fix: finalize Responses streams before terminal delivery

### DIFF
--- a/src/failover.py
+++ b/src/failover.py
@@ -4506,6 +4506,15 @@ async def _consume_stream(
 
     # 3. 通过检查 → 开始向下游发 ★
     state: dict = {"finalized": False}
+    stream_resources_closed = False
+
+    async def _close_stream_resources() -> None:
+        nonlocal stream_resources_closed
+        if stream_resources_closed:
+            return
+        await _safe_exit(ctx)
+        await _close_proxy_client(proxy_client)
+        stream_resources_closed = True
 
     def _responses_terminal_received() -> bool:
         """Responses 的显式终态就是 I/O 边界，不再额外等待 HTTP EOF。
@@ -4807,6 +4816,16 @@ async def _consume_stream(
             timing_snapshot, "client_disconnected", "client disconnected",
         )
 
+    async def _finalize_terminal_success() -> list[bytes]:
+        """Persist success and release upstream resources before terminal output."""
+
+        terminal_chunks: list[bytes] = []
+        if stream_translator is not None:
+            terminal_chunks = list(stream_translator.close())
+        await await_ws_owned(_finalize_success())
+        await _close_stream_resources()
+        return terminal_chunks
+
     async def stream_generator():
         """把首包 + 后续 chunk 转发给下游，同时在中途错误时用 SSE error event 收尾。"""
         if state["finalized"]:
@@ -4835,10 +4854,9 @@ async def _consume_stream(
                 )
                 return
 
-            for out in first_downstream_chunks:
-                yield out
-
             if getattr(tracker, "saw_stream_error", False):
+                for out in first_downstream_chunks:
+                    yield out
                 msg = getattr(tracker, "stream_error_message", None) or "upstream stream error"
                 await await_ws_owned(_emit_error_and_finalize(
                     "api_error", msg,
@@ -4846,12 +4864,23 @@ async def _consume_stream(
                 ))
                 return
 
-            # Responses 已在首个下游 chunk 中给出显式终态时直接收尾；否则继续
-            # 读取。普通 Chat/Anthropic 仍保留原有 EOF/终态生成规则。
-            upstream_terminal = _responses_terminal_received()
+            # Responses 客户端可以在读到 response.completed 后立即返回工具调用，
+            # 不再继续拉取 HTTP EOF，也不一定显式关闭 body iterator。因此显式
+            # 终态必须先完成 Store / retry / request_log 落账，再把终态帧交给下游；
+            # 否则生成器会永久停在 yield，最终被 stale cleaner 误标成 crash。
+            if _responses_terminal_received():
+                terminal_chunks = await _finalize_terminal_success()
+                for out in first_downstream_chunks:
+                    yield out
+                for out in terminal_chunks:
+                    yield out
+                return
+
+            for out in first_downstream_chunks:
+                yield out
 
             # 后续 chunk，带 first-byte / idle / total 超时
-            while not upstream_terminal:
+            while True:
                 step = await read_next_stream_step(
                     aiter=aiter,
                     channel=ch,
@@ -4902,14 +4931,13 @@ async def _consume_stream(
                     yield _sse_error_for_ingress(ingress_protocol, errors.ErrType.API, msg)
                     return
 
-                for out in step.downstream_chunks:
-                    yield out
-
                 # 上游在 stream 中途给出终态错误（Responses event:error /
                 # response.failed，或 Chat/Anthropic error chunk）时，下游通常会在
                 # 收到错误帧后立即断开。这里先把上游原始错误帧转发出去，再落库真实
                 # 错误并结束，避免被 finally/CancelledError 误标成 client disconnected。
                 if getattr(tracker, "saw_stream_error", False):
+                    for out in step.downstream_chunks:
+                        yield out
                     msg = getattr(tracker, "stream_error_message", None) or "upstream stream error"
                     await await_ws_owned(_emit_error_and_finalize(
                         "api_error", msg,
@@ -4918,7 +4946,15 @@ async def _consume_stream(
                     return
 
                 if _responses_terminal_received():
-                    upstream_terminal = True
+                    terminal_chunks = await _finalize_terminal_success()
+                    for out in step.downstream_chunks:
+                        yield out
+                    for out in terminal_chunks:
+                        yield out
+                    return
+
+                for out in step.downstream_chunks:
+                    yield out
 
             if not getattr(tracker, "saw_stream_end", False):
                 # A transport EOF after visible output cannot be retried without
@@ -4963,8 +4999,7 @@ async def _consume_stream(
             ))
             raise
         finally:
-            await _safe_exit(ctx)
-            await _close_proxy_client(proxy_client)
+            await _close_stream_resources()
 
     sresp = StreamingResponse(
         stream_generator(),

--- a/src/tests/test_protocol_fake_upstreams.py
+++ b/src/tests/test_protocol_fake_upstreams.py
@@ -456,6 +456,60 @@ def _responses_sse_response(text="ws over sse ok"):
     return httpx.Response(200, content=payload, headers={"content-type": "text/event-stream"})
 
 
+def _responses_sse_function_call_response():
+    output = {
+        "type": "function_call",
+        "id": "fc_sse",
+        "call_id": "call_sse",
+        "name": "lookup",
+        "arguments": '{"q":"ping"}',
+        "status": "completed",
+    }
+    payload = b"".join([
+        _responses_sse_event("response.created", {
+            "type": "response.created",
+            "sequence_number": 1,
+            "response": {"id": "resp_sse_tool", "status": "in_progress"},
+        }),
+        _responses_sse_event("response.output_item.added", {
+            "type": "response.output_item.added",
+            "sequence_number": 2,
+            "output_index": 0,
+            "item": {**output, "arguments": "", "status": "in_progress"},
+        }),
+        _responses_sse_event("response.function_call_arguments.done", {
+            "type": "response.function_call_arguments.done",
+            "sequence_number": 3,
+            "output_index": 0,
+            "item_id": "fc_sse",
+            "name": "lookup",
+            "arguments": output["arguments"],
+        }),
+        _responses_sse_event("response.output_item.done", {
+            "type": "response.output_item.done",
+            "sequence_number": 4,
+            "output_index": 0,
+            "item": output,
+        }),
+        _responses_sse_event("response.completed", {
+            "type": "response.completed",
+            "sequence_number": 5,
+            "response": {
+                "id": "resp_sse_tool",
+                "status": "completed",
+                "output": [output],
+                "usage": {
+                    "input_tokens": 7,
+                    "output_tokens": 4,
+                    "total_tokens": 11,
+                    "input_tokens_details": {"cached_tokens": 2},
+                },
+            },
+        }),
+    ])
+    return httpx.Response(200, content=payload, headers={"content-type": "text/event-stream"})
+
+
 def _chat_sse_response(text="openai chat stream ok"):
     payload = b"".join([
         b'data: {"id":"chatcmpl_sse","object":"chat.completion.chunk","created":1,"model":"gpt-real","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n',
@@ -3129,6 +3183,184 @@ async def test_native_responses_stream_response_is_saved_for_previous_response_i
         {"type": "input_text", "text": "stream seed"},
     ]}]
     assert rec.output_items[0]["content"][0]["text"] == "native stream stored"
+
+
+async def test_native_responses_function_call_stream_finishes_request_log(m):
+    _setup(m)
+    _install_keys(m, _default_key())
+    router = MockRouter()
+    expected_body = _responses_sse_function_call_response().content
+
+    def handler(req: httpx.Request):
+        assert str(req.url) == "https://responses-stream-tool.example/v1/responses"
+        return httpx.Response(
+            200,
+            content=expected_body,
+            headers={"content-type": "text/event-stream"},
+        )
+
+    router.register("https://responses-stream-tool.example", handler)
+    _install_channels(m, [
+        _make_openai_channel(
+            "responses-stream-tool",
+            "https://responses-stream-tool.example",
+            protocol="openai-responses",
+            alias="gpt-5",
+            real="gpt-real",
+        ),
+    ])
+
+    resp, mc = await _call_openai_handler(m, router, "responses", {
+        "model": "gpt-5",
+        "stream": True,
+        "input": "call lookup",
+        "tools": [{
+            "type": "function",
+            "name": "lookup",
+            "description": "Lookup a value",
+            "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+        }],
+    })
+    text = await _consume_streaming_to_string(resp)
+    await mc.aclose()
+
+    assert "event: response.completed" in text
+    assert text.encode("utf-8") == expected_body
+    row = m["log_db"]._get_conn().execute(
+        """SELECT request_id, status, http_status, error_message,
+                  input_tokens, output_tokens, cache_read_tokens, usage_observed
+             FROM request_log ORDER BY id DESC LIMIT 1"""
+    ).fetchone()
+    assert row is not None
+    assert row["status"] == "success"
+    assert row["http_status"] == 200
+    assert row["error_message"] is None
+    assert (row["input_tokens"], row["output_tokens"], row["cache_read_tokens"]) == (5, 4, 2)
+    assert row["usage_observed"] == 1
+
+    conn = m["log_db"]._get_conn()
+    retry = conn.execute(
+        "SELECT id, outcome FROM retry_chain WHERE request_id=?",
+        (row["request_id"],),
+    ).fetchone()
+    assert retry is not None
+    assert retry["outcome"] == "success"
+    settlement = conn.execute(
+        """SELECT outcome, usage_observed, input_tokens, output_tokens,
+                  cache_read_tokens, dispatch_state
+             FROM upstream_attempt_usage WHERE retry_attempt_id=?""",
+        (retry["id"],),
+    ).fetchone()
+    assert settlement is not None
+    assert dict(settlement) == {
+        "outcome": "success",
+        "usage_observed": 1,
+        "input_tokens": 5,
+        "output_tokens": 4,
+        "cache_read_tokens": 2,
+        "dispatch_state": "sent",
+    }
+    detail = conn.execute(
+        "SELECT response_body FROM request_detail WHERE request_id=?",
+        (row["request_id"],),
+    ).fetchone()
+    assert detail is not None
+    assert detail["response_body"].encode("utf-8") == expected_body
+
+
+async def test_native_responses_function_call_is_logged_before_terminal_event_is_yielded(m):
+    _setup(m)
+    _install_keys(m, _default_key())
+    router = MockRouter()
+    router.register(
+        "https://responses-stream-tool-terminal.example",
+        lambda req: _responses_sse_function_call_response(),
+    )
+    _install_channels(m, [
+        _make_openai_channel(
+            "responses-stream-tool-terminal",
+            "https://responses-stream-tool-terminal.example",
+            protocol="openai-responses",
+            alias="gpt-5",
+            real="gpt-real",
+        ),
+    ])
+
+    resp, mc = await _call_openai_handler(m, router, "responses", {
+        "model": "gpt-5",
+        "stream": True,
+        "input": "call lookup",
+        "tools": [{
+            "type": "function",
+            "name": "lookup",
+            "parameters": {"type": "object", "properties": {}},
+        }],
+    })
+    iterator = resp.body_iterator
+    emitted = b""
+    for _ in range(20):
+        chunk = await asyncio.wait_for(anext(iterator), timeout=1.0)
+        emitted += chunk.encode("utf-8") if isinstance(chunk, str) else chunk
+        if b"event: response.completed" in emitted:
+            break
+
+    assert b"event: response.completed" in emitted
+    row = m["log_db"]._get_conn().execute(
+        "SELECT status, http_status FROM request_log ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert row is not None
+    assert dict(row) == {"status": "success", "http_status": 200}
+
+    await iterator.aclose()
+    await mc.aclose()
+
+
+async def test_native_responses_function_call_releases_upstream_before_terminal_yield(m):
+    _setup(m)
+    _install_keys(m, _default_key())
+    router = MockRouter()
+    hanging = TerminalThenHangByteStream(_responses_sse_function_call_response().content)
+    router.register(
+        "https://responses-stream-tool-release.example",
+        lambda req: httpx.Response(
+            200,
+            stream=hanging,
+            headers={"content-type": "text/event-stream"},
+        ),
+    )
+    _install_channels(m, [
+        _make_openai_channel(
+            "responses-stream-tool-release",
+            "https://responses-stream-tool-release.example",
+            protocol="openai-responses",
+            alias="gpt-5",
+            real="gpt-real",
+        ),
+    ])
+
+    resp, mc = await _call_openai_handler(m, router, "responses", {
+        "model": "gpt-5",
+        "stream": True,
+        "input": "call lookup",
+        "tools": [{
+            "type": "function",
+            "name": "lookup",
+            "parameters": {"type": "object", "properties": {}},
+        }],
+    })
+    iterator = resp.body_iterator
+    emitted = b""
+    for _ in range(20):
+        chunk = await asyncio.wait_for(anext(iterator), timeout=1.0)
+        emitted += chunk.encode("utf-8") if isinstance(chunk, str) else chunk
+        if b"event: response.completed" in emitted:
+            break
+
+    assert b"event: response.completed" in emitted
+    assert hanging.closed.is_set()
+
+    await iterator.aclose()
+    await mc.aclose()
 
 
 async def test_responses_client_text_instruction_items_to_openai_chat_fake_upstream(m):


### PR DESCRIPTION
## 问题

Responses 流在收到 `response.completed` 后，会先把终态帧 `yield` 给客户端，再执行 Store、retry、Token/金额以及 `request_log` 的成功结算。

OpenClaw 等客户端在拿到 `function_call` 的终态后可能立即停止继续读取，也不一定显式关闭 body iterator。此时生成器会停在终态 `yield`，结算逻辑永远无法执行，记录持续为 `pending`，随后被 stale cleaner 误标为 `process crashed (stale pending)`；实际请求和上游容器均未崩溃。

## 修复

- 将 Responses 显式终态视为流的 I/O 边界，不再依赖 HTTP EOF。
- 在终态帧暴露给下游前完成：
  - Responses Store
  - retry attempt 与 usage/cost settlement
  - Token/cache usage
  - `request_log` / request detail
- 在终态帧暴露前幂等释放上游 HTTP context 和代理客户端资源。
- 保持 `response.failed`、上下文超限、流中错误等错误路径的原有发送与结算语义。

## 兼容性

- 无公开 API、配置或数据库 Schema 变化。
- 官方版与修复版在相同 fake upstream 下输出的 SSE 均为 1262 字节，SHA256 完全一致：`3521287cb8f475ada15bce7e9d1ed256be8ca5407dcd90a9d634111cd73bc5dc`。
- 唯一测得影响是终态落库带来的预期延迟：约增加 p50 4ms、p95 5.7ms。

## 验证

- 新增回归覆盖：
  - 完整消费流
  - 客户端读到 `response.completed` 后停止消费
  - hanging upstream 的终态资源释放
  - 下游字节精确一致
  - request/retry/settlement/Token/cache/detail 一致性
- 协议 fake-upstream 测试：`73 passed`
- 全量测试：`1790 passed, 18 skipped`
- 32 路并发终态停读：32/32 success，request/retry/settlement/detail 一一对应
- SQLite：`PRAGMA quick_check=ok`
