### PR TITLE
fix: make request body logging configurable

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -311,6 +311,7 @@
     }
   },
   "logDir": "logs",
+  "logStoreBodies": true,
   "logRetention": {
     "mode": "forever",
     "days": null

--- a/src/config.py
+++ b/src/config.py
@@ -488,6 +488,9 @@ DEFAULT_CONFIG: dict[str, Any] = {
         },
     },
     "logDir": "logs",
+    # 是否把完整请求头、请求正文和响应正文写入 request_detail。
+    # 关闭后仍保留请求摘要、token、成本、渠道、重试和代理链统计。
+    "logStoreBodies": True,
     # 请求业务日志留存：forever = 永久保留；days = 仅保留最近 N 天（N >= 1）。
     # 无效/缺失配置在运行时 fail-closed 为 forever，避免升级或手工编辑误删日志。
     "logRetention": {

--- a/src/log_db.py
+++ b/src/log_db.py
@@ -106,6 +106,12 @@ def _resolve_log_dir() -> str:
     return os.path.join(config.DATA_DIR, rel)
 
 
+def _store_log_bodies() -> bool:
+    """Return whether full request/response payloads may be persisted."""
+
+    return config.get().get("logStoreBodies", True) is not False
+
+
 def _schema_sql() -> str:
     return """
     CREATE TABLE IF NOT EXISTS request_log (
@@ -1591,6 +1597,7 @@ def insert_pending(
 ) -> RequestLogHandle:
     created = time.time() if created_at is None else float(created_at)
     handle = RequestLogHandle(request_id=request_id, db=_db_ref_for_timestamp(created))
+    store_bodies = _store_log_bodies()
     with _write_lock:
         conn = _get_conn_for_ref(handle.db)
         conn.execute(
@@ -1615,8 +1622,8 @@ def insert_pending(
                VALUES (?,?,?)""",
             (
                 request_id,
-                json.dumps(request_headers, ensure_ascii=False) if request_headers else None,
-                json.dumps(request_body, ensure_ascii=False) if request_body else None,
+                json.dumps(request_headers, ensure_ascii=False) if store_bodies and request_headers else None,
+                json.dumps(request_body, ensure_ascii=False) if store_bodies and request_body else None,
             ),
         )
         conn.commit()
@@ -2800,7 +2807,7 @@ def finish_success(
                 handle.request_id,
             ),
         )
-        if response_body is not None:
+        if response_body is not None and _store_log_bodies():
             conn.execute(
                 "UPDATE request_detail SET response_body=? WHERE request_id=?",
                 (response_body, handle.request_id),
@@ -2881,7 +2888,7 @@ def finish_error(
                 handle.request_id,
             ),
         )
-        if response_body is not None:
+        if response_body is not None and _store_log_bodies():
             conn.execute(
                 "UPDATE request_detail SET response_body=? WHERE request_id=?",
                 (response_body, handle.request_id),

--- a/src/tests/test_log_body_storage.py
+++ b/src/tests/test_log_body_storage.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+
+from src import config, log_db
+
+
+def test_log_store_bodies_false_keeps_summary_and_attempt_accounting() -> None:
+    previous_store_bodies = config.get().get("logStoreBodies", True)
+    try:
+        config.update(lambda cfg: cfg.__setitem__("logStoreBodies", False))
+        log_db.init()
+        handle = log_db.insert_pending(
+            "body-storage-disabled",
+            "127.0.0.1",
+            "test-key",
+            "grok-4.5",
+            True,
+            msg_count=1,
+            tool_count=0,
+            request_headers={"Authorization": "Bearer secret"},
+            request_body={"model": "grok-4.5", "input": "private prompt"},
+            ingress_protocol="responses",
+        )
+        attempt = log_db.record_retry_attempt(
+            handle,
+            1,
+            "oauth:xai:test@example.com",
+            "oauth",
+            "grok-4.5",
+            1.0,
+            upstream_protocol="openai-responses",
+        )
+        log_db.mark_retry_attempt_dispatch(
+            attempt,
+            {"model": "grok-4.5", "service_tier": "priority"},
+        )
+        response_body = json.dumps(
+            {
+                "model": "grok-4.5",
+                "service_tier": "priority",
+                "usage": {
+                    "input_tokens": 11,
+                    "output_tokens": 7,
+                    "cache_creation_tokens": 0,
+                    "cache_read_tokens": 3,
+                    "cost_in_usd_ticks": 123456,
+                },
+            }
+        )
+        log_db.finish_success(
+            handle,
+            "oauth:xai:test@example.com",
+            "oauth",
+            "grok-4.5",
+            input_tokens=11,
+            output_tokens=7,
+            cache_creation_tokens=0,
+            cache_read_tokens=3,
+            total_ms=25,
+            response_body=response_body,
+            upstream_protocol="openai-responses",
+            usage_observed=True,
+        )
+
+        conn = log_db._get_conn_for_ref(handle.db)
+        detail = conn.execute(
+            "SELECT request_headers, request_body, response_body "
+            "FROM request_detail WHERE request_id=?",
+            (handle.request_id,),
+        ).fetchone()
+        assert detail is not None
+        assert tuple(detail) == (None, None, None)
+
+        summary = conn.execute(
+            "SELECT status, input_tokens, output_tokens, cache_read_tokens, actual_service_tier "
+            "FROM request_log WHERE request_id=?",
+            (handle.request_id,),
+        ).fetchone()
+        assert tuple(summary) == ("success", 11, 7, 3, "priority")
+
+        ledger = conn.execute(
+            "SELECT input_tokens, output_tokens, cache_read_tokens, service_tier, cost_ticks "
+            "FROM upstream_attempt_usage WHERE root_request_id=?",
+            (handle.request_id,),
+        ).fetchone()
+        assert ledger is not None
+        assert tuple(ledger) == (11, 7, 3, "priority", 123456)
+    finally:
+        config.update(
+            lambda cfg: cfg.__setitem__("logStoreBodies", previous_store_bodies)
+        )


### PR DESCRIPTION
## Summary

- add a backward-compatible `logStoreBodies` configuration option
- allow operators to stop persisting full request headers, request bodies, and response bodies
- keep request summaries, token usage, cost accounting, channel data, retries, and proxy-chain statistics unchanged

The option defaults to `true`, so existing installations retain their current behavior. Set it to `false` to keep the `request_detail` row while storing its three body columns as `NULL`.

## Motivation

Full request and response payloads can make the monthly SQLite log shards grow quickly, especially for long agent conversations whose context is repeated on every request. Time-based retention removes both payloads and statistics; this option separates payload privacy/storage control from statistical retention.

## Test plan

- clean v0.30.6 baseline: `2173 passed, 18 skipped`
- final PR branch: `2174 passed, 18 skipped`
- stateful logging/billing tests in both forward and reverse order: `103 passed` each
- verified with a live Parrot v0.30.6 deployment that:
  - new `request_detail` body columns remain `NULL` when disabled
  - request summaries and upstream attempt cost/token ledgers are still written
  - the service remains healthy

## Compatibility

- default behavior remains unchanged (`logStoreBodies: true`)
- no schema migration is required
- existing historical payloads are not modified automatically
