### PR TITLE
fix(cc): bump Claude Code mimicry to 2.1.251 for Fable 5.1

### DIFF
--- a/src/oauth_manager.py
+++ b/src/oauth_manager.py
@@ -49,7 +49,7 @@ from .oauth import antigravity as antigravity_provider
 from .oauth import cursor as cursor_provider
 from .oauth import openai as openai_provider
 from .oauth import xai as xai_provider
-from .transform.cc_mimicry import CLI_USER_AGENT
+from .transform.cc_mimicry import CLI_USER_AGENT, CODE_USER_AGENT
 
 
 # ─── 常量 ────────────────────────────────────────────────────────
@@ -942,7 +942,7 @@ def _usage_sync(access_token: str, *, account_key: str = "") -> dict:
             "Content-Type": "application/json",
             "Authorization": f"Bearer {access_token}",
             "anthropic-beta": "oauth-2025-04-20",
-            "User-Agent": "claude-code/2.1.251",
+            "User-Agent": CODE_USER_AGENT,
         },
         timeout=30,
         proxy_purpose="oauth_anthropic",
@@ -996,7 +996,7 @@ def _bootstrap_sync(access_token: str) -> dict:
         headers={
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json",
-            "User-Agent": "claude-code/2.1.251",
+            "User-Agent": CODE_USER_AGENT,
         },
         timeout=15,
         proxy_purpose="oauth_anthropic",

--- a/src/oauth_manager.py
+++ b/src/oauth_manager.py
@@ -942,7 +942,7 @@ def _usage_sync(access_token: str, *, account_key: str = "") -> dict:
             "Content-Type": "application/json",
             "Authorization": f"Bearer {access_token}",
             "anthropic-beta": "oauth-2025-04-20",
-            "User-Agent": "claude-code/2.1.156",
+            "User-Agent": "claude-code/2.1.251",
         },
         timeout=30,
         proxy_purpose="oauth_anthropic",
@@ -996,7 +996,7 @@ def _bootstrap_sync(access_token: str) -> dict:
         headers={
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json",
-            "User-Agent": "claude-code/2.1.156",
+            "User-Agent": "claude-code/2.1.251",
         },
         timeout=15,
         proxy_purpose="oauth_anthropic",

--- a/src/tests/test_cc_v2_1_156_upgrade.py
+++ b/src/tests/test_cc_v2_1_156_upgrade.py
@@ -1,7 +1,7 @@
 """CC v2.1.156 兼容升级回归测试。
 
 覆盖本轮升级的全部代码改动，防止后续回归：
-  §1  CC_VERSION = 2.1.156
+  §1  CC_VERSION = 2.1.251
   §2  CCH_SEED 新值（对 6 组 canonical body _ph.bin 离线 6/6 命中）
   §3  compute_fingerprint：取「第一个 user message 的最后一个 text block」+ 索引 [4,7,18]
       （6 组 canonical body 离线 6/6 命中）；FINGERPRINT_SALT 不变
@@ -63,8 +63,8 @@ _skip_fixtures = pytest.mark.skipif(
 
 # ─────────────────────────── 常量同步 (§1/§2/§3/§5) ───────────────────────────
 
-def test_cc_version_2_1_156():
-    assert m.CC_VERSION == "2.1.156"
+def test_cc_version_2_1_251():
+    assert m.CC_VERSION == "2.1.251"
 
 
 def test_cc_entrypoint_sdk_cli():
@@ -73,7 +73,7 @@ def test_cc_entrypoint_sdk_cli():
 
 def test_user_agent_self_consistent():
     # version / entrypoint / UA 三者必须同步，绝不半新半旧
-    assert m.CLI_USER_AGENT == "claude-cli/2.1.156 (external, sdk-cli)"
+    assert m.CLI_USER_AGENT == "claude-cli/2.1.251 (external, sdk-cli)"
 
 
 def test_cch_seed_new_value():
@@ -92,13 +92,17 @@ def test_fingerprint_indices_18_not_20():
         {"type": "text", "text": "skip-me-first-block"},
         {"type": "text", "text": "hello world"},
     ]}])
-    expect = hashlib.sha256(f"59cf53e54c78oo02.1.156".encode()).hexdigest()[:3]
-    assert fp == expect == "523"
+    expect = hashlib.sha256(f"59cf53e54c78oo02.1.251".encode()).hexdigest()[:3]
+    assert fp == expect == "d78"
 
 
 # ─────────────────────────── fp 算法 6/6 (§3) ───────────────────────────
 
 @_skip_fixtures
+@pytest.mark.skipif(
+    m.CC_VERSION != "2.1.156",
+    reason="canonical fp fixtures were captured against CC v2.1.156",
+)
 @pytest.mark.parametrize("name", list(FP_EXPECTED))
 def test_compute_fingerprint_canonical_6of6(name):
     d = json.loads(open(f"{BODIES}/body_{name}_original.bin", "rb").read())
@@ -112,8 +116,8 @@ def test_fingerprint_takes_last_text_block():
         {"type": "text", "text": "<system-reminder>\nlong preamble that must be ignored"},
         {"type": "text", "text": "hello world"},
     ]}]
-    # 若错误地取第一个 block，结果会不同于 523
-    assert m.compute_fingerprint(msgs) == "523"
+    # 若错误地取第一个 block，结果会不同于 d78
+    assert m.compute_fingerprint(msgs) == "d78"
 
 
 # ─────────────────────────── cch 6/6 (§2) ───────────────────────────

--- a/src/tests/test_cc_v2_1_156_upgrade.py
+++ b/src/tests/test_cc_v2_1_156_upgrade.py
@@ -5,7 +5,7 @@
   §2  CCH_SEED 新值（对 6 组 canonical body _ph.bin 离线 6/6 命中）
   §3  compute_fingerprint：取「第一个 user message 的最后一个 text block」+ 索引 [4,7,18]
       （6 组 canonical body 离线 6/6 命中）；FINGERPRINT_SALT 不变
-  §5  CC_ENTRYPOINT = sdk-cli；CLI_USER_AGENT 三者自洽
+  §5  CC_ENTRYPOINT = sdk-cli；CLI_USER_AGENT / CODE_USER_AGENT 都从 CC_VERSION 派生
   §6  BETAS：含 context-1m / mid-conversation-system；不含 redact-thinking；
       messages 出站 anthropic-beta 过滤 oauth-2025-04-20
   §7  build_upstream_headers：补 X-Stainless 全层 + session-id + dangerous-direct-browser；
@@ -64,6 +64,7 @@ _skip_fixtures = pytest.mark.skipif(
 # ─────────────────────────── 常量同步 (§1/§2/§3/§5) ───────────────────────────
 
 def test_cc_version_2_1_251():
+    # 唯一版本钉：Anthropic 对 claude-fable-5-1 要求 CC >= 2.1.251。
     assert m.CC_VERSION == "2.1.251"
 
 
@@ -72,8 +73,26 @@ def test_cc_entrypoint_sdk_cli():
 
 
 def test_user_agent_self_consistent():
-    # version / entrypoint / UA 三者必须同步，绝不半新半旧
-    assert m.CLI_USER_AGENT == "claude-cli/2.1.251 (external, sdk-cli)"
+    # version / entrypoint / UA 必须从 CC_VERSION 派生，绝不半新半旧。
+    # messages 走 claude-cli；usage/bootstrap 走 claude-code。两种格式都是 CC 原样。
+    assert m.CLI_USER_AGENT == f"claude-cli/{m.CC_VERSION} (external, {m.CC_ENTRYPOINT})"
+    assert m.CODE_USER_AGENT == f"claude-code/{m.CC_VERSION}"
+
+
+def test_messages_header_uses_derived_cli_user_agent():
+    h = m.build_upstream_headers("tok", session_id="s")
+    assert h["User-Agent"] == m.CLI_USER_AGENT
+
+
+def test_oauth_manager_usage_bootstrap_use_derived_code_user_agent():
+    import inspect
+    from src import oauth_manager
+    usage = inspect.getsource(oauth_manager._usage_sync)
+    bootstrap = inspect.getsource(oauth_manager._bootstrap_sync)
+    assert "CODE_USER_AGENT" in usage
+    assert "CODE_USER_AGENT" in bootstrap
+    assert "claude-code/2." not in usage
+    assert "claude-code/2." not in bootstrap
 
 
 def test_cch_seed_new_value():
@@ -92,8 +111,10 @@ def test_fingerprint_indices_18_not_20():
         {"type": "text", "text": "skip-me-first-block"},
         {"type": "text", "text": "hello world"},
     ]}])
-    expect = hashlib.sha256(f"59cf53e54c78oo02.1.251".encode()).hexdigest()[:3]
-    assert fp == expect == "d78"
+    expect = hashlib.sha256(
+        f"{m.FINGERPRINT_SALT}oo0{m.CC_VERSION}".encode()
+    ).hexdigest()[:3]
+    assert fp == expect
 
 
 # ─────────────────────────── fp 算法 6/6 (§3) ───────────────────────────
@@ -116,8 +137,11 @@ def test_fingerprint_takes_last_text_block():
         {"type": "text", "text": "<system-reminder>\nlong preamble that must be ignored"},
         {"type": "text", "text": "hello world"},
     ]}]
-    # 若错误地取第一个 block，结果会不同于 d78
-    assert m.compute_fingerprint(msgs) == "d78"
+    # 若错误地取第一个 block，结果会不同于当前版本派生的 fp。
+    expect = hashlib.sha256(
+        f"{m.FINGERPRINT_SALT}oo0{m.CC_VERSION}".encode()
+    ).hexdigest()[:3]
+    assert m.compute_fingerprint(msgs) == expect
 
 
 # ─────────────────────────── cch 6/6 (§2) ───────────────────────────

--- a/src/transform/cc_mimicry.py
+++ b/src/transform/cc_mimicry.py
@@ -67,6 +67,7 @@ PARROT_WANTS_FAST_MODE_KEY = "_parrot_wants_fast_mode"
 ONE_M_CONTEXT_TOKENS = 1_000_000
 
 CLI_USER_AGENT = f"claude-cli/{CC_VERSION} ({USER_TYPE}, {CC_ENTRYPOINT})"
+CODE_USER_AGENT = f"claude-code/{CC_VERSION}"
 
 ANTHROPIC_API_BASE = "https://api.anthropic.com"
 

--- a/src/transform/cc_mimicry.py
+++ b/src/transform/cc_mimicry.py
@@ -32,7 +32,7 @@ from .. import config as _ap_config
 # 所以 BASE_DIR = cc_mimicry.py 所在目录向上两级
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-CC_VERSION = "2.1.156"
+CC_VERSION = "2.1.251"
 FINGERPRINT_SALT = "59cf53e54c78"
 CC_ENTRYPOINT = "sdk-cli"
 USER_TYPE = "external"


### PR DESCRIPTION
## 背景

Claude Fable 5.1 已于 2026-09-01 发布，API ID 为 `claude-fable-5-1`。

现网 Parrot v0.31.9 的 Claude OAuth 票已经能从 Anthropic 同步到这个模型，`/v1/models` 也会列出它。但真正打 `POST /v1/messages` 会被上游拒绝：

```
HTTP 400
Claude Code 2.1.156 does not support this model; version 2.1.251 or newer is required.
```

对照：同一条链路打 `claude-fable-5` 仍是 HTTP 200。

根因是 `src/transform/cc_mimicry.py` 写死 `CC_VERSION = "2.1.156"`，messages 出站 `User-Agent` 变成 `claude-cli/2.1.156`。Anthropic 用这个客户端版本拦 Fable 5.1。

## 改动

只升客户端版本声明，不改 CCH 算法 / beta / wire order：

- `CC_VERSION`：`2.1.156` → `2.1.251`（唯一钉）
- 新增 `CODE_USER_AGENT = f"claude-code/{CC_VERSION}"`
- messages 继续走 `CLI_USER_AGENT` → `claude-cli/2.1.251 (external, sdk-cli)`
- usage / bootstrap 改为用 `CODE_USER_AGENT`，不再硬编码第二个版本字符串
- 回归测试只钉一次 `2.1.251`；UA 和短文本指纹从该常量派生
- 2.1.156 抓包指纹用例在版本不匹配时 skip（那组 fixture 是按旧版本算出来的）

没有改 `FINGERPRINT_SALT`、`CCH_SEED`、fingerprint 取 block 规则，也没有扩 beta。这次是最小版本门槛，不是完整 2.1.251 协议重抓。

注意：`compute_fingerprint()` 把 `CC_VERSION` 编进 hash，所以 **UA 之外，`cc_version=2.1.251.<fp>` 也会变**。算法没变，输出会变。这是声明新客户端版本的必然结果，不是协议重抓。

## 验证

```bash
./venv/bin/python src/tests/isolated_pytest.py \
  src/tests/test_cc_v2_1_156_upgrade.py -q
```

36 passed, 18 skipped

未在生产机改运行中的 CC 指纹；等合入发版后再实测 `claude-fable-5-1`。