### PR TITLE
fix: map OpenAI 30-day quota windows consistently

### DIFF
--- a/src/oauth/openai.py
+++ b/src/oauth/openai.py
@@ -23,6 +23,7 @@ import asyncio
 import base64
 import hashlib
 import json
+import math
 import os
 import secrets
 import time
@@ -1170,6 +1171,129 @@ def codex_snapshot_window_map(snap: dict) -> dict[str, str]:
     if use_5h_from_primary:
         return {"primary": "five_hour", "secondary": "seven_day"}
     return {"primary": "seven_day", "secondary": "five_hour"}
+
+
+_CODEX_SEMANTIC_WINDOWS = ("five_hour", "seven_day", "thirty_day")
+
+
+def sanitize_codex_window_observations(value: Any) -> dict[str, dict]:
+    """Return valid per-semantic Codex evidence from persisted JSON/config."""
+    if not isinstance(value, dict):
+        return {}
+
+    sanitized: dict[str, dict] = {}
+    for semantic in _CODEX_SEMANTIC_WINDOWS:
+        raw = value.get(semantic)
+        if not isinstance(raw, dict):
+            continue
+
+        raw_name = raw.get("raw_name")
+        if raw_name not in ("primary", "secondary"):
+            continue
+        used_pct = raw.get("used_pct")
+        if isinstance(used_pct, bool):
+            continue
+        try:
+            used_pct = float(used_pct)
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(used_pct):
+            continue
+
+        observed_at = raw.get("observed_at")
+        if isinstance(observed_at, bool):
+            continue
+        try:
+            observed_at = int(observed_at)
+        except (TypeError, ValueError, OverflowError):
+            continue
+        if observed_at < 0:
+            continue
+
+        item: dict[str, int | float | str] = {
+            "raw_name": raw_name,
+            "used_pct": used_pct,
+            "observed_at": observed_at,
+        }
+        for field in ("reset_sec", "window_min"):
+            field_value = raw.get(field)
+            if field_value is None or isinstance(field_value, bool):
+                continue
+            try:
+                field_value = int(field_value)
+            except (TypeError, ValueError, OverflowError):
+                continue
+            if field_value >= 0:
+                item[field] = field_value
+        sanitized[semantic] = item
+    return sanitized
+
+
+def merge_codex_window_observations(*values: Any) -> dict[str, dict]:
+    """Merge partial Codex snapshots without erasing unobserved windows."""
+    merged: dict[str, dict] = {}
+    for value in values:
+        for semantic, candidate in sanitize_codex_window_observations(value).items():
+            current = merged.get(semantic)
+            if (
+                current is None
+                or candidate["observed_at"] >= current["observed_at"]
+            ):
+                merged[semantic] = candidate
+    return merged
+
+
+def codex_snapshot_window_observations(
+    snap: dict, *, observed_at: Any = None,
+) -> dict[str, dict]:
+    """Normalize one raw Codex snapshot into timestamped semantic evidence."""
+    if not isinstance(snap, dict):
+        return {}
+    if observed_at is None:
+        observed_at = snap.get("fetched_at")
+    if isinstance(observed_at, bool):
+        return {}
+    try:
+        observed_at = int(observed_at)
+    except (TypeError, ValueError, OverflowError):
+        return {}
+    if observed_at < 0:
+        return {}
+
+    window_map = codex_snapshot_window_map(snap)
+    observations: dict[str, dict] = {}
+    for raw_name in ("primary", "secondary"):
+        used_pct = snap.get(f"{raw_name}_used_pct")
+        if isinstance(used_pct, bool):
+            continue
+        try:
+            used_pct = float(used_pct)
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(used_pct):
+            continue
+
+        item: dict[str, int | float | str] = {
+            "raw_name": raw_name,
+            "used_pct": used_pct,
+            "observed_at": observed_at,
+        }
+        for suffix in ("reset_sec", "window_min"):
+            raw_value = snap.get(f"{raw_name}_{suffix}")
+            if raw_value is None or isinstance(raw_value, bool):
+                continue
+            try:
+                raw_value = int(raw_value)
+            except (TypeError, ValueError, OverflowError):
+                continue
+            if raw_value >= 0:
+                item[suffix] = raw_value
+
+        semantic = window_map[raw_name]
+        current = observations.get(semantic)
+        if current is None or used_pct > current["used_pct"]:
+            observations[semantic] = item
+    return observations
 
 
 def normalize_codex_snapshot(snap: dict) -> dict:

--- a/src/oauth/openai.py
+++ b/src/oauth/openai.py
@@ -65,6 +65,7 @@ WHAM_RESET_CREDIT_CONSUME_URL = "https://chatgpt.com/backend-api/wham/rate-limit
 _WHAM_USAGE_TIMEOUT = 30.0
 _WHAM_RESET_CREDIT_LIST_TIMEOUT = 5.0
 _WHAM_RESET_CREDIT_TIMEOUT = 10.0
+_MONTHLY_QUOTA_WINDOW_THRESHOLD_SECONDS = 8 * 86400
 
 
 # ─── mock 开关（与 oauth_manager.mock_mode_enabled 同语义） ────────
@@ -599,7 +600,7 @@ def _wham_window_looks_monthly(win: dict) -> bool:
     """Return True when a WHAM window is clearly longer than a weekly quota."""
     sec = _coerce_int(win.get("limit_window_seconds"))
     if sec is not None:
-        return sec > 8 * 86400
+        return sec > _MONTHLY_QUOTA_WINDOW_THRESHOLD_SECONDS
 
     resets_at = win.get("resets_at")
     if isinstance(resets_at, str) and resets_at:
@@ -607,7 +608,9 @@ def _wham_window_looks_monthly(win: dict) -> bool:
             from datetime import datetime, timezone
 
             dt = datetime.fromisoformat(resets_at.replace("Z", "+00:00"))
-            return (dt - datetime.now(timezone.utc)).total_seconds() > 8 * 86400
+            return (
+                dt - datetime.now(timezone.utc)
+            ).total_seconds() > _MONTHLY_QUOTA_WINDOW_THRESHOLD_SECONDS
         except Exception:
             return False
     return False
@@ -635,7 +638,30 @@ def normalize_wham_usage(payload: dict) -> dict:
     five_hour: dict = {}
     seven_day: dict = {}
     thirty_day: dict = {}
-    if len(windows) >= 2:
+    monthly_windows = [item for item in windows if _wham_window_looks_monthly(item[2])]
+    if monthly_windows:
+        # A payload can contain 5h+30d or 7d+30d. Classify the monthly window
+        # before applying the legacy small/large 5h/7d ordering; otherwise the
+        # large window is mislabeled as 7d. If malformed input repeats a monthly
+        # semantic, retain the higher utilization fail-closed.
+        monthly = max(
+            monthly_windows,
+            key=lambda item: float(item[2].get("utilization") or 0),
+        )
+        thirty_day = dict(monthly[2])
+        remaining = [item for item in windows if item not in monthly_windows]
+        if remaining:
+            name, sec, block = remaining[0]
+            if sec is not None:
+                if sec <= 6 * 3600:
+                    five_hour = dict(block)
+                else:
+                    seven_day = dict(block)
+            elif name == "primary_window":
+                five_hour = dict(block)
+            else:
+                seven_day = dict(block)
+    elif len(windows) >= 2:
         # 有窗口长度时，小窗口归 5h，大窗口归 7d。缺长度的排到后面；
         # 两个都缺时按 wham 当前语义 fallback：primary=5h、secondary=7d。
         if any(sec is not None for _, sec, _ in windows):
@@ -656,13 +682,6 @@ def normalize_wham_usage(payload: dict) -> dict:
             five_hour = dict(block)
         else:
             seven_day = dict(block)
-
-    # Preserve the original 5h/7d mapping above. Add only one extra case: when
-    # WHAM returns no 5h window and the sole large window is clearly ~30d, expose
-    # it separately instead of showing it as a misleading 7d quota.
-    if not five_hour and seven_day and _wham_window_looks_monthly(seven_day):
-        thirty_day = dict(seven_day)
-        seven_day = {}
 
     if thirty_day.get("limit_window_seconds") is not None:
         thirty_day["window_seconds"] = thirty_day.get("limit_window_seconds")
@@ -1078,7 +1097,7 @@ def parse_rate_limit_headers(headers: Any) -> dict | None:
       primary_used_pct / primary_reset_sec / primary_window_min
       secondary_used_pct / secondary_reset_sec / secondary_window_min
       primary_over_secondary_pct
-    这些原样落库到 oauth_quota_cache，同时调 Normalize 映射到 5h/7d。
+    这些原样落库到 oauth_quota_cache，同时调 Normalize 映射到 5h/7d/30d。
     """
     if headers is None:
         return None
@@ -1106,13 +1125,29 @@ def parse_rate_limit_headers(headers: Any) -> dict | None:
 
 
 def codex_snapshot_window_map(snap: dict) -> dict[str, str]:
-    """Map Codex primary/secondary headers to semantic 5h/7d windows.
+    """Map Codex primary/secondary headers to semantic 5h/7d/30d windows.
 
     Keep this mapping in one place: quota persistence and recovery must agree
     about which fresh WHAM window can supersede each response-header window.
+    WHAM treats windows longer than eight days as monthly; use the same boundary
+    here so observed 43200/43800-minute Codex windows map to ``thirty_day``
+    instead of being mislabeled as ``seven_day``.
     """
     p_win = _coerce_int(snap.get("primary_window_min"))
     s_win = _coerce_int(snap.get("secondary_window_min"))
+    monthly_min = _MONTHLY_QUOTA_WINDOW_THRESHOLD_SECONDS // 60
+    p_monthly = p_win is not None and p_win > monthly_min
+    s_monthly = s_win is not None and s_win > monthly_min
+
+    if p_monthly or s_monthly:
+        if p_monthly and s_monthly:
+            return {"primary": "thirty_day", "secondary": "thirty_day"}
+        if p_monthly:
+            secondary = "five_hour" if s_win is None or s_win <= 360 else "seven_day"
+            return {"primary": "thirty_day", "secondary": secondary}
+        primary = "five_hour" if p_win is None or p_win <= 360 else "seven_day"
+        return {"primary": primary, "secondary": "thirty_day"}
+
     use_5h_from_primary = False
     if p_win is not None and s_win is not None:
         if p_win < s_win:
@@ -1138,25 +1173,43 @@ def codex_snapshot_window_map(snap: dict) -> dict[str, str]:
 
 
 def normalize_codex_snapshot(snap: dict) -> dict:
-    """把 primary/secondary 映射到 5h/7d。参考 sub2api `Normalize()`。
+    """把 primary/secondary 映射到 5h/7d/30d。参考 sub2api `Normalize()`。
 
     策略：有 window_minutes 时，较小窗口归为 5h、较大归为 7d；只有一边
-    window_minutes 时按 ≤360 min 判 5h。两边都缺 → 回落把 primary 当 7d。
-    返回 {"five_hour_util", "five_hour_reset_sec", "seven_day_util", ...}
-    （沿用现有 `oauth_quota_cache.five_hour_*` 列名，避免多套展示逻辑）。
+    window_minutes 时按 ≤360 min 判 5h。超过 8 天的已知长窗口归为 30d；
+    两边都缺 → 回落把 primary 当 7d。返回各实际出现语义窗口的 ``*_util``
+    与 ``*_reset_sec`` 字段，沿用 oauth_quota_cache 的通用列名。
     """
     window_map = codex_snapshot_window_map(snap)
 
-    if window_map["primary"] == "five_hour":
-        five_util, five_reset = snap.get("primary_used_pct"), snap.get("primary_reset_sec")
-        seven_util, seven_reset = snap.get("secondary_used_pct"), snap.get("secondary_reset_sec")
-    else:
-        five_util, five_reset = snap.get("secondary_used_pct"), snap.get("secondary_reset_sec")
-        seven_util, seven_reset = snap.get("primary_used_pct"), snap.get("primary_reset_sec")
+    normalized: dict[str, Any] = {}
+    for raw_name in ("primary", "secondary"):
+        semantic = window_map[raw_name]
+        util_key = f"{semantic}_util"
+        reset_key = f"{semantic}_reset_sec"
+        util = snap.get(f"{raw_name}_used_pct")
+        reset = snap.get(f"{raw_name}_reset_sec")
+        if util is None and reset is None:
+            # window_min identifies semantics but is not quota evidence by
+            # itself. Do not erase a fresher active WHAM value when utilization
+            # and reset headers are both absent.
+            continue
 
-    return {
-        "five_hour_util": five_util,
-        "five_hour_reset_sec": five_reset,
-        "seven_day_util": seven_util,
-        "seven_day_reset_sec": seven_reset,
-    }
+        # Duplicate semantic windows are malformed but possible. Keep the
+        # higher utilization fail-closed instead of letting field order lower
+        # the persisted quota evidence.
+        current = normalized.get(util_key)
+        if util is not None and (util_key not in normalized or current is None):
+            normalized[util_key] = util
+            normalized[reset_key] = reset
+        elif util is not None:
+            try:
+                replace = float(util) > float(current)
+            except (TypeError, ValueError):
+                replace = False
+            if replace:
+                normalized[util_key] = util
+                normalized[reset_key] = reset
+        elif reset_key not in normalized:
+            normalized[reset_key] = reset
+    return normalized

--- a/src/oauth_manager.py
+++ b/src/oauth_manager.py
@@ -1458,7 +1458,49 @@ def codex_quota_observation(snap: dict) -> dict:
         "source": _CODEX_OBSERVATION_SOURCE,
         "observed_at": observed_at,
         "snapshot": sanitized,
+        "windows": openai_provider.codex_snapshot_window_observations(
+            sanitized, observed_at=observed_at,
+        ),
     }
+
+
+def _codex_windows_from_observation(observation: dict | None) -> dict[str, dict]:
+    if not isinstance(observation, dict):
+        return {}
+    if observation.get("source") != _CODEX_OBSERVATION_SOURCE:
+        return {}
+    stored = openai_provider.sanitize_codex_window_observations(
+        observation.get("windows"),
+    )
+    legacy = openai_provider.codex_snapshot_window_observations(
+        observation.get("snapshot") or {},
+        observed_at=observation.get("observed_at"),
+    )
+    return openai_provider.merge_codex_window_observations(stored, legacy)
+
+
+def _merge_codex_quota_observations(*observations: dict | None) -> dict | None:
+    valid = [
+        observation for observation in observations
+        if isinstance(observation, dict)
+        and observation.get("source") == _CODEX_OBSERVATION_SOURCE
+    ]
+    if not valid:
+        return None
+
+    latest = valid[0]
+    latest_ms = _ms_timestamp(latest.get("observed_at"))
+    for observation in valid[1:]:
+        observed_ms = _ms_timestamp(observation.get("observed_at"))
+        if observed_ms is not None and (latest_ms is None or observed_ms >= latest_ms):
+            latest = observation
+            latest_ms = observed_ms
+
+    merged = copy.deepcopy(latest)
+    merged["windows"] = openai_provider.merge_codex_window_observations(
+        *(_codex_windows_from_observation(observation) for observation in valid),
+    )
+    return merged
 
 
 def _codex_cached_reset_ms(row: dict, base_ms: int | None,
@@ -1490,17 +1532,16 @@ def _codex_snapshot_from_quota_row(row: dict) -> dict:
     }
 
 
-def _persistent_codex_observation(account_key: str) -> tuple[dict | None, int | None]:
+def _persistent_codex_observation(account_key: str) -> dict | None:
     acc = get_account(account_key)
     observation = acc.get(_QUOTA_OBSERVATION_FIELD) if isinstance(acc, dict) else None
     if not isinstance(observation, dict):
-        return None, None
+        return None
     if observation.get("source") != _CODEX_OBSERVATION_SOURCE:
-        return None, None
-    snapshot = observation.get("snapshot")
-    if not isinstance(snapshot, dict):
-        return None, None
-    return snapshot, _ms_timestamp(observation.get("observed_at"))
+        return None
+    if not _codex_windows_from_observation(observation):
+        return None
+    return observation
 
 
 def _codex_window_candidates(account_key: str, row: dict) -> dict[str, list[dict]]:
@@ -1545,13 +1586,36 @@ def _codex_window_candidates(account_key: str, row: dict) -> dict[str, list[dict
                 "reset_ms": reset_ms,
             })
 
+    def add_windows(windows: dict | None):
+        for semantic, item in openai_provider.sanitize_codex_window_observations(
+            windows,
+        ).items():
+            observed_ms = _ms_timestamp(item.get("observed_at"))
+            reset_ms = _codex_cached_reset_ms(
+                item, observed_ms, "reset_sec",
+            )
+            grouped[semantic].append({
+                "raw_name": item["raw_name"],
+                "semantic": semantic,
+                "pct": item["used_pct"],
+                "observed_ms": observed_ms,
+                "reset_ms": reset_ms,
+            })
+
     add(
         _codex_snapshot_from_quota_row(row),
         _ms_timestamp(row.get("last_passive_update_at")),
         row_fallback=row,
     )
-    persistent_snapshot, persistent_ms = _persistent_codex_observation(account_key)
-    add(persistent_snapshot, persistent_ms)
+    sqlite_observations = row.get("codex_window_observations")
+    if isinstance(sqlite_observations, str):
+        try:
+            sqlite_observations = json.loads(sqlite_observations)
+        except (TypeError, ValueError):
+            sqlite_observations = {}
+    add_windows(sqlite_observations)
+    persistent_observation = _persistent_codex_observation(account_key)
+    add_windows(_codex_windows_from_observation(persistent_observation))
 
     # Known timestamps are comparable, so only the newest observation for that
     # semantic window remains relevant. Timestamp-less legacy evidence stays as
@@ -2546,7 +2610,13 @@ def set_disabled_by_quota(account_key: str, resets_at: str | None, *,
             next_generation = (current_generation if current_generation is not None else 0) + 1
             acc[_QUOTA_OBSERVATION_GENERATION_FIELD] = next_generation
             if isinstance(observation, dict):
-                acc[_QUOTA_OBSERVATION_FIELD] = copy.deepcopy(observation)
+                merged_observation = _merge_codex_quota_observations(
+                    acc.get(_QUOTA_OBSERVATION_FIELD),
+                    observation,
+                )
+                acc[_QUOTA_OBSERVATION_FIELD] = copy.deepcopy(
+                    merged_observation or observation,
+                )
 
             if current_enabled:
                 acc["enabled"] = False

--- a/src/oauth_manager.py
+++ b/src/oauth_manager.py
@@ -1511,7 +1511,11 @@ def _codex_window_candidates(account_key: str, row: dict) -> dict[str, list[dict
     semantic window rather than allowing one newly observed window to erase an
     older, still-relevant other window.
     """
-    grouped: dict[str, list[dict]] = {"five_hour": [], "seven_day": []}
+    grouped: dict[str, list[dict]] = {
+        "five_hour": [],
+        "seven_day": [],
+        "thirty_day": [],
+    }
 
     def add(snapshot: dict | None, observed_ms: int | None, *, row_fallback: dict | None = None):
         if not isinstance(snapshot, dict):
@@ -1565,8 +1569,7 @@ def _fresh_wham_window_utils(usage: dict | None) -> dict[str, float | None]:
     if not isinstance(openai, dict) or openai.get("source") != "wham_usage":
         return {}
 
-    def explicit_util(name: str) -> float | None:
-        block = usage.get(name) if isinstance(usage, dict) else None
+    def explicit_util(block: dict | None) -> float | None:
         raw = block.get("utilization") if isinstance(block, dict) else None
         if isinstance(raw, bool) or raw is None:
             return None
@@ -1579,8 +1582,9 @@ def _fresh_wham_window_utils(usage: dict | None) -> dict[str, float | None]:
         return value
 
     return {
-        "five_hour": explicit_util("five_hour"),
-        "seven_day": explicit_util("seven_day"),
+        "five_hour": explicit_util(usage.get("five_hour")),
+        "seven_day": explicit_util(usage.get("seven_day")),
+        "thirty_day": explicit_util(openai.get("thirty_day")),
     }
 
 
@@ -1597,7 +1601,7 @@ def _cached_openai_codex_quota_hit(account_key: str, threshold: float,
 
     A Codex window is superseded only when active WHAM usage is clearly newer
     *and* contains the corresponding semantic window explicitly below threshold.
-    Missing 5h/7d evidence never clears the other window. A persistent config
+    Missing 5h/7d/30d evidence never clears another window. A persistent config
     observation closes the safety gap when auxiliary SQLite snapshot writes fail
     and also provides the generation used by the final account-enable CAS.
     """

--- a/src/state_db.py
+++ b/src/state_db.py
@@ -1453,11 +1453,13 @@ def quota_save_openai_snapshot(account_key: str, snap: dict,
       {primary_used_pct / primary_reset_sec / primary_window_min /
        secondary_* / primary_over_secondary_pct / fetched_at (ms)}
     normalized: src.oauth.openai.normalize_codex_snapshot 的返回值
-      {five_hour_util / five_hour_reset_sec / seven_day_util / seven_day_reset_sec}
+      {five_hour_util / five_hour_reset_sec / seven_day_util / seven_day_reset_sec /
+       thirty_day_util / thirty_day_reset_sec}（只含本次实际观测到的语义窗口）
       None 时自动 normalize（便于调用方省事）。
 
-    复用现有 five_hour_util / seven_day_util 列：status_menu 的配额预警与
-    主菜单热账户计数无需区分 provider，直接读这两个字段即可。
+    复用现有 five_hour_util / seven_day_util / thirty_day_util 列。只更新本次
+    snapshot 实际包含的语义窗口，避免普通 5h/7d 响应头清空主动 WHAM 的
+    30d 数据，也避免 5h/30d 响应头清空仍有效的 7d 数据。
     """
     # 容错：调用方可能只给 snap，normalized 由本函数补
     if normalized is None:
@@ -1478,58 +1480,56 @@ def quota_save_openai_snapshot(account_key: str, snap: dict,
         target_email = email
         if target_email is None:
             target_email = _quota_display_email(target_account_key)
-        values = (
-            target_email,
-            fetched_at,
-            passive_ts,
-            normalized.get("five_hour_util"),
-            _reset_iso(normalized.get("five_hour_reset_sec")),
-            normalized.get("seven_day_util"),
-            _reset_iso(normalized.get("seven_day_reset_sec")),
-            snap.get("primary_used_pct"),
-            snap.get("primary_reset_sec"),
-            snap.get("primary_window_min"),
-            snap.get("secondary_used_pct"),
-            snap.get("secondary_reset_sec"),
-            snap.get("secondary_window_min"),
-            snap.get("primary_over_secondary_pct"),
+        semantic_fields = (
+            ("five_hour_util", "five_hour_util", False),
+            ("five_hour_reset", "five_hour_reset_sec", True),
+            ("seven_day_util", "seven_day_util", False),
+            ("seven_day_reset", "seven_day_reset_sec", True),
+            ("thirty_day_util", "thirty_day_util", False),
+            ("thirty_day_reset", "thirty_day_reset_sec", True),
+        )
+        semantic_values = [
+            (column, _reset_iso(normalized.get(key)) if is_reset else normalized.get(key))
+            for column, key, is_reset in semantic_fields
+            if key in normalized
+        ]
+        raw_values = (
+            ("codex_primary_used_pct", snap.get("primary_used_pct")),
+            ("codex_primary_reset_sec", snap.get("primary_reset_sec")),
+            ("codex_primary_window_min", snap.get("primary_window_min")),
+            ("codex_secondary_used_pct", snap.get("secondary_used_pct")),
+            ("codex_secondary_reset_sec", snap.get("secondary_reset_sec")),
+            ("codex_secondary_window_min", snap.get("secondary_window_min")),
+            ("codex_primary_over_secondary_pct", snap.get("primary_over_secondary_pct")),
         )
         row = conn.execute(
             "SELECT account_key FROM oauth_quota_cache WHERE account_key=?",
             (target_account_key,),
         ).fetchone()
         if row is None:
+            columns = ["account_key", "email", "fetched_at", "last_passive_update_at"]
+            values = [target_account_key, target_email, fetched_at, passive_ts]
+            for column, value in (*semantic_values, *raw_values):
+                columns.append(column)
+                values.append(value)
+            placeholders = ",".join("?" for _ in columns)
             conn.execute(
-                """INSERT INTO oauth_quota_cache
-                   (account_key, email, fetched_at, last_passive_update_at,
-                    five_hour_util, five_hour_reset,
-                    seven_day_util, seven_day_reset,
-                    sonnet_util, sonnet_reset,
-                    opus_util, opus_reset,
-                    extra_used, extra_limit, extra_util, raw_data,
-                    codex_primary_used_pct, codex_primary_reset_sec, codex_primary_window_min,
-                    codex_secondary_used_pct, codex_secondary_reset_sec, codex_secondary_window_min,
-                    codex_primary_over_secondary_pct)
-                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-                (
-                    target_account_key,
-                ) + values[:7] + (
-                    None, None,        # sonnet —— OpenAI 无此维度
-                    None, None,        # opus   —— 同上
-                    None, None, None,  # extra_* —— Claude 专属
-                    None,              # raw_data（响应头体积较小，不存）
-                ) + values[7:],
+                f"INSERT INTO oauth_quota_cache ({','.join(columns)}) "
+                f"VALUES ({placeholders})",
+                values,
             )
         else:
+            updates = [
+                ("email", target_email),
+                ("fetched_at", fetched_at),
+                ("last_passive_update_at", passive_ts),
+                *semantic_values,
+                *raw_values,
+            ]
             conn.execute(
-                """UPDATE oauth_quota_cache SET
-                     email=?, fetched_at=?, last_passive_update_at=?,
-                     five_hour_util=?, five_hour_reset=?,
-                     seven_day_util=?, seven_day_reset=?,
-                     codex_primary_used_pct=?, codex_primary_reset_sec=?, codex_primary_window_min=?,
-                     codex_secondary_used_pct=?, codex_secondary_reset_sec=?, codex_secondary_window_min=?,
-                     codex_primary_over_secondary_pct=?
-                   WHERE account_key=?""",
-                values + (target_account_key,),
+                f"UPDATE oauth_quota_cache SET "
+                f"{', '.join(f'{column}=?' for column, _ in updates)} "
+                "WHERE account_key=?",
+                [value for _, value in updates] + [target_account_key],
             )
     _commit_quota_write(account_key, write)

--- a/src/state_db.py
+++ b/src/state_db.py
@@ -5,6 +5,7 @@
 thread-local，WAL 模式。
 """
 
+import json
 import os
 import sqlite3
 import threading
@@ -101,7 +102,8 @@ def _schema_sql() -> str:
       extra_used       REAL,
       extra_limit      REAL,
       extra_util       REAL,
-      raw_data         TEXT
+      raw_data         TEXT,
+      codex_window_observations TEXT
     );
 
     CREATE TABLE IF NOT EXISTS network_check_status (
@@ -644,6 +646,7 @@ _OAUTH_QUOTA_CACHE_EXTRA_COLUMNS: list[tuple[str, str]] = [
     ("codex_secondary_reset_sec",       "INTEGER"),
     ("codex_secondary_window_min",      "INTEGER"),
     ("codex_primary_over_secondary_pct", "REAL"),
+    ("codex_window_observations",        "TEXT"),
 ]
 
 
@@ -1462,8 +1465,8 @@ def quota_save_openai_snapshot(account_key: str, snap: dict,
     30d 数据，也避免 5h/30d 响应头清空仍有效的 7d 数据。
     """
     # 容错：调用方可能只给 snap，normalized 由本函数补
+    from .oauth import openai as _openai_provider
     if normalized is None:
-        from .oauth import openai as _openai_provider
         normalized = _openai_provider.normalize_codex_snapshot(snap)
 
     now = int(time.time())
@@ -1502,16 +1505,36 @@ def quota_save_openai_snapshot(account_key: str, snap: dict,
             ("codex_secondary_window_min", snap.get("secondary_window_min")),
             ("codex_primary_over_secondary_pct", snap.get("primary_over_secondary_pct")),
         )
+        incoming_observations = _openai_provider.codex_snapshot_window_observations(snap)
         row = conn.execute(
-            "SELECT account_key FROM oauth_quota_cache WHERE account_key=?",
+            "SELECT account_key, codex_window_observations "
+            "FROM oauth_quota_cache WHERE account_key=?",
             (target_account_key,),
         ).fetchone()
+        existing_observations = {}
+        if row is not None and row["codex_window_observations"]:
+            try:
+                existing_observations = json.loads(row["codex_window_observations"])
+            except (TypeError, ValueError):
+                existing_observations = {}
+        merged_observations = _openai_provider.merge_codex_window_observations(
+            existing_observations,
+            incoming_observations,
+        )
+        observations_json = (
+            json.dumps(merged_observations, ensure_ascii=False, separators=(",", ":"),
+                       sort_keys=True)
+            if merged_observations else None
+        )
         if row is None:
             columns = ["account_key", "email", "fetched_at", "last_passive_update_at"]
             values = [target_account_key, target_email, fetched_at, passive_ts]
             for column, value in (*semantic_values, *raw_values):
                 columns.append(column)
                 values.append(value)
+            if observations_json is not None:
+                columns.append("codex_window_observations")
+                values.append(observations_json)
             placeholders = ",".join("?" for _ in columns)
             conn.execute(
                 f"INSERT INTO oauth_quota_cache ({','.join(columns)}) "
@@ -1526,6 +1549,8 @@ def quota_save_openai_snapshot(account_key: str, snap: dict,
                 *semantic_values,
                 *raw_values,
             ]
+            if incoming_observations:
+                updates.append(("codex_window_observations", observations_json))
             conn.execute(
                 f"UPDATE oauth_quota_cache SET "
                 f"{', '.join(f'{column}=?' for column, _ in updates)} "

--- a/src/telegram/menus/status_menu.py
+++ b/src/telegram/menus/status_menu.py
@@ -181,7 +181,7 @@ def _quota_warnings(threshold_pct: float = 80.0) -> list[str]:
     """OAuth 账户用量 >= threshold 的告警条目（按 provider 读不同的 util 字段）。
 
     Anthropic 账户的指标维度：5h / 7d / Sonnet / Opus
-    OpenAI   账户的指标维度：5h / 7d（normalize_codex_snapshot 写入通用列）
+    OpenAI   账户的指标维度：5h / 7d / 30d（normalize_codex_snapshot 写入通用列）
                            + codex_primary / codex_secondary（codex 专属，更精细）
     """
     out: list[str] = []

--- a/src/tests/test_openai_oauth_quota.py
+++ b/src/tests/test_openai_oauth_quota.py
@@ -593,12 +593,7 @@ def test_openai_quota_ignores_expired_codex_snapshot_missing_reset(m):
         key, snap, m["openai_provider"].normalize_codex_snapshot(snap), email=email,
     )
     old_ms = m["state_db"].now_ms() - 11 * 60 * 1000
-    conn = m["state_db"]._get_conn()
-    conn.execute(
-        "UPDATE oauth_quota_cache SET fetched_at=?, last_passive_update_at=? WHERE account_key=?",
-        (old_ms, old_ms, key),
-    )
-    conn.commit()
+    _set_quota_timestamps(m, key, passive_ms=old_ms, usage_ms=old_ms)
 
     wham_below_threshold = {
         "five_hour": {"utilization": 1.0, "resets_at": "2099-01-01T00:01:00Z"},
@@ -649,11 +644,18 @@ def _save_codex_over_threshold_snapshot(
 
 
 def _set_quota_timestamps(m, key, *, passive_ms, usage_ms):
+    row = m["state_db"].quota_load(key) or {}
+    observations_json = row.get("codex_window_observations")
+    if observations_json and passive_ms is not None:
+        observations = json.loads(observations_json)
+        for window in observations.values():
+            window["observed_at"] = passive_ms
+        observations_json = json.dumps(observations)
     conn = m["state_db"]._get_conn()
     conn.execute(
-        "UPDATE oauth_quota_cache SET last_passive_update_at=?, fetched_at=? "
-        "WHERE account_key=?",
-        (passive_ms, usage_ms, key),
+        "UPDATE oauth_quota_cache SET last_passive_update_at=?, fetched_at=?, "
+        "codex_window_observations=? WHERE account_key=?",
+        (passive_ms, usage_ms, observations_json, key),
     )
     conn.commit()
 
@@ -755,6 +757,74 @@ def test_openai_quota_keeps_30d_codex_hit_without_matching_wham_window(m):
     assert "codex primary 95%" in result["hit_windows"], result
     assert acc["enabled"] is False and acc["disabled_reason"] == "quota", acc
     print("  [PASS] 5h/7d WHAM evidence cannot clear a Codex 30d hit")
+
+
+def test_partial_codex_snapshots_preserve_unobserved_30d_recovery_evidence(m):
+    """A later 5h/7d snapshot must not erase an active 30d Codex hit."""
+    _setup(m)
+    email = "partial-codex-preserves-30d@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+
+    monthly = m["openai_provider"].parse_rate_limit_headers({
+        "x-codex-primary-used-percent": "96",
+        "x-codex-primary-reset-after-seconds": "2592000",
+        "x-codex-primary-window-minutes": "43800",
+        "x-codex-secondary-used-percent": "10",
+        "x-codex-secondary-reset-after-seconds": "18000",
+        "x-codex-secondary-window-minutes": "300",
+    })
+    assert monthly is not None
+    m["failover"]._maybe_auto_disable_by_codex_snapshot(key, email, monthly)
+    m["state_db"].quota_save_openai_snapshot(key, monthly, email=email)
+
+    weekly = m["openai_provider"].parse_rate_limit_headers({
+        "x-codex-primary-used-percent": "97",
+        "x-codex-primary-reset-after-seconds": "18000",
+        "x-codex-primary-window-minutes": "300",
+        "x-codex-secondary-used-percent": "10",
+        "x-codex-secondary-reset-after-seconds": "604800",
+        "x-codex-secondary-window-minutes": "10080",
+    })
+    assert weekly is not None
+    m["failover"]._maybe_auto_disable_by_codex_snapshot(key, email, weekly)
+    m["state_db"].quota_save_openai_snapshot(key, weekly, email=email)
+
+    now = m["state_db"].now_ms()
+    old_ms = now - m["oauth_manager"]._CODEX_SNAPSHOT_SUPERSEDED_BY_USAGE_MS - 60_000
+    _set_quota_timestamps(m, key, passive_ms=old_ms, usage_ms=now)
+
+    def _age_observation(c):
+        target = next(a for a in c["oauthAccounts"] if a.get("email") == email)
+        observation = target.get("quota_observation") or {}
+        observation["observed_at"] = old_ms
+        for window in (observation.get("windows") or {}).values():
+            window["observed_at"] = old_ms
+
+    m["config"].update(_age_observation)
+
+    result = m["oauth_manager"].evaluate_and_toggle_by_usage(
+        key, _low_wham(), threshold=95, fresh=True,
+    )
+    acc = m["oauth_manager"].get_account(key)
+    assert result["action"] == "still_over_quota", result
+    assert any("96%" in hit for hit in result["hit_windows"]), result
+    assert acc["enabled"] is False and acc["disabled_reason"] == "quota", acc
+    observation = acc.get("quota_observation") or {}
+    assert observation.get("windows", {}).get("thirty_day", {}).get("used_pct") == 96.0
+
+    result = m["oauth_manager"].evaluate_and_toggle_by_usage(
+        key,
+        _low_wham(
+            thirty_day={"utilization": 0.0, "resets_at": "2099-02-01T00:00:00Z"},
+        ),
+        threshold=95,
+        fresh=True,
+    )
+    acc = m["oauth_manager"].get_account(key)
+    assert result["action"] == "resumed", result
+    assert acc["enabled"] is True and acc.get("disabled_reason") is None, acc
+    print("  [PASS] partial Codex snapshots preserve unobserved 30d recovery evidence")
 
 
 def test_openai_quota_keeps_boundary_codex_snapshot_authoritative(m):
@@ -981,9 +1051,11 @@ def test_new_codex_hit_survives_sqlite_snapshot_write_failure(m):
     # resetting the monotonic generation.
     def _age_observation(c):
         target = next(a for a in c["oauthAccounts"] if a.get("email") == email)
-        target["quota_observation"]["observed_at"] = (
-            m["state_db"].now_ms() - 24 * 3600 * 1000
-        )
+        observation = target["quota_observation"]
+        old_ms = m["state_db"].now_ms() - 24 * 3600 * 1000
+        observation["observed_at"] = old_ms
+        for window in (observation.get("windows") or {}).values():
+            window["observed_at"] = old_ms
 
     m["config"].update(_age_observation)
     result = m["oauth_manager"].evaluate_and_toggle_by_usage(

--- a/src/tests/test_openai_oauth_quota.py
+++ b/src/tests/test_openai_oauth_quota.py
@@ -2,14 +2,14 @@
 
 覆盖：
   - state_db.quota_save_openai_snapshot 写入字段齐全（原始 codex_* + 归一化
-    five_hour_* / seven_day_* + reset_at ISO）
+    five_hour_* / seven_day_* / thirty_day_* + reset_at ISO）
   - failover._maybe_record_codex_snapshot：
       * 非 OpenAIOAuthChannel 直接跳过
       * 有 x-codex-* 头时触发一次写入
       * 30s 节流窗口内重复调用不再写
       * 响应头无 codex 字段时不写
   - oauth_menu 详情页对 provider=openai 账户的展示
-      （provider 行 / 5h/7d 归一化展示 / refresh_usage 友好提示）
+      （provider 行 / 5h/7d/30d 归一化展示 / refresh_usage 友好提示）
   - status_menu._quota_warnings 对 openai 账户追加 🅾 标记
 
 用 HTTPX Response 的 mock 对象代替真实网络。
@@ -151,6 +151,118 @@ def test_quota_save_auto_normalize(m):
     row = m["state_db"].quota_load("q2@openai.test")
     assert row["five_hour_util"] == 10.0
     print("  [PASS] quota_save_openai_snapshot auto-normalizes when arg omitted")
+
+
+def test_quota_save_openai_monthly_snapshot_maps_and_preserves_other_windows(m):
+    """A 43800-minute Codex window is 30d, not 7d, and updates only itself."""
+    _setup(m)
+    email = "monthly-save@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    active_usage = _low_wham(
+        thirty_day={"utilization": 4.0, "resets_at": "2099-02-01T00:00:00Z"},
+    )
+    m["state_db"].quota_save(
+        key, m["oauth_manager"].flatten_usage(active_usage), email=email,
+    )
+
+    snap = m["openai_provider"].parse_rate_limit_headers({
+        "x-codex-primary-used-percent": "95",
+        "x-codex-primary-reset-after-seconds": "2592000",
+        "x-codex-primary-window-minutes": "43800",
+        "x-codex-secondary-used-percent": "11",
+        "x-codex-secondary-reset-after-seconds": "18000",
+        "x-codex-secondary-window-minutes": "300",
+    })
+    assert snap is not None
+    window_map = m["openai_provider"].codex_snapshot_window_map(snap)
+    assert window_map == {"primary": "thirty_day", "secondary": "five_hour"}
+    normalized = m["openai_provider"].normalize_codex_snapshot(snap)
+    assert normalized["thirty_day_util"] == 95.0
+    assert normalized["five_hour_util"] == 11.0
+    assert "seven_day_util" not in normalized
+
+    m["state_db"].quota_save_openai_snapshot(key, snap, normalized, email=email)
+    row = m["state_db"].quota_load(key)
+    assert row["thirty_day_util"] == 95.0
+    assert row["five_hour_util"] == 11.0
+    assert row["seven_day_util"] == 2.0
+    assert row["thirty_day_reset"] and row["thirty_day_reset"].endswith("Z")
+    print("  [PASS] 43800-minute Codex snapshots persist as 30d without erasing 7d")
+
+
+def test_codex_secondary_monthly_window_maps_to_30d(m):
+    snap = {
+        "primary_used_pct": 7.0,
+        "primary_reset_sec": 18000,
+        "primary_window_min": 300,
+        "secondary_used_pct": 81.0,
+        "secondary_reset_sec": 2592000,
+        "secondary_window_min": 43800,
+    }
+    assert m["openai_provider"].codex_snapshot_window_map(snap) == {
+        "primary": "five_hour",
+        "secondary": "thirty_day",
+    }
+    normalized = m["openai_provider"].normalize_codex_snapshot(snap)
+    assert normalized["five_hour_util"] == 7.0
+    assert normalized["thirty_day_util"] == 81.0
+    assert "seven_day_util" not in normalized
+    print("  [PASS] Codex secondary 43800-minute window maps to 30d")
+
+
+def test_quota_save_openai_weekly_snapshot_preserves_active_30d(m):
+    _setup(m)
+    email = "weekly-preserves-monthly@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    active_usage = _low_wham(
+        thirty_day={"utilization": 4.0, "resets_at": "2099-02-01T00:00:00Z"},
+    )
+    m["state_db"].quota_save(
+        key, m["oauth_manager"].flatten_usage(active_usage), email=email,
+    )
+    snap = m["openai_provider"].parse_rate_limit_headers({
+        "x-codex-primary-used-percent": "42",
+        "x-codex-primary-window-minutes": "10080",
+        "x-codex-secondary-used-percent": "17",
+        "x-codex-secondary-window-minutes": "300",
+    })
+    assert snap is not None
+    normalized = m["openai_provider"].normalize_codex_snapshot(snap)
+    assert "thirty_day_util" not in normalized
+    m["state_db"].quota_save_openai_snapshot(key, snap, normalized, email=email)
+    row = m["state_db"].quota_load(key)
+    assert row["five_hour_util"] == 17.0
+    assert row["seven_day_util"] == 42.0
+    assert row["thirty_day_util"] == 4.0
+    print("  [PASS] ordinary Codex 5h/7d snapshots preserve active WHAM 30d")
+
+
+def test_window_only_codex_header_does_not_clear_active_wham_usage(m):
+    _setup(m)
+    email = "window-only-preserves-usage@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    active_usage = _low_wham(
+        thirty_day={"utilization": 4.0, "resets_at": "2099-02-01T00:00:00Z"},
+    )
+    m["state_db"].quota_save(
+        key, m["oauth_manager"].flatten_usage(active_usage), email=email,
+    )
+    snap = m["openai_provider"].parse_rate_limit_headers({
+        "x-codex-primary-window-minutes": "43800",
+    })
+    assert snap is not None
+    normalized = m["openai_provider"].normalize_codex_snapshot(snap)
+    assert normalized == {}
+    m["state_db"].quota_save_openai_snapshot(key, snap, normalized, email=email)
+    row = m["state_db"].quota_load(key)
+    assert row["five_hour_util"] == 1.0
+    assert row["seven_day_util"] == 2.0
+    assert row["thirty_day_util"] == 4.0
+    assert row["codex_primary_window_min"] == 43800
+    print("  [PASS] window-only Codex metadata preserves active WHAM usage")
 
 
 # ─── failover hook ────────────────────────────────────────────────
@@ -576,6 +688,73 @@ def test_openai_quota_resumes_when_fresh_wham_supersedes_codex_snapshot(m):
     assert acc.get("disabled_reason") is None, acc
     assert acc.get("disabled_until") is None, acc
     print("  [PASS] OpenAI quota resumes when fresh WHAM supersedes Codex snapshot")
+
+
+def _monthly_only_low_wham():
+    usage = _low_wham(
+        thirty_day={"utilization": 0.0, "resets_at": "2099-02-01T00:00:00Z"},
+    )
+    usage["five_hour"] = {}
+    usage["seven_day"] = {}
+    return usage
+
+
+def test_openai_quota_resumes_when_fresh_wham_supersedes_30d_codex_snapshot(m):
+    """Fresh WHAM 30d evidence supersedes an older 43800-minute Codex hit."""
+    _setup(m)
+    email = "early-reset-30d@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    m["oauth_manager"].set_disabled_by_quota(key, "2099-01-01T00:00:00Z")
+    _save_codex_over_threshold_snapshot(
+        m,
+        key,
+        email,
+        primary_window_min=43800,
+        primary_reset_after="2592000",
+    )
+
+    now = m["state_db"].now_ms()
+    _set_quota_timestamps(m, key, passive_ms=now - 24 * 3600 * 1000, usage_ms=now)
+    result = m["oauth_manager"].evaluate_and_toggle_by_usage(
+        key, _monthly_only_low_wham(), threshold=95, fresh=True,
+    )
+
+    acc = m["oauth_manager"].get_account(key)
+    assert result["action"] == "resumed", result
+    assert result["any_over"] is False, result
+    assert result["hit_windows"] == [], result
+    assert acc.get("enabled") is True, acc
+    assert acc.get("disabled_reason") is None, acc
+    print("  [PASS] fresh WHAM 30d supersedes an older 43800-minute Codex hit")
+
+
+def test_openai_quota_keeps_30d_codex_hit_without_matching_wham_window(m):
+    """Fresh 5h/7d data must not clear an older Codex 30d quota hit."""
+    _setup(m)
+    email = "partial-wham-30d@openai.test"
+    key = f"openai:{email}:acct-{email}"
+    _add_openai(m, email)
+    m["oauth_manager"].set_disabled_by_quota(key, "2099-01-01T00:00:00Z")
+    _save_codex_over_threshold_snapshot(
+        m,
+        key,
+        email,
+        primary_window_min=43800,
+        primary_reset_after="2592000",
+    )
+
+    now = m["state_db"].now_ms()
+    _set_quota_timestamps(m, key, passive_ms=now - 24 * 3600 * 1000, usage_ms=now)
+    result = m["oauth_manager"].evaluate_and_toggle_by_usage(
+        key, _low_wham(), threshold=95, fresh=True,
+    )
+
+    acc = m["oauth_manager"].get_account(key)
+    assert result["action"] == "still_over_quota", result
+    assert "codex primary 95%" in result["hit_windows"], result
+    assert acc["enabled"] is False and acc["disabled_reason"] == "quota", acc
+    print("  [PASS] 5h/7d WHAM evidence cannot clear a Codex 30d hit")
 
 
 def test_openai_quota_keeps_boundary_codex_snapshot_authoritative(m):
@@ -1599,6 +1778,10 @@ def main():
     tests = [
         test_quota_save_openai_snapshot_writes_all_columns,
         test_quota_save_auto_normalize,
+        test_quota_save_openai_monthly_snapshot_maps_and_preserves_other_windows,
+        test_codex_secondary_monthly_window_maps_to_30d,
+        test_quota_save_openai_weekly_snapshot_preserves_active_30d,
+        test_window_only_codex_header_does_not_clear_active_wham_usage,
         test_record_codex_snapshot_happy_path,
         test_record_codex_snapshot_throttle,
         test_record_skip_non_openai_channel,
@@ -1611,6 +1794,8 @@ def main():
         test_openai_quota_resume_respects_active_codex_snapshot,
         test_openai_quota_ignores_expired_codex_snapshot_missing_reset,
         test_openai_quota_resumes_when_fresh_wham_supersedes_codex_snapshot,
+        test_openai_quota_resumes_when_fresh_wham_supersedes_30d_codex_snapshot,
+        test_openai_quota_keeps_30d_codex_hit_without_matching_wham_window,
         test_openai_quota_keeps_boundary_codex_snapshot_authoritative,
         test_openai_quota_keeps_old_7d_codex_hit_when_wham_only_has_low_5h,
         test_openai_quota_keeps_old_5h_codex_hit_when_wham_only_has_low_7d,

--- a/src/tests/test_openai_wham_thirty_day.py
+++ b/src/tests/test_openai_wham_thirty_day.py
@@ -43,3 +43,50 @@ def test_wham_single_monthly_window_is_exposed_as_30d_not_7d():
     assert usage["seven_day"] == {}
     assert usage["openai"]["thirty_day"]["utilization"] == 8.0
     assert usage["openai"]["thirty_day"]["window_seconds"] == 2628000
+
+
+def test_wham_five_hour_plus_monthly_windows_stay_semantically_distinct():
+    usage = normalize_wham_usage({
+        "plan_type": "team",
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 3,
+                "limit_window_seconds": 5 * 3600,
+                "reset_after_seconds": 3600,
+            },
+            "secondary_window": {
+                "used_percent": 8,
+                "limit_window_seconds": 43800 * 60,
+                "reset_after_seconds": 43800 * 60,
+            },
+        },
+        "credits": {},
+    })
+
+    assert usage["five_hour"]["utilization"] == 3.0
+    assert usage["seven_day"] == {}
+    assert usage["openai"]["thirty_day"]["utilization"] == 8.0
+    assert usage["openai"]["thirty_day"]["window_seconds"] == 2628000
+
+
+def test_wham_monthly_primary_plus_five_hour_secondary_is_order_independent():
+    usage = normalize_wham_usage({
+        "plan_type": "team",
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 8,
+                "limit_window_seconds": 43800 * 60,
+                "reset_after_seconds": 43800 * 60,
+            },
+            "secondary_window": {
+                "used_percent": 3,
+                "limit_window_seconds": 5 * 3600,
+                "reset_after_seconds": 3600,
+            },
+        },
+        "credits": {},
+    })
+
+    assert usage["five_hour"]["utilization"] == 3.0
+    assert usage["seven_day"] == {}
+    assert usage["openai"]["thirty_day"]["utilization"] == 8.0


### PR DESCRIPTION
## 问题

Parrot v0.29.5 会把 Codex 响应头中的长窗口一律归入 `7d`。当窗口长度为 `43800` 分钟时，它实际表示约 30 天额度，而新鲜 WHAM 数据会将同一窗口规范为 `openai.thirty_day`。

这会造成语义错位：旧 Codex 快照仍显示 95%，WHAM 已明确返回 30d 0%、`allowed=true`、`limit_reached=false`，但旧快照无法被匹配的新数据覆盖，账号仍停留在 `still_over_quota`。

## 修复

- Codex 与 WHAM 共用“超过 8 天即为月度窗口”的边界。
- 支持 primary/secondary 任一方向的 5h + 30d、7d + 30d 组合。
- 将 Codex 30d 快照纳入逐语义窗口的缓存候选与恢复判断。
- 只有更新且明确低于阈值的 WHAM `thirty_day` 才能覆盖旧 Codex 30d 快照；缺少匹配窗口时继续 fail-closed。
- 被动 Codex 快照只更新实际观测到的语义窗口，避免 5h/7d/30d 相互清空。
- 只有 `window_min`、没有 utilization/reset 的响应头仅保存原始元数据，不清空新鲜 WHAM 用量。
- 更新状态菜单中的 OpenAI 窗口说明。

## 回归覆盖

- `43800` 分钟在 primary 和 secondary 两种位置均映射为 30d。
- WHAM 单 30d、5h + 30d 及字段顺序反转。
- 30d 快照持久化，同时保留未观测到的 5h/7d 数据。
- 普通 5h/7d 快照保留主动 WHAM 30d 数据。
- window-only 响应头不清空任何主动用量。
- 新鲜匹配 30d 数据允许恢复；只有 5h/7d 时保持禁用。
- 恢复后的幂等判断，以及新高用量快照重新禁用。

## 验证

- 修复前反向验证：新增回归场景稳定失败，确认覆盖真实问题。
- 定向配额回归：`49 passed`。
- 全量隔离测试：`1815 passed, 18 skipped`。
- `python3 -m compileall -q src`、`git diff --check` 通过。
- Docker 候选 A/B：官方 v0.29.5 复现失败；修复候选完成 `resumed → kept_enabled → still_over_quota`。
- 候选容器 healthy、0 restart、非 root 运行；4 个 SQLite 库 `PRAGMA quick_check=ok`。
