### PR TITLE
fix(oauth): show inactive Fable scoped quota in Telegram

### DIFF
--- a/src/oauth_manager.py
+++ b/src/oauth_manager.py
@@ -1423,57 +1423,79 @@ def _is_fable_model_label(value: str) -> bool:
     return compact in {"f5", "claudef5", "claudefable", "claudefable5"}
 
 
+def _fable_scoped_candidates(
+    usage: dict | None, *, include_inactive: bool,
+) -> tuple[bool, list[tuple[int, float, float, int, dict]]]:
+    """Collect ranked Claude Fable / F5 weekly scoped limit windows."""
+    data = usage if isinstance(usage, dict) else {}
+    candidates: list[tuple[int, float, float, int, dict]] = []
+    saw_scoped_fable = False
+    limits = data.get("limits")
+    if not isinstance(limits, list):
+        return False, candidates
+    for index, item in enumerate(limits):
+        if not isinstance(item, dict):
+            continue
+        kind = str(item.get("kind") or "")
+        if kind not in {"weekly_scoped", "seven_day_scoped"}:
+            continue
+        scope = item.get("scope") if isinstance(item.get("scope"), dict) else {}
+        model = scope.get("model") if isinstance(scope.get("model"), dict) else {}
+        name = str(model.get("display_name") or model.get("id") or "")
+        if not _is_fable_model_label(name):
+            continue
+        saw_scoped_fable = True
+        if item.get("is_active") is False and not include_inactive:
+            continue
+        raw_util = item.get("utilization")
+        if raw_util is None:
+            raw_util = item.get("percent")
+        try:
+            utilization = float(raw_util)
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(utilization):
+            continue
+        utilization = max(0.0, min(100.0, utilization))
+        reset = item.get("resets_at")
+        reset_dt = _parse_iso(reset)
+        reset_rank = reset_dt.timestamp() if reset_dt is not None else -1.0
+        candidates.append((
+            1 if item.get("is_active") is True else 0,
+            reset_rank,
+            utilization,
+            -index,
+            {"utilization": utilization, "resets_at": reset},
+        ))
+    return saw_scoped_fable, candidates
+
+
+def _pick_fable_candidate(
+    candidates: list[tuple[int, float, float, int, dict]],
+) -> dict:
+    if not candidates:
+        return {}
+    return max(candidates, key=lambda candidate: candidate[:4])[4]
+
+
 def fable_usage_block(usage: dict | None) -> dict:
     """Extract the active Claude Fable / F5 weekly quota window.
 
     Newer /api/oauth/usage payloads keep Sonnet/Opus null and put Fable on
     ``limits[]`` as ``weekly_scoped`` (``scope.model.display_name = Fable``).
-    Explicitly inactive entries are historical and must not drive live display
-    or routing.  If more than one viable entry is returned, prefer an explicitly
-    active entry, then the latest reset, then the highest utilization.  Older or
-    mock payloads may still expose ``seven_day_fable`` as a fallback.
+    Explicitly inactive entries are historical and must not drive routing or
+    model cooldown.  If more than one viable entry is returned, prefer an
+    explicitly active entry, then the latest reset, then the highest
+    utilization.  Older or mock payloads may still expose ``seven_day_fable``
+    as a fallback.  Telegram display uses ``fable_display_block`` so a lone
+    inactive scoped window can still be shown.
     """
     data = usage if isinstance(usage, dict) else {}
-    candidates: list[tuple[int, float, float, int, dict]] = []
-    saw_scoped_fable = False
-    limits = data.get("limits")
-    if isinstance(limits, list):
-        for index, item in enumerate(limits):
-            if not isinstance(item, dict):
-                continue
-            kind = str(item.get("kind") or "")
-            if kind not in {"weekly_scoped", "seven_day_scoped"}:
-                continue
-            scope = item.get("scope") if isinstance(item.get("scope"), dict) else {}
-            model = scope.get("model") if isinstance(scope.get("model"), dict) else {}
-            name = str(model.get("display_name") or model.get("id") or "")
-            if not _is_fable_model_label(name):
-                continue
-            saw_scoped_fable = True
-            if item.get("is_active") is False:
-                continue
-            raw_util = item.get("utilization")
-            if raw_util is None:
-                raw_util = item.get("percent")
-            try:
-                utilization = float(raw_util)
-            except (TypeError, ValueError):
-                continue
-            if not math.isfinite(utilization):
-                continue
-            utilization = max(0.0, min(100.0, utilization))
-            reset = item.get("resets_at")
-            reset_dt = _parse_iso(reset)
-            reset_rank = reset_dt.timestamp() if reset_dt is not None else -1.0
-            candidates.append((
-                1 if item.get("is_active") is True else 0,
-                reset_rank,
-                utilization,
-                -index,
-                {"utilization": utilization, "resets_at": reset},
-            ))
+    saw_scoped_fable, candidates = _fable_scoped_candidates(
+        data, include_inactive=False,
+    )
     if candidates:
-        return max(candidates, key=lambda candidate: candidate[:4])[4]
+        return _pick_fable_candidate(candidates)
     if saw_scoped_fable:
         return {}
 
@@ -1487,8 +1509,45 @@ def fable_usage_block(usage: dict | None) -> dict:
     return {}
 
 
+def fable_display_block(usage: dict | None) -> dict:
+    """Quota window for Telegram / refresh copy.
+
+    Prefer the live active Fable pool used by routing.  Anthropic currently
+    returns the Fable weekly scoped cap with ``is_active: false`` even when it
+    is the only Fable window and still has percent + reset; show that instead of
+    hiding the row.  Inactive entries never override an active scoped window.
+    """
+    data = usage if isinstance(usage, dict) else {}
+    active = fable_usage_block(data)
+    if active:
+        return active
+    _saw, inactive = _fable_scoped_candidates(data, include_inactive=True)
+    if inactive:
+        return _pick_fable_candidate(inactive)
+    direct = data.get("seven_day_fable")
+    if isinstance(direct, dict) and direct.get("utilization") is not None:
+        return direct
+    return {}
+
+
+def _fable_util_from_block(block: dict | None) -> tuple[float | None, str | None]:
+    if not block or block.get("utilization") is None:
+        return None, None
+    try:
+        value = float(block["utilization"])
+    except (TypeError, ValueError):
+        return None, None
+    if math.isnan(value) or math.isinf(value):
+        return None, None
+    return max(0.0, min(100.0, value)), block.get("resets_at")
+
+
 def fable_from_quota_row(row: dict | None) -> tuple[float | None, str | None]:
-    """Return (util%, resets_at) for Fable, including raw_data fallback."""
+    """Return active (util%, resets_at) for Fable, including raw_data fallback.
+
+    This path is for routing, cooldown and cached reconstruction.  UI should
+    call ``fable_display_from_quota_row`` so inactive scoped windows remain visible.
+    """
     if not isinstance(row, dict):
         return None, None
     util = row.get("fable_util")
@@ -1502,16 +1561,17 @@ def fable_from_quota_row(row: dict | None) -> tuple[float | None, str | None]:
                 value = None
             else:
                 return max(0.0, min(100.0, value)), row.get("fable_reset")
-    block = fable_usage_block(_raw_usage_from_flat(row))
-    if not block or block.get("utilization") is None:
+    return _fable_util_from_block(fable_usage_block(_raw_usage_from_flat(row)))
+
+
+def fable_display_from_quota_row(row: dict | None) -> tuple[float | None, str | None]:
+    """Return Fable (util%, resets_at) for Telegram list/detail/refresh copy."""
+    if not isinstance(row, dict):
         return None, None
-    try:
-        value = float(block["utilization"])
-    except (TypeError, ValueError):
-        return None, None
-    if math.isnan(value) or math.isinf(value):
-        return None, None
-    return max(0.0, min(100.0, value)), block.get("resets_at")
+    active_util, active_reset = fable_from_quota_row(row)
+    if active_util is not None:
+        return active_util, active_reset
+    return _fable_util_from_block(fable_display_block(_raw_usage_from_flat(row)))
 
 
 def flatten_usage(usage: dict) -> dict:
@@ -4925,7 +4985,7 @@ def _refresh_notice_window_lines(usage_flat: dict | None) -> list[str]:
     lines: list[str] = []
     fh_util = usage_flat.get("five_hour_util")
     sd_util = usage_flat.get("seven_day_util")
-    fb_util = usage_flat.get("fable_util")
+    fb_util, fb_reset = fable_display_from_quota_row(usage_flat)
     if fh_util is not None:
         lines.append(
             f"📊 5h 用量: <b>{fh_util:.0f}%</b>"
@@ -4939,7 +4999,7 @@ def _refresh_notice_window_lines(usage_flat: dict | None) -> list[str]:
     if fb_util is not None:
         lines.append(
             f"📖 Fable 7d: <b>{fb_util:.0f}%</b>"
-            f" | 重置: <code>{_to_bjt(usage_flat.get('fable_reset'))}</code>"
+            f" | 重置: <code>{_to_bjt(fb_reset)}</code>"
         )
     return lines
 

--- a/src/telegram/menus/main.py
+++ b/src/telegram/menus/main.py
@@ -43,7 +43,7 @@ def _quota_hot_count(threshold_pct: float = 80.0) -> int:
         else:
             utils = [row.get(k) for k in ("five_hour_util", "seven_day_util",
                                            "thirty_day_util", "sonnet_util", "opus_util")]
-            utils.append(oauth_manager.fable_from_quota_row(row)[0])
+            utils.append(oauth_manager.fable_display_from_quota_row(row)[0])
         if any(u is not None and u >= threshold_pct for u in utils):
             n += 1
     return n

--- a/src/telegram/menus/oauth_menu.py
+++ b/src/telegram/menus/oauth_menu.py
@@ -670,7 +670,7 @@ def _quota_cache_has_usage_signal(row: dict | None) -> bool:
     ):
         if row.get(key) is not None:
             return True
-    if oauth_manager.fable_from_quota_row(row)[0] is not None:
+    if oauth_manager.fable_display_from_quota_row(row)[0] is not None:
         return True
     try:
         raw = json.loads(row.get("raw_data") or "{}")
@@ -1644,7 +1644,7 @@ def _format_account_block(acc: dict, *, month_snapshot: dict | None = None,
             line = _format_usage_line_html("📊 30d", td_util, reset)
             if line:
                 lines.append(line)
-        fable_util, fable_reset = oauth_manager.fable_from_quota_row(row)
+        fable_util, fable_reset = oauth_manager.fable_display_from_quota_row(row)
         if prov == "claude" and fable_util is not None:
             line = _format_usage_line_html("📖 Fable 7d", fable_util, fable_reset)
             if line:
@@ -1744,7 +1744,7 @@ def _format_usage_block(account_key: str, *, month_snapshot: dict | None = None,
         ("🧠 Opus 7d", row.get("opus_util"), row.get("opus_reset"), None),
     ]
     if provider == "claude":
-        fable_util, fable_reset = oauth_manager.fable_from_quota_row(row)
+        fable_util, fable_reset = oauth_manager.fable_display_from_quota_row(row)
         usage_rows.append(("📖 Fable 7d", fable_util, fable_reset, None))
     for label, util, reset, util_k in usage_rows:
         line = _format_usage_line_text(label, util, reset)

--- a/src/telegram/menus/status_menu.py
+++ b/src/telegram/menus/status_menu.py
@@ -220,7 +220,7 @@ def _quota_warnings(threshold_pct: float = 80.0) -> list[str]:
             }
         elif provider == "claude":
             # Anthropic: 5h / 7d / Sonnet / Opus / Fable
-            fable_util, _fable_reset = oauth_manager.fable_from_quota_row(row)
+            fable_util, _fable_reset = oauth_manager.fable_display_from_quota_row(row)
             utils = {
                 "5h": row.get("five_hour_util"),
                 "7d": row.get("seven_day_util"),

--- a/src/tests/test_composite_key_migration.py
+++ b/src/tests/test_composite_key_migration.py
@@ -733,7 +733,65 @@ def test_fable_usage_selects_active_scoped_entry(m):
     inactive_only["limits"] = [usage["limits"][0]]
     assert m["oauth_manager"].fable_usage_block(inactive_only) == {}
     assert m["oauth_manager"].flatten_usage(inactive_only)["fable_util"] is None
+    assert m["oauth_manager"].fable_display_block(inactive_only) == {
+        "utilization": 99.0,
+        "resets_at": "2030-08-31T00:00:00Z",
+    }
+    assert m["oauth_manager"].fable_display_block(usage) == {
+        "utilization": 12.0,
+        "resets_at": "2030-08-30T10:00:00Z",
+    }
     print("  [PASS] Fable usage: inactive/history entries cannot shadow active scope")
+
+
+def test_fable_display_falls_back_to_inactive_scoped_window(m):
+    reset = "2026-08-30T09:59:59.911926+00:00"
+    usage = {
+        "five_hour": {"utilization": 0.0, "resets_at": None},
+        "seven_day": {"utilization": 38.0, "resets_at": reset},
+        "seven_day_sonnet": None,
+        "seven_day_opus": None,
+        "limits": [
+            {
+                "kind": "session",
+                "percent": 0,
+                "is_active": False,
+                "scope": None,
+            },
+            {
+                "kind": "weekly_all",
+                "percent": 38,
+                "is_active": True,
+                "resets_at": reset,
+                "scope": None,
+            },
+            {
+                "kind": "weekly_scoped",
+                "percent": 6,
+                "is_active": False,
+                "resets_at": reset,
+                "scope": {"model": {"id": None, "display_name": "Fable"}},
+            },
+        ],
+    }
+    assert m["oauth_manager"].fable_usage_block(usage) == {}
+    assert m["oauth_manager"].flatten_usage(usage)["fable_util"] is None
+    assert m["oauth_manager"].fable_display_block(usage) == {
+        "utilization": 6.0,
+        "resets_at": reset,
+    }
+    row = {
+        "five_hour_util": 0.0,
+        "seven_day_util": 38.0,
+        "fable_util": None,
+        "fable_reset": None,
+        "raw_data": m["oauth_manager"].flatten_usage(usage)["raw_data"],
+    }
+    assert m["oauth_manager"].fable_from_quota_row(row) == (None, None)
+    util, shown_reset = m["oauth_manager"].fable_display_from_quota_row(row)
+    assert util == 6.0
+    assert shown_reset == reset
+    print("  [PASS] Fable display: inactive-only scoped window stays visible")
 
 # ==============================================================
 # main
@@ -785,6 +843,7 @@ def main():
         test_flatten_usage_reads_fable_from_weekly_scoped_limit,
         test_usage_from_quota_row_reads_fable_from_raw_limits,
         test_fable_usage_selects_active_scoped_entry,
+        test_fable_display_falls_back_to_inactive_scoped_window,
     ]
     passed = 0
     failed = 0

--- a/src/tests/test_m7_oauth_menu.py
+++ b/src/tests/test_m7_oauth_menu.py
@@ -1559,6 +1559,40 @@ def test_claude_fable_quota_renders_progress_bar(m):
     print("  [PASS] Claude Fable / F5 quota renders with black/white bar")
 
 
+def test_claude_fable_quota_renders_inactive_scoped_window(m):
+    _setup(m)
+    _add_fake_account(m, "fable-inactive@x.com")
+    reset = (datetime.now(timezone.utc) + timedelta(days=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    usage = {
+        "five_hour": {"utilization": 0.0, "resets_at": None},
+        "seven_day": {"utilization": 38.0, "resets_at": reset},
+        "seven_day_sonnet": None,
+        "seven_day_opus": None,
+        "limits": [{
+            "kind": "weekly_scoped",
+            "is_active": False,
+            "percent": 6,
+            "resets_at": reset,
+            "scope": {"model": {"display_name": "Fable"}},
+        }],
+    }
+    m["state_db"].quota_save(
+        "fable-inactive@x.com",
+        m["oauth_manager"].flatten_usage(usage),
+        email="fable-inactive@x.com",
+    )
+    rec = _install_recorder(m)
+    m["oauth_menu"].show(42, 100)
+    list_text = rec.last("editMessageText")["text"]
+    assert "📖 Fable 7d: 已用 <code>█░░░░░░░░░</code> <b>6%</b>（剩 " in list_text
+    rec.clear()
+    short = m["ui"].register_code("fable-inactive@x.com")
+    m["oauth_menu"].on_view(42, 100, "cb", short)
+    detail_text = rec.last("editMessageText")["text"]
+    assert "📖 Fable 7d: 已用 6% <code>█░░░░░░░░░</code>" in detail_text
+    print("  [PASS] Claude Fable inactive scoped window still renders")
+
+
 def test_non_claude_detail_ignores_stale_fable_fields(m):
     _setup(m)
     _add_openai_fake_account(m, "stale-fable@x.com")
@@ -1618,6 +1652,7 @@ def main():
         test_add_menu_cancel_buttons,
         test_router_dispatch,
         test_claude_fable_quota_renders_progress_bar,
+        test_claude_fable_quota_renders_inactive_scoped_window,
         test_non_claude_detail_ignores_stale_fable_fields,
     ]
 


### PR DESCRIPTION
## 背景

现网 Claude `/api/oauth/usage` 会返回 Fable 的 `weekly_scoped` 窗口（`scope.model.display_name = Fable`，带 percent 和 reset），但当前这条窗口的 `is_active` 是 `false`。

v0.31.5 把 inactive scoped 一律当成历史窗口丢掉，结果 Telegram OAuth 列表 / 详情看不到「Fable 7d」，即使它是唯一的 Fable 窗口。

实测 payload 形态：

- `session` 0%，`is_active: false`
- `weekly_all` 38%，`is_active: true`（总 7d）
- `weekly_scoped` + `display_name: Fable`，6%，`is_active: false`

## 改动

- 冷却 / 路由继续只认 **active** Fable 池：`fable_usage_block()` 行为不变，inactive 不会拿去冻模型
- Telegram 列表、详情、刷新通知改走 `fable_display_block()` / `fable_display_from_quota_row()`
- 没有 active Fable 时，回退展示这条带 percent + reset 的 inactive scoped 窗口
- inactive 不会盖住已经存在的 active scoped 窗口

## 验证

```bash
./venv/bin/python src/tests/isolated_pytest.py \
  src/tests/test_composite_key_migration.py \
  src/tests/test_m7_oauth_menu.py \
  src/tests/test_unified_usage_and_auto_disable.py -q
```

109 passed
